### PR TITLE
fix(proxy): restore the loopback address-family fallback interception removes

### DIFF
--- a/.github/workflows/e2e-cgroup-v2-selfmount.yml
+++ b/.github/workflows/e2e-cgroup-v2-selfmount.yml
@@ -57,7 +57,13 @@ jobs:
           sudo timeout 600 apt-get -y install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 build-essential gcc libc-dev pkg-config
 
       - name: Install dependencies
-        run: go mod download
+        run: |
+          # Same `cache: false` + unretried module download as go-test.yaml: one
+          # transient proxy error kills the job. The `go test -c` below stays
+          # unwrapped (go-retry.sh forbids wrapping `go test`) and needs no
+          # network once this step has warmed the cache.
+          source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/go-retry.sh"
+          go_retry mod download
 
       # Compile the tagged test binary as the runner user (build cache is
       # available here), then run it as root — mounting cgroup2 needs

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -85,7 +85,25 @@ jobs:
             libxxf86vm-dev libx11-dev libx11-xcb-dev  
 
       - name: Install dependencies
-        run: go get .
+        run: |
+          # `cache: false` above means this lane re-downloads keploy's whole
+          # module graph on every run, before every test in this job.
+          source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/go-retry.sh"
+          go_retry get .
+          # `go get .` resolves the main module's NON-test import graph. The two
+          # test steps additionally load github.com/go-sql-driver/mysql and its
+          # dependency filippo.io/edwards25519, and neither step can be wrapped
+          # (go-retry.sh forbids wrapping `go test`), so a transient proxy error
+          # while those resolve kills the job unretried. Measured by evicting
+          # both from GOMODCACHE: `go get .` leaves them absent, and
+          # `go list -deps -test ./...` extracts exactly those two.
+          # `go list -deps -test` rather than `go mod download` is a preference,
+          # not a correctness point — both warm what the test steps need, and
+          # both leave go.sum byte-identical (measured +0 lines, 3/3 trials; the
+          # command that does rewrite go.sum is `go mod download all`, which is
+          # not this). `go list` warms only what these steps load and picks up
+          # new test-only deps by itself.
+          go_retry list -deps -test ./... > /dev/null
 
       - name: Running Unit Tests
         run: go test ./...
@@ -93,7 +111,12 @@ jobs:
       # The mock-manager's concurrency guards — the tier-key/HitCount race and
       # the hitMu/treesMu lock order — are only meaningful under -race: without
       # it their tests pass on a build that races, so they read as coverage
-      # while proving nothing. Scoped to this package rather than the whole
-      # tree to keep the lane fast.
+      # while proving nothing. That applies past the mock manager: util/ keeps the
+      # loopback fallback's process-wide atomic.Bool, and syncMock, supervisor and
+      # tls ship eight tests with Race/Concurrent/Deadlock in their names. Naming
+      # packages here left those eight raced by nothing, so race the whole subtree
+      # instead — it is not slower in any way that matters, because package tests
+      # run in parallel: measured 43s for all 29 packages against 40.5s for
+      # ./pkg/agent/proxy/ alone, which dominates either way.
       - name: Running Race Detector (agent proxy)
-        run: go test -race -count=1 ./pkg/agent/proxy/
+        run: go test -race -count=1 ./pkg/agent/proxy/...

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -28,6 +28,15 @@ jobs:
       # database, so keying on it would turn an unrelated contributor's PR red
       # over a service they were never offered. Unset, the tests skip.
       KEPLOY_TEST_MYSQL_REQUIRED: "1"
+      # Same shape, different resource: the proxy's loopback address-family
+      # fallback tests need ::1 on lo. Without this they SKIP and the package
+      # still reports ok — a suite that tests nothing while looking healthy,
+      # which is the exact failure the fallback itself exists to prevent.
+      # Unlike MySQL this is not a service the lane provides, it is a property
+      # of the runner; every GitHub-hosted ubuntu image has ::1 on lo, so this
+      # only fires if that stops being true, and it stays unset elsewhere so a
+      # v6-less environment skips rather than fails.
+      KEPLOY_TEST_IPV6_REQUIRED: "1"
       KEPLOY_TEST_MYSQL_ADDR: "127.0.0.1:3306"
       KEPLOY_TEST_MYSQL_USER: root
       KEPLOY_TEST_MYSQL_PASS: rootpass

--- a/.github/workflows/golang_linux.yml
+++ b/.github/workflows/golang_linux.yml
@@ -292,29 +292,10 @@ jobs:
           REPLAY_BIN: ${{ steps.replay.outputs.path }}
         run: |
           cd samples-go/${{ matrix.app.path }}
-          download_go_modules() {
-            local attempt=1
-            local max_attempts=4
-            local sleep_sec=5
-            local go_proxy="https://proxy.golang.org,direct"
-            while [ "$attempt" -le "$max_attempts" ]; do
-              if GOPROXY="$go_proxy" go mod download; then
-                return 0
-              fi
-              if [ "$attempt" -ge "$max_attempts" ]; then
-                echo "::error::go mod download failed after ${max_attempts} attempts"
-                return 1
-              fi
-              if [ "$attempt" -eq 2 ]; then
-                go_proxy="direct"
-              fi
-              echo "go mod download attempt ${attempt} failed; retrying in ${sleep_sec}s"
-              sleep "$sleep_sec"
-              sleep_sec=$((sleep_sec * 2))
-              attempt=$((attempt + 1))
-            done
-          }
-          download_go_modules
+          # Was a hand-rolled copy of this retry. It retried EVERY failure with
+          # no transient check, which is the policy go-retry.sh exists to avoid.
+          source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/go-retry.sh"
+          go_retry mod download
           $REPLAY_BIN test --port 8000 --sse-port 8047 --api-timeout 200 --delay 30
 
       - name: Test port mapping (http-sse only)

--- a/.github/workflows/sampling-test.yml
+++ b/.github/workflows/sampling-test.yml
@@ -43,7 +43,11 @@ jobs:
       - name: Build keploy
         working-directory: keploy
         run: |
-          go build -o keploy main.go
+          # Relative, not $GITHUB_WORKSPACE-rooted: this is the one workflow that
+          # checks keploy out into a subdirectory (path: keploy above), and
+          # working-directory: keploy is already in effect for this step.
+          source .github/workflows/test_workflow_scripts/go-retry.sh
+          go_retry build -o keploy main.go
           chmod +x keploy
           ls -lh keploy
 

--- a/.github/workflows/schema_noise_detection_linux.yml
+++ b/.github/workflows/schema_noise_detection_linux.yml
@@ -72,7 +72,11 @@ jobs:
 
       - name: Build keploy from this branch
         run: |
-          go build -tags=viper_bind_struct -o /usr/local/bin/keploy .
+          # keploy's own module graph is far larger than the sample's, and this
+          # runs first in the same job — leaving it bare would keep the exposure
+          # the sample-side wrap removes.
+          source "$GITHUB_WORKSPACE/.github/workflows/test_workflow_scripts/go-retry.sh"
+          go_retry build -tags=viper_bind_struct -o /usr/local/bin/keploy .
           keploy --version || true
 
       - name: Checkout the samples-go repository

--- a/.github/workflows/test_workflow_scripts/check-deprecated-deps.sh
+++ b/.github/workflows/test_workflow_scripts/check-deprecated-deps.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source "$(dirname "${BASH_SOURCE[0]}")/go-retry.sh"
 set -euo pipefail
 # -------------------------------
 # Allowlisted deprecated deps
@@ -12,7 +13,11 @@ ALLOWLIST=(
 direct_deps=$(go mod edit -json | jq -r '.Require[] | select(.Indirect == null) | .Path')
 
 # List all modules with their update / deprecation status
-output=$(go list -m -u all)
+# Proxy-only retry: `go list -m -u all` asks about EVERY module in the graph,
+# so a stream error here kills the lint job the same way it kills a sample
+# lane — but GO_RETRY_DIRECT_FROM is pushed past max attempts because going
+# direct would git ls-remote hundreds of upstream repositories.
+output=$(GO_RETRY_DIRECT_FROM=99 go_retry list -m -u all)
 
 found_deprecated=false
 

--- a/.github/workflows/test_workflow_scripts/go-retry.sh
+++ b/.github/workflows/test_workflow_scripts/go-retry.sh
@@ -42,6 +42,11 @@
 # Usage:  source .../go-retry.sh
 #         go_retry build -o app .
 #         go_retry mod tidy
+#
+# NEVER wrap `go test`. Retrying a suite hides a flaky test instead of fixing
+# it, and the transient regex is matched against stdout as well as stderr — so
+# ordinary test output containing "connection reset by peer" would arm the retry
+# on a genuine failure.
 
 # The transport subset of docker-build-retry.sh's DOCKER_BUILD_RETRY_RE (its
 # rate-limit terms are Docker-specific), plus the two proxy HTTP errors go

--- a/.github/workflows/test_workflow_scripts/go-retry.sh
+++ b/.github/workflows/test_workflow_scripts/go-retry.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Shared bounded retry for the go commands that download modules.
+#
+# Go has no built-in retry for module download, so ONE transient error from
+# proxy.golang.org kills the whole job — and it kills whichever lanes happen to
+# be resolving modules at that moment, which reads as a code failure in an
+# unrelated PR. Observed on run 34349029943, where three lanes died inside two
+# minutes on three different modules:
+#
+#   go.mongodb.org/mongo-driver@v1.8.1: read "https://proxy.golang.org/...zip":
+#     stream error: stream ID 1; INTERNAL_ERROR; received from peer
+#
+# Wraps `go <args>`, not `go build` specifically, because the download is just
+# as often done by `go mod tidy`, `go mod download`, `go install` or
+# `go list -m -u` — and in a script under `set -e` an unwrapped `go mod tidy`
+# aborts before a wrapped build is ever reached, so guarding only the build
+# guards nothing.
+#
+# WHY ONLY TRANSIENT FAILURES ARE RETRIED
+#
+# Same reasoning docker-build-retry.sh sets out for its own regex: retrying
+# every failure turns a genuine 30-second compile break into a multi-minute one
+# and prints the compiler error four times, pushing the real message screens
+# above the tail of the log. A failure that does not look transient aborts on
+# the first attempt with its own exit code. The pattern is shared with
+# docker-build-retry.sh rather than reinvented.
+#
+# WHY THE PROXY IS RETRIED BEFORE GOING DIRECT
+#
+# The observed failure is a transient HTTP/2 stream error, so the same proxy on
+# a fresh connection is both the cheapest retry (a zip GET, not a full VCS
+# fetch) and the likeliest to work. `direct` is also strictly riskier: for a
+# module whose upstream was renamed, deleted or retagged, direct fails
+# PERMANENTLY where the proxy would still serve it, turning a recoverable blip
+# into a red lane with a more confusing error. So: proxy on attempts 1-2,
+# direct from 3 — the schedule of the inline download_go_modules this replaces.
+#
+# Set GO_RETRY_DIRECT_FROM to a number past max attempts to never go direct.
+# check-deprecated-deps.sh needs that: `go list -m -u all` asks about every
+# module in the graph, and direct would git ls-remote hundreds of upstreams.
+#
+# Usage:  source .../go-retry.sh
+#         go_retry build -o app .
+#         go_retry mod tidy
+
+# The transport subset of docker-build-retry.sh's DOCKER_BUILD_RETRY_RE (its
+# rate-limit terms are Docker-specific), plus the two proxy HTTP errors go
+# surfaces. NOT a copy of that list, and deliberately narrower in one place:
+#
+#   `unexpected EOF` is matched ONLY when qualified by a URL. cmd/compile
+#   prints "syntax error: unexpected EOF, expected }" for any unterminated
+#   brace — verified against the real toolchain — and docker-build-retry.sh
+#   documents removing that bare pattern because it retried a syntax error four
+#   times. But a truncated proxy zip genuinely surfaces as
+#   `read "https://proxy.golang.org/…zip": unexpected EOF`, which is transient
+#   and worth retrying. cmd/compile never emits a URL, so anchoring on the read
+#   keeps the transient case and excludes the compile break.
+#
+#   429/500/504 are included because proxy.golang.org really does return them —
+#   it rate-limits by egress IP, which on a shared-NAT runner is the same
+#   scenario docker-build-retry.sh documents for Docker Hub. Matched on wording,
+#   never on bare digits, which also occur in byte counts and timestamps.
+#
+#   Bare `no such host` is excluded: it lives in DOCKER_PULL_RETRY_RE, not the
+#   build one, because a dead host is usually permanent.
+GO_RETRY_RE=${GO_RETRY_RE:-'stream error: stream id|INTERNAL_ERROR; received from peer|tls handshake timeout|i/o timeout|connection reset by peer|500 Internal Server Error|502 Bad Gateway|503 Service Unavailable|504 Gateway Time-?out|429 Too Many Requests|too many requests|read "https?://[^"]*": unexpected EOF'}
+
+go_retry() {
+  local attempt=1
+  local max_attempts="${GO_RETRY_MAX_ATTEMPTS:-4}"
+  local direct_from="${GO_RETRY_DIRECT_FROM:-3}"
+  local sleep_sec="${GO_RETRY_BACKOFF:-5}"
+  local proxy rc out_f err_f fifo_f tee_pid
+  # Explicit template so the names are greppable in a log and portable to
+  # BSD mktemp; no lane that sources this runs on macOS today.
+  out_f="$(mktemp "${TMPDIR:-/tmp}/go-retry-out.XXXXXX")"
+  err_f="$(mktemp "${TMPDIR:-/tmp}/go-retry-err.XXXXXX")"
+  fifo_f="${err_f}.fifo"
+  # Streams stay SEPARATE. Merging them would corrupt any caller that captures
+  # the command's output — check-deprecated-deps.sh does
+  # `output=$(go_retry list -m -u all)`, and go writes "go: downloading …"
+  # progress to stderr, which would land in the parsed value. Every message
+  # this function emits itself goes to stderr for the same reason.
+
+  while [ "$attempt" -le "$max_attempts" ]; do
+    # Never override a GOPROXY the caller set on purpose (GOPROXY=off is an
+    # assertion that nothing may touch the network).
+    if [ -n "${GOPROXY:-}" ] || [ "$attempt" -lt "$direct_from" ]; then
+      proxy="${GOPROXY:-https://proxy.golang.org,direct}"
+    else
+      proxy="direct"
+    fi
+
+    # An `if` condition is exempt from errexit, so a failing go does not abort
+    # the CALLER while this function decides whether to retry. Deliberately not
+    # `set +e; …; set -e`: that would turn errexit ON for callers that never
+    # had it, and their next failure anywhere would abort the script.
+    # stderr streams LIVE and is captured. `go: downloading …` progress is the
+    # only signal of what a stalled download is doing, and a step that hits
+    # timeout-minutes is SIGKILLed — with plain redirection nothing would have
+    # been replayed yet and the command's entire output would be lost, which is
+    # exactly the case this file exists for. stdout stays file-only so a
+    # caller's `output=$(go_retry …)` is unaffected.
+    #
+    # A FIFO with a real background PID, NOT `2> >(tee …)`: process
+    # substitution does not set $!, so the `wait $!` such a version needs
+    # degrades to a bare `wait` that blocks on EVERY child — and these scripts
+    # background the application under test, so that deadlocks the lane.
+    mkfifo "$fifo_f" || { echo "::error::go_retry: cannot create fifo" >&2; rm -f "$out_f" "$err_f" "$fifo_f"; return 1; }
+    tee "$err_f" >&2 < "$fifo_f" &
+    tee_pid=$!
+    if GOPROXY="$proxy" go "$@" >"$out_f" 2>"$fifo_f"; then
+      rc=0
+    else
+      rc=$?
+    fi
+    # Unbounded by design: it is what guarantees err_f is complete before the
+    # transient-match grep below reads it. A process that outlived go while
+    # holding the inherited stderr fd would stall here, but go reaps its own
+    # children, so the only candidates are git/ssh helpers on the direct-mode
+    # attempts, which the runners do not spawn.
+    wait "$tee_pid" 2>/dev/null || true
+    rm -f "$fifo_f"
+    # stdout reaches the caller ONLY on success. A failed attempt's partial
+    # stdout would otherwise land in `output=$(go_retry …)` — `go list -m -u all`
+    # streams module lines as it resolves, so a mid-way failure would inject
+    # hundreds of them into the captured value, two or three times over.
+    if [ "$rc" -eq 0 ]; then
+      cat "$out_f"
+    else
+      cat "$out_f" >&2
+    fi
+
+    if [ "$rc" -eq 0 ]; then
+      rm -f "$out_f" "$err_f" "$fifo_f"
+      return 0
+    fi
+    if ! grep -qiE "$GO_RETRY_RE" "$out_f" "$err_f"; then
+      echo "::error::go $* failed (exit ${rc}) and the output does not look transient — not retrying" >&2
+      rm -f "$out_f" "$err_f" "$fifo_f"
+      return "$rc"
+    fi
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "::error::go $* failed after ${max_attempts} attempts (last GOPROXY=${proxy})" >&2
+      rm -f "$out_f" "$err_f" "$fifo_f"
+      return "$rc"
+    fi
+    echo "go $* attempt ${attempt} failed transiently; retrying in ${sleep_sec}s (attempt $((attempt + 1))/${max_attempts})…" >&2
+    sleep "$sleep_sec"
+    sleep_sec=$((sleep_sec * 2))
+    attempt=$((attempt + 1))
+  done
+  # Reached only when max_attempts < 1 (e.g. a bad override): never silently
+  # report success for a command that was never run.
+  echo "::error::go $* was never attempted (GO_RETRY_MAX_ATTEMPTS=${max_attempts})" >&2
+  rm -f "$out_f" "$err_f" "$fifo_f"
+  return 1
+}

--- a/.github/workflows/test_workflow_scripts/golang/connect_tunnel/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/connect_tunnel/golang-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 # E2E test for CONNECT tunnel support.
 # Verifies that Keploy can record and replay HTTP requests that the app
@@ -125,7 +126,7 @@ if ! (echo > /dev/tcp/127.0.0.1/3128) >/dev/null 2>&1; then
 fi
 
 # ── Build the app ──
-go build -o connect-tunnel
+go_retry build -o connect-tunnel
 echo "Go binary built."
 
 # ── Generate keploy config with noise rules ──

--- a/.github/workflows/test_workflow_scripts/golang/dns_dedup/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/dns_dedup/golang-linux.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 # E2E test for DNS mock deduplication.
 #
@@ -113,8 +114,8 @@ sudo rm -f /tmp/keploy-logs.txt
 
 section "Build App"
 echo "Building app..."
-go mod tidy
-go build -o dns-dedup
+go_retry mod tidy
+go_retry build -o dns-dedup
 endsec
 
 # Generate keploy config with noise for DNS-dependent fields.

--- a/.github/workflows/test_workflow_scripts/golang/dns_mock/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/dns_mock/golang-linux.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 set -Eeuxo pipefail
 
@@ -89,8 +90,8 @@ sudo rm -f /tmp/keploy-logs.txt
 # Build
 section "Build App"
 echo "Building app..."
-go mod tidy
-go build -o dns-test
+go_retry mod tidy
+go_retry build -o dns-test
 endsec
 
 # Record

--- a/.github/workflows/test_workflow_scripts/golang/echo_mysql/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_mysql/golang-linux.sh
@@ -120,78 +120,53 @@ run_record_iteration() {
 
   sudo rm -f /tmp/keploy-logs.txt
 
-  # Start recording in background so we capture its PID explicitly.
+  # A plain redirect, NOT `| tee`. A pipeline's $! is its LAST element, so this
+  # used to hold tee's pid and the recorder's own was never available — which is
+  # why the stop below had to guess with `pgrep keploy`. Measured: with the tee
+  # pipeline $! names tee, so signalling it never reached the recorder at all
+  # — the recorder instead died on its next stdout write, from SIGPIPE, which
+  # Go does not suppress on fd 1/2 (measured with a Go writer: exit 141, and its
+  # shutdown handler never ran). An ungraceful stop that skips the flush path.
+  # Six other lanes already record this way — spring_petclinic,
+  # express_mongoose, mysql_dual_conn, tidb_stmt_cache, mysql_auto_port and
+  # async_config_poll — all redirect to a file and signal $!.
   # extra_flags is intentionally unquoted so the empty default expands
   # to nothing; the json pass passes "--storage-format json".
   # shellcheck disable=SC2086
   "$RECORD_BIN" record $extra_flags -c "./urlShort" --generateGithubActions=false \
-    2>&1 | tee "${app_name}.txt" &
-  # $! is the LAST element of the pipeline — tee — not the recorder (measured).
-  # Nothing depends on that today: send_request ignores its argument, and the
-  # stop below locates the recorder with pgrep instead. Do not turn this into a
-  # signal target without changing the pipeline's shape first.
+    > "${app_name}.txt" 2>&1 &
   local KEPLOY_PID=$!
 
   # Drive traffic + stop keploy
   send_request "$KEPLOY_PID"
 
+  # tee used to stream this into the job log as it was written; a redirect only
+  # reaches the log when something prints it, so print it.
+  cat "${app_name}.txt" || true
+
   # Wait for keploy exit and capture code
   section "Stop Recording"
   sleep 10
   echo "Stopping Keploy record process (PID: $KEPLOY_PID)..."
-  # NOT `pid=$(pgrep keploy || true) && [ -n "$pid" ] && sudo kill $pid`.
-  # `sudo kill` was the LAST command of that && list, so errexit checks its
-  # status — and errexit is on here today, from the step shell. pgrep→kill is a
-  # TOCTOU race: keploy can exit on its own between the two calls, and the kill
-  # then fails for a reason that carries no information, aborting the run at a
-  # point where the recording has already succeeded and skipping the artifact
-  # listing and the DATA RACE scan below. "Not running" is the state this block
-  # exists to reach, so a pid that is already gone is success — but a pid still
-  # running afterwards is a real failure and still fails the step, which the
-  # replaced line never checked at all.
-  local pid
-  pid=$(pgrep keploy || true)
-  if [ -n "$pid" ]; then
-    # shellcheck disable=SC2086  # split on purpose: pgrep can print several pids
-    if ! sudo kill $pid; then
-      # `sudo kill` reports failure if ANY named pid failed, and pgrep can name
-      # several, so a failing kill may still have delivered SIGTERM to a live
-      # one. Poll instead of judging instantly: a signalled process needs a
-      # moment to leave /proc.
-      # /proc, not `kill -0`: the process this stops needs sudo to signal —
-      # that is what the replaced line already assumed — so an UNPRIVILEGED
-      # `kill -0` on it returns a status indistinguishable from "no such
-      # process" (measured: `kill -0` on a live root pid and on a vanished pid
-      # both exit 1). A missing /proc/<pid> entry is unambiguous and needs no
-      # privilege; a zombie has already exited and only awaits reaping.
-      local waited=0 alive p stat_raw state
-      while :; do
-        alive=""
-        for p in $pid; do
-          # an unreadable /proc entry IS the answer here: the process is gone
-          stat_raw=$(cat "/proc/$p/stat" 2>/dev/null || true)
-          [ -n "$stat_raw" ] || continue
-          state=${stat_raw##*) }; state=${state%% *}
-          [ "$state" = "Z" ] || alive="$alive $p"
-        done
-        [ -n "$alive" ] || break
-        if [ "$waited" -ge 10 ]; then break; fi
-        sleep 1; waited=$((waited+1))
-      done
-      if [ -n "$alive" ]; then
-        echo "::error::keploy (pid$alive) still running ${waited}s after 'sudo kill' failed"
-        return 1
-      fi
-      # pgrep prints one pid per line, so the newlines are replaced before the
-      # list goes into a message. True whether the pid had already exited before
-      # the kill or died from a SIGTERM the same kill did deliver.
-      echo "no keploy process remains after 'sudo kill' reported failure (pid ${pid//$'\n'/ })"
-    fi
-    # `|| true`: pgrep can match a keploy that is not a child of this shell, and
-    # "not a child of this shell" carries no information about the recording.
-    # shellcheck disable=SC2086
-    wait $pid 2>/dev/null || true
-  fi
+  # Signal the recorder we started, by pid. `pgrep keploy` is gone from here: it
+  # named BOTH the CLI and the root agent — the agent is this same binary
+  # re-run under sudo (agent.go's GetCurrentBinaryPath into NewAgentCommand), so
+  # both carry comm `keploy`, which golang/mock_mismatch/golang-linux.sh relies
+  # on by name. It also matches by unanchored comm, so any other keploy* process
+  # on the host was in its blast radius. Signalling by pid removes both.
+  # `|| true` on the kill because keploy may have exited on its own first —
+  # pgrep-then-kill was a TOCTOU race whose failure carried no information, and
+  # errexit checking it aborted runs whose recording had already succeeded.
+  # The kill is not what establishes the outcome; `wait` is. KEPLOY_PID is this
+  # shell's own child, so wait returns only once it is really gone and yields
+  # its status — no /proc inspection and no privilege question, which is what
+  # the pgrep form needed because it signalled processes it did not start.
+  sudo kill "$KEPLOY_PID" 2>/dev/null || true
+  local rc=0
+  wait "$KEPLOY_PID" || rc=$?
+  # Reported, not gated: this lane has never failed on the recorder's exit
+  # status, and a SIGTERM'd process legitimately reports one.
+  echo "Record exit code: $rc"
   sleep 30
   echo "Recording stopped."
   endsec

--- a/.github/workflows/test_workflow_scripts/golang/echo_mysql/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_mysql/golang-linux.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 # safer bash, but we’ll locally disable -e around commands we want to inspectset -Eeuo pipefail
 
 source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
@@ -156,7 +157,7 @@ sudo rm -f /tmp/keploy-logs.txt
 
 sudo "$RECORD_BIN" config --generate
 sed -i 's/global: {}/global: {"body": {"updated_at":[]}}/' ./keploy.yml
-go build -o urlShort
+go_retry build -o urlShort
 endsec
 
 section "Start MySQL"

--- a/.github/workflows/test_workflow_scripts/golang/echo_mysql/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/echo_mysql/golang-linux.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
-# safer bash, but we’ll locally disable -e around commands we want to inspectset -Eeuo pipefail
+# safer bash. -e also arrives from the step shell: golang_linux.yml SOURCES
+# this file from a `run:` step with no `shell:` key, i.e. GitHub's `bash -e {0}`.
+set -Eeuo pipefail
 
 source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 git fetch origin
@@ -10,7 +12,9 @@ git checkout origin/add-ssl-mysql
 section()  { echo "::group::$*"; }
 endsec()   { echo "::endgroup::"; }
 dump_logs() {
-  rc=$?
+  # `local`: this file is SOURCED, so an undeclared assignment here writes a
+  # variable in the calling step shell.
+  local rc=$?
   echo "Dumping logs and artifacts (exit code: $rc)"
   section "Record logs"
   cat urlShort_*.txt || true
@@ -26,7 +30,12 @@ trap dump_logs EXIT
 wait_for_mysql() {
   section "Wait for MySQL readiness"
   # ping until mysqld accepts connections
-  for i in {1..60}; do
+  # `local`, and not `i`: the main flow drives recording with `for i in 1 2`,
+  # and an undeclared `i` in a helper writes the caller's copy. The counter is
+  # never read in this loop; it only bounds the wait.
+  local attempt
+  # shellcheck disable=SC2034  # a bare bound; the loop body never reads it
+  for attempt in {1..60}; do
     if docker exec mysql-container mysql -uroot -ppassword -e "SELECT 1" >/dev/null 2>&1; then
       echo "MySQL is ready."
       endsec; return 0
@@ -41,7 +50,15 @@ send_request() {
   local kp_pid="$1"
 
   # Wait for the app to report healthy
-  for i in {1..60}; do
+  # `local`, and not `i`: send_request is called from inside the main flow's
+  # `for i in 1 2` record loop, and an undeclared `i` here left the caller's
+  # counter at this loop's final value — so the pass-2 confirmation echo
+  # printed the health-poll count instead of the pass number (1 when the app
+  # was healthy on the first poll, 60 when it never became healthy). The
+  # counter is never read in this loop; it only bounds the wait.
+  local attempt
+  # shellcheck disable=SC2034  # a bare bound; the loop body never reads it
+  for attempt in {1..60}; do
     if curl -fsS http://localhost:9090/healthcheck >/dev/null; then
       echo "good!App started"
       break
@@ -109,6 +126,10 @@ run_record_iteration() {
   # shellcheck disable=SC2086
   "$RECORD_BIN" record $extra_flags -c "./urlShort" --generateGithubActions=false \
     2>&1 | tee "${app_name}.txt" &
+  # $! is the LAST element of the pipeline — tee — not the recorder (measured).
+  # Nothing depends on that today: send_request ignores its argument, and the
+  # stop below locates the recorder with pgrep instead. Do not turn this into a
+  # signal target without changing the pipeline's shape first.
   local KEPLOY_PID=$!
 
   # Drive traffic + stop keploy
@@ -118,8 +139,59 @@ run_record_iteration() {
   section "Stop Recording"
   sleep 10
   echo "Stopping Keploy record process (PID: $KEPLOY_PID)..."
-  pid=$(pgrep keploy || true) && [ -n "$pid" ] && sudo kill $pid
-  wait "$pid" 2>/dev/null || true
+  # NOT `pid=$(pgrep keploy || true) && [ -n "$pid" ] && sudo kill $pid`.
+  # `sudo kill` was the LAST command of that && list, so errexit checks its
+  # status — and errexit is on here today, from the step shell. pgrep→kill is a
+  # TOCTOU race: keploy can exit on its own between the two calls, and the kill
+  # then fails for a reason that carries no information, aborting the run at a
+  # point where the recording has already succeeded and skipping the artifact
+  # listing and the DATA RACE scan below. "Not running" is the state this block
+  # exists to reach, so a pid that is already gone is success — but a pid still
+  # running afterwards is a real failure and still fails the step, which the
+  # replaced line never checked at all.
+  local pid
+  pid=$(pgrep keploy || true)
+  if [ -n "$pid" ]; then
+    # shellcheck disable=SC2086  # split on purpose: pgrep can print several pids
+    if ! sudo kill $pid; then
+      # `sudo kill` reports failure if ANY named pid failed, and pgrep can name
+      # several, so a failing kill may still have delivered SIGTERM to a live
+      # one. Poll instead of judging instantly: a signalled process needs a
+      # moment to leave /proc.
+      # /proc, not `kill -0`: the process this stops needs sudo to signal —
+      # that is what the replaced line already assumed — so an UNPRIVILEGED
+      # `kill -0` on it returns a status indistinguishable from "no such
+      # process" (measured: `kill -0` on a live root pid and on a vanished pid
+      # both exit 1). A missing /proc/<pid> entry is unambiguous and needs no
+      # privilege; a zombie has already exited and only awaits reaping.
+      local waited=0 alive p stat_raw state
+      while :; do
+        alive=""
+        for p in $pid; do
+          # an unreadable /proc entry IS the answer here: the process is gone
+          stat_raw=$(cat "/proc/$p/stat" 2>/dev/null || true)
+          [ -n "$stat_raw" ] || continue
+          state=${stat_raw##*) }; state=${state%% *}
+          [ "$state" = "Z" ] || alive="$alive $p"
+        done
+        [ -n "$alive" ] || break
+        if [ "$waited" -ge 10 ]; then break; fi
+        sleep 1; waited=$((waited+1))
+      done
+      if [ -n "$alive" ]; then
+        echo "::error::keploy (pid$alive) still running ${waited}s after 'sudo kill' failed"
+        return 1
+      fi
+      # pgrep prints one pid per line, so the newlines are replaced before the
+      # list goes into a message. True whether the pid had already exited before
+      # the kill or died from a SIGTERM the same kill did deliver.
+      echo "no keploy process remains after 'sudo kill' reported failure (pid ${pid//$'\n'/ })"
+    fi
+    # `|| true`: pgrep can match a keploy that is not a child of this shell, and
+    # "not a child of this shell" carries no information about the recording.
+    # shellcheck disable=SC2086
+    wait $pid 2>/dev/null || true
+  fi
   sleep 30
   echo "Recording stopped."
   endsec
@@ -145,6 +217,24 @@ run_record_iteration() {
 # ----- main flow -----
 
 section "Environment"
+# The calling job sets these from `steps.<id>.outputs.path`. These are the only
+# unguarded script-external expansions in this file, so they look like what
+# `set -u` buys — they are not: -u fires only on an UNSET name, and a variable
+# that is set to the empty string sails straight through it (measured). An
+# empty or stale path is otherwise first reported ten lines below, by sudo,
+# after `rm -rf keploy/` has already run. Asserted here instead.
+: "${RECORD_BIN:?not set by the calling job (steps.record.outputs.path)}"
+: "${REPLAY_BIN:?not set by the calling job (steps.replay.outputs.path)}"
+for _b in "$RECORD_BIN" "$REPLAY_BIN"; do
+  # `command -v`, not `[ -x ]`: it accepts an absolute path and a bare PATH
+  # name alike, where `[ -x ]` rejects a bare name outright (measured on `git`).
+  # The `[ -e ]` fallback is deliberate and must not be dropped: this script
+  # also runs these binaries under sudo, so the calling user's execute bit is
+  # not the right question — only "names nothing at all" is. That is exactly
+  # what an empty or stale path does, and both are rejected here.
+  command -v -- "$_b" >/dev/null 2>&1 || [ -e "$_b" ] || {
+    echo "::error::not a usable binary path: $_b"; exit 1; }
+done
 echo "RECORD_BIN: $RECORD_BIN"
 echo "REPLAY_BIN : $REPLAY_BIN"
 "$RECORD_BIN" --version 2>/dev/null || true
@@ -161,7 +251,29 @@ go_retry build -o urlShort
 endsec
 
 section "Start MySQL"
-if ! docker ps --format '{{.Names}}' | grep -q '^mysql-container$'; then
+# Capture first, match second — deliberately NOT `docker ps … | grep -q …`, the
+# shape json-pass-helpers.sh documents. That pipeline conflated two different
+# facts into one status: `grep -q` exits at its first match and can SIGPIPE a
+# writer that still has bytes pending, and a `docker ps` that fails outright
+# prints nothing and exits non-zero. pipefail promotes either to the pipeline,
+# so `if !` read "container absent" while it was PRESENT, took the create
+# branch, and `docker run --name mysql-container` then failed on a healthy run.
+# Measured: the real docker CLI emits its whole --format output in ONE write(),
+# and a single write that fits the 64KiB pipe buffer completes before the reader
+# can exit — so with the real CLI that route needs an implausibly long container
+# list. Any producer that writes incrementally takes it at this lane's output
+# size (measured: 61 wrong branches in 200 trials). A capture has no reader to
+# race with at all, which is why this is a capture and not a -c/-q swap.
+# The explicit rc check is here because an `if` condition is exempt from
+# errexit: a `docker ps` that fails has not established that the container is
+# absent, so the run must stop and say so rather than branch on a value it
+# never got.
+if ! running_containers=$(docker ps --format '{{.Names}}'); then
+  echo "::error::docker ps failed; cannot determine whether mysql-container is running"
+  exit 1
+fi
+# exact-line match, equivalent to `grep -qxF mysql-container`
+if [[ $'\n'"$running_containers"$'\n' != *$'\n'mysql-container$'\n'* ]]; then
   if [[ "${ENABLE_SSL:-false}" == "true" ]]; then
     echo "Starting MySQL with SSL/TLS via Docker Compose"
     docker_compose_pull_retry
@@ -222,23 +334,52 @@ echo "MySQL stopped - Keploy should now use mocks for database interactions"
 endsec
 
 section "Replay"
-# Run replay but DON'T crash the step; capture rc and print logs
-set +e
-
+# Run replay but DON'T crash the step; capture rc and print logs.
 sudo rm -f /tmp/keploy-logs.txt
 
-"$REPLAY_BIN" test -c "./urlShort" --delay 7 --generateGithubActions=false \
-  2>&1 | tee test_logs.txt || true
-REPLAY_RC=$?
-set -e
+# An `if` condition is exempt from errexit, so the step survives a failing
+# replay long enough to say WHICH test set failed. Deliberately not
+# `set +e; …; set -e`, the idiom go-retry.sh argues against by name: a window
+# is a shell-wide state that a later edit can silently widen, and the one this
+# replaces already covered the `sudo rm -f` above, hiding its failures while
+# the identical `sudo rm -f` calls elsewhere in this file ran bare.
+# This matters now in a way it did not before: with the pragma at the top of
+# this file actually executing, pipefail makes the pipeline carry the replay's
+# own status instead of tee's 0, so a failing replay would otherwise kill the
+# step right here — losing "Replay exit code", the per-test-set verdict read
+# from the report files below, and the ::error:: that names the outcome.
+# PIPESTATUS[0], not $?: it names the replay's own status whatever tee does,
+# and it survives into the else branch because nothing runs in between. No
+# `|| true` — that would not merely swallow the failure, it would reset
+# PIPESTATUS before it could be read.
+# Other failures still abort the step under errexit: wait_for_mysql's
+# `return 1` and run_record_iteration's DATA RACE `return 1` are both called
+# bare. (Named, not cited by line: line numbers go stale, comments must not.)
+if "$REPLAY_BIN" test -c "./urlShort" --delay 7 --generateGithubActions=false \
+  2>&1 | tee test_logs.txt
+then
+  REPLAY_RC=0
+else
+  REPLAY_RC=${PIPESTATUS[0]}
+fi
 echo "Replay exit code: $REPLAY_RC"
 cat test_logs.txt || true
 endsec
 
 # If replay failed, still try to read reports to say which set failed
 section "Check reports"
-# Find the most recent test-run dir (don’t assume test-run-0)
-RUN_DIR=$(ls -1dt ./keploy/reports/test-run-* 2>/dev/null | head -n1 || true)
+# Newest test-run dir (don’t assume test-run-0), picked in bash: no pipeline,
+# so pipefail has nothing to promote and no status is discarded. The replaced
+# form was `ls … | head -n1 || true`, where `ls` legitimately exits 2 when no
+# test-run dir exists; with pipefail live that `|| true` became the only thing
+# keeping the ::error:: below reachable, while reading as removable dead weight.
+# With no test-run dir the glob stays literal (nullglob is off), fails -d, and
+# leaves RUN_DIR empty — which the check below already reports by name.
+RUN_DIR=""
+for _d in ./keploy/reports/test-run-*; do
+  [[ -d "$_d" ]] || continue
+  if [[ -z "$RUN_DIR" || "$_d" -nt "$RUN_DIR" ]]; then RUN_DIR="$_d"; fi
+done
 if [[ -z "${RUN_DIR:-}" ]]; then
   echo "::error::No test-run directory found under ./keploy/reports"
   [[ $REPLAY_RC -ne 0 ]] && exit "$REPLAY_RC" || exit 1
@@ -246,8 +387,13 @@ fi
 
 echo "Using reports from: $RUN_DIR"
 all_passed=true
+# found_any, because the glob falls through to `continue` when RUN_DIR holds no
+# yaml reports at all — leaving all_passed=true and passing the lane on a run
+# that scanned nothing. json_scan_reports and mysql_dual_conn both guard this.
+found_any=false
 for rpt in "$RUN_DIR"/test-set-*-report.yaml; do
   [[ -f "$rpt" ]] || continue
+  found_any=true
   status=$(awk '/^status:/{print $2; exit}' "$rpt")
   echo "Test status for $(basename "$rpt"): ${status:-<missing>}"
   if [[ "$status" != "PASSED" ]]; then
@@ -256,6 +402,11 @@ for rpt in "$RUN_DIR"/test-set-*-report.yaml; do
 done
 endsec
 
+if [[ "$found_any" != "true" ]]; then
+  echo "::error::No test-set report files found in $RUN_DIR"
+  exit 1
+fi
+
 if [[ "$all_passed" != "true" || $REPLAY_RC -ne 0 ]]; then
   echo "::error::Some yaml tests failed or replay exited non-zero"
   exit 1
@@ -263,22 +414,27 @@ fi
 
 if json_pass_supported; then
   section "Replay (json)"
-  set +e
   sudo rm -f /tmp/keploy-logs.txt
-  "$REPLAY_BIN" test --storage-format json -c "./urlShort" --delay 7 --generateGithubActions=false \
-    2>&1 | tee test_logs_json.txt || true
-  REPLAY_RC_JSON=$?
-  set -e
+  # Same shape and same reasons as REPLAY_RC above.
+  if "$REPLAY_BIN" test --storage-format json -c "./urlShort" --delay 7 --generateGithubActions=false \
+    2>&1 | tee test_logs_json.txt
+  then
+    REPLAY_RC_JSON=0
+  else
+    REPLAY_RC_JSON=${PIPESTATUS[0]}
+  fi
   echo "Replay (json) exit code: $REPLAY_RC_JSON"
   cat test_logs_json.txt || true
   endsec
 
-  if [[ $REPLAY_RC_JSON -ne 0 ]]; then
-    echo "::error::Json replay exited non-zero"
-    exit 1
-  fi
-
-  if ! json_scan_reports; then
+  # Scan first, fail second, mirroring the yaml branch's "still try to read
+  # reports to say which set failed". With REPLAY_RC_JSON now live, exiting on
+  # it before the scan would drop the per-test-set diagnostic on exactly the
+  # runs that need it.
+  json_ok=true
+  json_scan_reports || json_ok=false
+  if [[ "$json_ok" != "true" || $REPLAY_RC_JSON -ne 0 ]]; then
+    echo "::error::Json replay failed or exited non-zero (rc=$REPLAY_RC_JSON)"
     cat test_logs_json.txt
     exit 1
   fi

--- a/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/gin_mongo/golang-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 echo "root ALL=(ALL:ALL) ALL" | sudo tee -a /etc/sudoers
@@ -61,7 +62,7 @@ sed -i 's/ports: 0/ports: 27017/' "$config_file"
 rm -rf keploy/
 
 # Build the binary.
-go build -cover -coverpkg=./... -o ginApp
+go_retry build -cover -coverpkg=./... -o ginApp
 
 stop_recording(){
     local kp_pid="${1:-}"

--- a/.github/workflows/test_workflow_scripts/golang/go-grpc/grpc-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/go-grpc/grpc-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 # This script tests the go-grpc sample application in two modes:
 # 'incoming': Tests the gRPC server by recording its incoming gRPC calls.
@@ -31,8 +32,8 @@ echo "Building gRPC server and client binaries..."
 if grep -q '"localhost:50051"' client/client.go; then
     sed -i 's/"localhost:50051"/"127.0.0.1:50051"/' client/client.go
 fi
-go build -o grpc-server .
-go build -o grpc-client ./client
+go_retry build -o grpc-server .
+go_retry build -o grpc-client ./client
 chmod +x ./grpc-server ./grpc-client
 
 # --- Helper Functions ---

--- a/.github/workflows/test_workflow_scripts/golang/grpc-protoscope/grpc-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/grpc-protoscope/grpc-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 # This script tests the grpc-protoscope sample application.
 # Keploy wraps the server to record incoming gRPC calls.
@@ -19,8 +20,8 @@ command -v go >/dev/null 2>&1 || { echo "go not found"; exit 1; }
 
 # --- Build Application ---
 echo "Building gRPC server and client binaries..."
-go build -o grpc-server ./server
-go build -o grpc-client ./client
+go_retry build -o grpc-server ./server
+go_retry build -o grpc-client ./client
 chmod +x ./grpc-server ./grpc-client
 
 # --- Helper Functions ---

--- a/.github/workflows/test_workflow_scripts/golang/grpc-secret/grpc-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/grpc-secret/grpc-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 # This script tests the grpc-secret sample application with Keploy's sanitize functionality.
 # It records gRPC requests with secrets in headers and body, sanitizes them, and validates test results.
@@ -20,7 +21,7 @@ command -v go >/dev/null 2>&1 || { echo "go not found"; exit 1; }
 echo "Installing grpcurl..."
 if ! command -v grpcurl &> /dev/null; then
     echo "grpcurl not found, installing..."
-    go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+    go_retry install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
     export PATH="$PATH:$HOME/go/bin"
 fi
 command -v grpcurl >/dev/null 2>&1 || { echo "grpcurl installation failed"; exit 1; }
@@ -315,7 +316,7 @@ rm -rf ./keploy*
 "$RECORD_BIN" config --generate
 sleep 3
 
-go build -o grpc-secret .
+go_retry build -o grpc-secret .
 sleep 4
 
 echo "✅ Built grpc-secret binary"

--- a/.github/workflows/test_workflow_scripts/golang/http_pokeapi/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/http_pokeapi/golang-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 echo "$RECORD_BIN"
 echo "$REPLAY_BIN"
@@ -17,34 +18,10 @@ fi
 
 rm -rf keploy/
 
-# Build go binary.
-#
-# proxy.golang.org intermittently returns a TLS handshake timeout
-# when the WSL/linux runner first reaches it — seen on
-# keploy/keploy#4077 run 24631193918/job/72018929505 fetching
-# github.com/go-chi/chi@v1.5.5. `go build` has no built-in retry
-# for module download, so a single transient DNS/TLS hiccup kills
-# the whole job. Wrap with a bounded retry + GOPROXY fallback so
-# the flake no longer blocks PRs unrelated to this sample.
-build_go_app() {
-  local attempt=1
-  local max_attempts=4
-  local sleep_sec=5
-  while [ "$attempt" -le "$max_attempts" ]; do
-    if GOPROXY="proxy.golang.org,direct" go build -o http-pokeapi; then
-      return 0
-    fi
-    if [ "$attempt" -ge "$max_attempts" ]; then
-      echo "::error::go build for http-pokeapi failed after ${max_attempts} attempts"
-      return 1
-    fi
-    echo "go build attempt ${attempt} failed; retrying in ${sleep_sec}s (attempt $((attempt+1))/${max_attempts})…"
-    sleep "$sleep_sec"
-    sleep_sec=$((sleep_sec * 2))
-    attempt=$((attempt + 1))
-  done
-}
-build_go_app
+# Build go binary. The retry lives in go-retry.sh now; the flake it exists for
+# was first seen here — keploy/keploy#4077 run 24631193918/job/72018929505,
+# a TLS handshake timeout fetching github.com/go-chi/chi@v1.5.5.
+go_retry build -o http-pokeapi
 echo "go binary built"
 
 # Generate the keploy-config file.

--- a/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mock_mismatch/golang-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 # E2E for the mock-mismatch report. Reuses the http-pokeapi sample (it makes
 # mockable outgoing HTTP calls), records it, then MUTATES the recorded mocks so
@@ -36,25 +37,7 @@ if [ -f "./keploy.yml" ]; then
 fi
 rm -rf keploy/
 
-build_go_app() {
-  local attempt=1
-  local max_attempts=4
-  local sleep_sec=5
-  while [ "$attempt" -le "$max_attempts" ]; do
-    if GOPROXY="proxy.golang.org,direct" go build -o http-pokeapi; then
-      return 0
-    fi
-    if [ "$attempt" -ge "$max_attempts" ]; then
-      echo "::error::go build for http-pokeapi failed after ${max_attempts} attempts"
-      return 1
-    fi
-    echo "go build attempt ${attempt} failed; retrying in ${sleep_sec}s…"
-    sleep "$sleep_sec"
-    sleep_sec=$((sleep_sec * 2))
-    attempt=$((attempt + 1))
-  done
-}
-build_go_app
+go_retry build -o http-pokeapi
 echo "go binary built"
 
 sudo "$RECORD_BIN" config --generate

--- a/.github/workflows/test_workflow_scripts/golang/mock_mismatch_streaming/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mock_mismatch_streaming/golang-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
@@ -51,25 +52,7 @@ for i in $(seq 1 30); do
     sleep 2
 done
 
-build_go_app() {
-  local attempt=1
-  local max_attempts=4
-  local sleep_sec=5
-  while [ "$attempt" -le "$max_attempts" ]; do
-    if GOPROXY="proxy.golang.org,direct" go build -o sse-redis-app; then
-      return 0
-    fi
-    if [ "$attempt" -ge "$max_attempts" ]; then
-      echo "::error::go build for sse-redis-app failed after ${max_attempts} attempts"
-      return 1
-    fi
-    echo "go build attempt ${attempt} failed; retrying in ${sleep_sec}s…"
-    sleep "$sleep_sec"
-    sleep_sec=$((sleep_sec * 2))
-    attempt=$((attempt + 1))
-  done
-}
-build_go_app
+go_retry build -o sse-redis-app
 echo "go binary built"
 
 sudo "$RECORD_BIN" config --generate

--- a/.github/workflows/test_workflow_scripts/golang/mux_elasticsearch_schema_noise/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/mux_elasticsearch_schema_noise/golang-linux.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 #
 # Schema-based request-body noise detection — end-to-end CI test using the real
 # samples-go/mux-elasticsearch app.
@@ -52,15 +53,7 @@ trap cleanup EXIT
 # Build app + wait for Elasticsearch
 # ---------------------------------------------------------------------------
 step "Building mux-elasticsearch"
-build_go_app() {
-  local attempt=1
-  while [ "$attempt" -le 4 ]; do
-    if GOPROXY="proxy.golang.org,direct" go build -o "$APP_BIN" .; then return 0; fi
-    echo "go build attempt ${attempt} failed; retrying…"; sleep $((attempt * 5)); attempt=$((attempt + 1))
-  done
-  echo "::error::go build for $APP_BIN failed"; return 1
-}
-build_go_app || exit 1
+go_retry build -o "$APP_BIN" . || exit 1
 
 step "Waiting for Elasticsearch at $ELASTICSEARCH_URL"
 for i in $(seq 1 30); do

--- a/.github/workflows/test_workflow_scripts/golang/risk_profile/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/risk_profile/golang-linux.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 # This script automates the testing of the risk profile identification feature.
 # It records test cases, validates the initial failure report, then tests the
@@ -371,7 +372,7 @@ git checkout origin/risk-profile
 echo "Cleaning up previous runs..."
 rm -rf keploy/ my-app *.log
 echo "Building the Go application..."
-go build -o my-app
+go_retry build -o my-app
 endsec
 
 section "Record Test Cases"
@@ -415,7 +416,7 @@ fi
 section "Run Keploy Tests"
 echo "Running tests with risk profile analysis..."
 git checkout origin/risk-profile-v2
-go build -o my-app
+go_retry build -o my-app
 $REPLAY_BIN test -c "./my-app" --skip-coverage=false 2>&1 --compare-all | tee test.log || true
 check_for_errors "test.log"
 check_report_for_risk_profiles

--- a/.github/workflows/test_workflow_scripts/golang/sse_preflight/golang-linux.sh
+++ b/.github/workflows/test_workflow_scripts/golang/sse_preflight/golang-linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 echo "$RECORD_BIN"
 echo "$REPLAY_BIN"
@@ -18,8 +19,8 @@ fi
 rm -rf keploy/
 
 # Build go binaries
-go build -o sse-preflight-server ./cmd/server
-go build -o sse-preflight-client ./cmd/client
+go_retry build -o sse-preflight-server ./cmd/server
+go_retry build -o sse-preflight-client ./cmd/client
 echo "go binaries built"
 
 # Generate the keploy-config file.

--- a/.github/workflows/test_workflow_scripts/java/async_config_poll/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/async_config_poll/java-linux.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../../go-retry.sh"
 
 source "${GITHUB_WORKSPACE:-${PWD%/samples-*}}/.github/workflows/test_workflow_scripts/docker-build-retry.sh"
 
@@ -158,7 +159,7 @@ section "Start dependencies (MySQL + config-service stub)"
 # only awaited (wait_for_mysql) just before the app boots under keploy.
 docker_compose_pull_retry
 docker compose up -d
-( cd config-stub && go build -o /tmp/acp-config-stub . )
+( cd config-stub && go_retry build -o /tmp/acp-config-stub . )
 env ${STUB_ENV} /tmp/acp-config-stub > config-stub.log 2>&1 &
 CONFIG_STUB_PID=$!
 endsec

--- a/.github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh
+++ b/.github/workflows/test_workflow_scripts/java/spring_petclinic/java-linux.sh
@@ -819,13 +819,26 @@ fi
 echo "Using reports from: $RUN_DIR"
 
 all_passed=true
+# found_any, because the glob falls through to `continue` when RUN_DIR holds no
+# yaml reports at all. This branch is the only gate that can fail it: the
+# REPLAY_RC check below downgrades a non-zero replay to a ::warning::, so with
+# an empty RUN_DIR the lane printed "All tests passed" and exited 0 having
+# scanned nothing. Eight sibling report loops in this tree already ship this
+# guard.
+found_any=false
 for rpt in "$RUN_DIR"/test-set-*-report.yaml; do
   [[ -f "$rpt" ]] || continue
+  found_any=true
   status=$(awk '/^status:/{print $2; exit}' "$rpt")
   echo "Test status for $(basename "$rpt"): ${status:-<missing>}"
   [[ "$status" == "PASSED" ]] || all_passed=false
 done
 endsec
+
+if [[ "$found_any" != "true" ]]; then
+  echo "::error::No test-set report files found in $RUN_DIR"
+  exit 1
+fi
 
 if [[ "$all_passed" != "true" ]]; then
   echo "::error::Some tests failed or replay exited non-zero"

--- a/.github/workflows/test_workflow_scripts/json-pass-helpers.sh
+++ b/.github/workflows/test_workflow_scripts/json-pass-helpers.sh
@@ -21,16 +21,36 @@
 json_pass_supported() {
     local _rec="${RECORD_BIN:-${RECORD_KEPLOY_BIN:-keploy}}"
     local _rep="${REPLAY_BIN:-${REPLAY_KEPLOY_BIN:-keploy}}"
-    # grep -c, not grep -q: -q exits at the first match, and with `set -o
-    # pipefail` — which ~10 of this helper's ~30 callers already set, so this is
-    # a pre-existing latent bug across many lanes, not one this PR introduced —
-    # that SIGPIPEs the writer and turns
-    # the pipeline into 141. This probe FAILING SILENTLY is the bad outcome —
-    # json_pass_supported would return 1, the caller would print "json pass
-    # skipped for compat-matrix cell", and the whole JSON record+replay pass
-    # would vanish with the lane still green.
-    "$_rec" --help 2>&1 | grep -c -- '--storage-format' >/dev/null || return 1
-    "$_rep" --help 2>&1 | grep -c -- '--storage-format' >/dev/null || return 1
+    # Capture first, match second — deliberately NOT a pipeline.
+    #
+    # This probe failing SILENTLY is the bad outcome: json_pass_supported
+    # returns 1, the caller prints "json pass skipped for compat-matrix cell",
+    # and the entire JSON record+replay pass vanishes with the lane still green.
+    # Under `set -o pipefail` — which 18 of this helper's 31 callers set — a
+    # pipeline does exactly that: pipefail promotes the left side's status, so a
+    # keploy that prints --storage-format while exiting non-zero fails the probe.
+    # (`grep -q` would add a second, INTERMITTENT route: it exits at the first
+    # match and SIGPIPEs a writer that has not finished. Measured here that route
+    # is LIVE — keploy emits its --help in ~500 separate write()s, none as large
+    # as 1KB, and the first --storage-format lands ~93% of the way through the
+    # merged stream, so grep can exit with ~700 bytes still unwritten. Measured
+    # rc=141 on roughly 1-8% of trials on a quiet machine (N=1000 per binary,
+    # two binaries, across several runs) and 16%+ under CPU contention — a
+    # scheduling race whose rate tracks host load, so treat any single figure
+    # here as conditional on the runner, not as a property of the command.
+    # Total output fitting the 64KiB pipe buffer does NOT save an incremental
+    # writer; only the writer finishing before the reader exits does, and that
+    # is a race. `grep -c` reads to EOF, so the form replaced
+    # here never took that route (60/60 rc=0) — but it stayed exposed to the
+    # pipefail promotion above, which is why this is a capture, not a -c/-q swap.)
+    # Command substitution takes only the binary's status, and `|| true`
+    # discards it on purpose — the question is "does the help text mention the
+    # flag", never "did --help succeed".
+    local _help
+    _help="$("$_rec" --help 2>&1)" || true
+    case "$_help" in *--storage-format*) ;; *) return 1 ;; esac
+    _help="$("$_rep" --help 2>&1)" || true
+    case "$_help" in *--storage-format*) ;; *) return 1 ;; esac
     return 0
 }
 

--- a/.github/workflows/test_workflow_scripts/json-pass-helpers.sh
+++ b/.github/workflows/test_workflow_scripts/json-pass-helpers.sh
@@ -21,8 +21,16 @@
 json_pass_supported() {
     local _rec="${RECORD_BIN:-${RECORD_KEPLOY_BIN:-keploy}}"
     local _rep="${REPLAY_BIN:-${REPLAY_KEPLOY_BIN:-keploy}}"
-    "$_rec" --help 2>&1 | grep -q -- '--storage-format' || return 1
-    "$_rep" --help 2>&1 | grep -q -- '--storage-format' || return 1
+    # grep -c, not grep -q: -q exits at the first match, and with `set -o
+    # pipefail` — which ~10 of this helper's ~30 callers already set, so this is
+    # a pre-existing latent bug across many lanes, not one this PR introduced —
+    # that SIGPIPEs the writer and turns
+    # the pipeline into 141. This probe FAILING SILENTLY is the bad outcome —
+    # json_pass_supported would return 1, the caller would print "json pass
+    # skipped for compat-matrix cell", and the whole JSON record+replay pass
+    # would vanish with the lane still green.
+    "$_rec" --help 2>&1 | grep -c -- '--storage-format' >/dev/null || return 1
+    "$_rep" --help 2>&1 | grep -c -- '--storage-format' >/dev/null || return 1
     return 0
 }
 

--- a/.github/workflows/test_workflow_scripts/sample-tls-pcap.sh
+++ b/.github/workflows/test_workflow_scripts/sample-tls-pcap.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/go-retry.sh"
 # E2E validation for keploy's TLS capture features.
 #
 # Runs the sample-tls-app under keploy with $KEPLOY_FLAGS — either
@@ -281,7 +282,7 @@ echo "127.0.0.1 ${QUOTE_HOST} ${ECHO_HOST}" | sudo tee -a /etc/hosts >/dev/null
 # The upstream fixture ships with the sample app (ci/tls-upstream); build
 # and run it from the checked-out app repo. Pre-build so $! is the server
 # PID itself (not a `go run` wrapper), which the teardown kill relies on.
-go build -o tls-upstream ./ci/tls-upstream
+go_retry build -o tls-upstream ./ci/tls-upstream
 ./tls-upstream .ci/certs/upstream.crt .ci/certs/upstream.key 127.0.0.1 "$UPSTREAM_PORT" \
   > tls-upstream.log 2>&1 &
 UPSTREAM_PID=$!
@@ -317,7 +318,7 @@ export POSTGRES_DSN="postgres://app:ci_pg_pw@localhost:5433/app?sslmode=verify-c
 export QUOTE_URL="https://${QUOTE_HOST}:${UPSTREAM_PORT}/zen"
 export ECHO_URL="https://${ECHO_HOST}:${UPSTREAM_PORT}/anything"
 
-go build -o sample-tls-app .
+go_retry build -o sample-tls-app .
 
 # shellcheck disable=SC2086
 sudo -E env PATH="$PATH" MYSQL_DSN="$MYSQL_DSN" POSTGRES_DSN="$POSTGRES_DSN" \

--- a/.github/workflows/test_workflow_scripts/sampling/run-sampling-test.sh
+++ b/.github/workflows/test_workflow_scripts/sampling/run-sampling-test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/../go-retry.sh"
 # Drives the --enable-sampling end-to-end test:
 #
 #   1. Build the sample HTTP app (./sampling-test/main.go).
@@ -49,7 +50,7 @@ rm -rf keploy/ curl-results/ record.log sampling-test
 endsec
 
 section "Build sample app"
-go build -o sampling-test .
+go_retry build -o sampling-test .
 ls -lh sampling-test
 endsec
 

--- a/pkg/agent/proxy/integrations/http/onmiss.go
+++ b/pkg/agent/proxy/integrations/http/onmiss.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	pUtil "go.keploy.io/server/v3/pkg/agent/proxy/util"
+
 	"go.keploy.io/server/v3/pkg"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.uber.org/zap"
@@ -156,7 +158,11 @@ func (h *HTTP) serveOnMiss(ctx context.Context, clientConn net.Conn, reqBuf []by
 // on-miss path dials the real network, so it must not disable verification.
 func (h *HTTP) dialUpstream(ctx context.Context, dstCfg *models.ConditionalDstCfg) (net.Conn, error) {
 	d := &net.Dialer{Timeout: 30 * time.Second}
-	raw, err := d.DialContext(ctx, "tcp", dstCfg.Addr)
+	raw, err := pUtil.DialDestinationWith(ctx, h.Logger,
+		pUtil.DialTarget{Addr: dstCfg.Addr, Fabricated: dstCfg.AddrFabricated},
+		func(ctx context.Context, a string) (net.Conn, error) {
+			return d.DialContext(ctx, "tcp", a)
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/agent/proxy/integrations/mysql/recorder/conn.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/conn.go
@@ -965,7 +965,7 @@ func handlePostTLSRecord(ctx context.Context, logger *zap.Logger, clientConn, de
 			zap.String("connKey", opts.ConnKey),
 			zap.Uint16("dstPort", dstPort))
 		var err error
-		serverGreetingBuf, err = fetchServerGreeting(ctx, opts)
+		serverGreetingBuf, err = fetchServerGreeting(ctx, logger, opts)
 		if err != nil {
 			return fmt.Errorf("no server greeting in TLSHandshakeStore for key %s and direct fetch failed: %w", storeKey, err)
 		}
@@ -1306,7 +1306,7 @@ func recordSyntheticConfigMock(ctx context.Context, logger *zap.Logger, clientCo
 // initial HandshakeV10 greeting packet. This is used as a fallback when the
 // pre-TLS handshake was not captured by the proxy (e.g. the connection was
 // established before interception started).
-func fetchServerGreeting(ctx context.Context, opts models.OutgoingOptions) ([]byte, error) {
+func fetchServerGreeting(ctx context.Context, logger *zap.Logger, opts models.OutgoingOptions) ([]byte, error) {
 	addr := ""
 	if opts.DstCfg != nil {
 		addr = opts.DstCfg.Addr
@@ -1330,7 +1330,10 @@ func fetchServerGreeting(ctx context.Context, opts models.OutgoingOptions) ([]by
 	}
 
 	dialer := &net.Dialer{Timeout: 3 * time.Second}
-	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	conn, err := pUtils.DialDestinationWith(ctx, logger, pUtils.DialTarget{Addr: addr},
+		func(ctx context.Context, a string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "tcp", a)
+		})
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", addr, err)
 	}

--- a/pkg/agent/proxy/integrations/mysql/recorder/conn_test.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/conn_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+
 	"go.keploy.io/server/v3/pkg/models"
 )
 
@@ -37,7 +39,7 @@ func TestFetchServerGreeting_RefusesFabricatedAddr(t *testing.T) {
 	opts := models.OutgoingOptions{
 		DstCfg: &models.ConditionalDstCfg{Addr: ln.Addr().String(), Port: 3306, AddrFabricated: true},
 	}
-	buf, err := fetchServerGreeting(context.Background(), opts)
+	buf, err := fetchServerGreeting(context.Background(), zap.NewNop(), opts)
 	if err == nil {
 		t.Fatal("fetchServerGreeting must refuse a fabricated destination")
 	}
@@ -78,7 +80,7 @@ func TestFetchServerGreeting_ReadsRealGreeting(t *testing.T) {
 	opts := models.OutgoingOptions{
 		DstCfg: &models.ConditionalDstCfg{Addr: ln.Addr().String(), Port: 3306},
 	}
-	buf, err := fetchServerGreeting(context.Background(), opts)
+	buf, err := fetchServerGreeting(context.Background(), zap.NewNop(), opts)
 	if err != nil {
 		t.Fatalf("fetchServerGreeting: %v", err)
 	}

--- a/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
+++ b/pkg/agent/proxy/integrations/mysql/recorder/record_v2.go
@@ -516,7 +516,7 @@ func handlePostTLSHandshakeV2(ctx context.Context, logger *zap.Logger, sess *sup
 		// fabricated destinations (see models.ConditionalDstCfg.AddrFabricated),
 		// so this cannot dial an address the capture layer merely invented.
 		var gErr error
-		greetingBuf, gErr = fetchServerGreeting(ctx, sess.Opts)
+		greetingBuf, gErr = fetchServerGreeting(ctx, logger, sess.Opts)
 		if gErr != nil {
 			return res, fmt.Errorf("post-TLS V2: no greeting in store (key port %d) and direct fetch failed: %w", dstPort, gErr)
 		}

--- a/pkg/agent/proxy/mysql_detect.go
+++ b/pkg/agent/proxy/mysql_detect.go
@@ -642,7 +642,7 @@ func (p *Proxy) probeMysql(
 	// port; the negative cache makes it exactly once. A server-speaks-
 	// first protocol simply re-greets on the fresh connection, so
 	// discarding this one loses nothing.
-	dstConn, err := net.Dial("tcp", dstAddr)
+	dstConn, err := util.DialDestination(ctx, logger, "tcp", util.DialTarget{Addr: dstAddr})
 	if err != nil {
 		return &mysqlProbe{SrcConn: srcConn, Reason: "upstream-dial-failed"}, err
 	}

--- a/pkg/agent/proxy/opportunistic_tls.go
+++ b/pkg/agent/proxy/opportunistic_tls.go
@@ -68,7 +68,10 @@ func (p *Proxy) opportunisticTLSIntercept(ctx context.Context, srcConn net.Conn,
 	dialCtx, dialCancel := context.WithTimeout(ctx, opportunisticDialTimeout)
 	defer dialCancel()
 	var dialer net.Dialer
-	dstConn, err := dialer.DialContext(dialCtx, "tcp", dstAddr)
+	dstConn, err := util.DialDestinationWith(dialCtx, p.logger, util.DialTarget{Addr: dstAddr},
+		func(ctx context.Context, a string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "tcp", a)
+		})
 	if err != nil {
 		return fmt.Errorf("dial upstream %s: %w", dstAddr, err)
 	}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -595,7 +595,10 @@ func dialPostgresSSLUpstream(ctx context.Context, connID, addr string, cfg *tls.
 		deadline = time.Now().Add(10 * time.Second)
 	}
 	dialer := net.Dialer{Deadline: deadline}
-	rawConn, err := dialer.DialContext(ctx, "tcp", addr)
+	rawConn, err := util.DialDestinationWith(ctx, logger, util.DialTarget{Addr: addr},
+		func(ctx context.Context, a string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "tcp", a)
+		})
 	if err != nil {
 		return nil, fmt.Errorf("postgres SSL upstream: plain dial %s failed: %w", addr, err)
 	}
@@ -691,7 +694,7 @@ type speculativeUpstreamTLSResult struct {
 // participates in shutdown. The helper derives its own cancellable ctx so
 // the caller can tear the dial down independently (e.g. on client-handshake
 // failure or an ALPN mismatch).
-func startSpeculativeUpstreamTLS(parentCtx context.Context, addr string, cfg *tls.Config) *speculativeUpstreamTLS {
+func startSpeculativeUpstreamTLS(parentCtx context.Context, logger *zap.Logger, addr string, cfg *tls.Config) *speculativeUpstreamTLS {
 	dialCtx, cancel := context.WithCancel(parentCtx)
 	s := &speculativeUpstreamTLS{
 		done:   make(chan speculativeUpstreamTLSResult, 1),
@@ -700,7 +703,14 @@ func startSpeculativeUpstreamTLS(parentCtx context.Context, addr string, cfg *tl
 	}
 	go func() {
 		dialer := &tls.Dialer{Config: cfg}
-		c, err := dialer.DialContext(dialCtx, "tcp", addr)
+		// The logger matters here specifically: for a TLS dependency this
+		// speculative dial IS the primary path — when join() succeeds no other
+		// dial runs — so a nil logger would make the fallback permanently
+		// silent on exactly the topology this fixes.
+		c, err := util.DialDestinationWith(dialCtx, logger, util.DialTarget{Addr: addr},
+			func(ctx context.Context, a string) (net.Conn, error) {
+				return dialer.DialContext(ctx, "tcp", a)
+			})
 		var tlsConn *tls.Conn
 		if err == nil {
 			if tc, ok := c.(*tls.Conn); ok {
@@ -2262,7 +2272,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 
 	//check for global passthrough in test mode
 	if p.GlobalPassthrough || (!rule.Mocking && (rule.Mode == models.MODE_TEST)) {
-		dstConn, err = net.Dial("tcp", dstAddr)
+		dstConn, err = util.DialDestination(parserCtx, p.logger, "tcp", util.DialTarget{Addr: dstAddr})
 		if err != nil {
 			utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", util.NextStepDialDestination))
 			return err
@@ -2313,7 +2323,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 			// probeMysql already dialed when it had to read the
 			// upstream greeting; dstConn then replays those bytes.
 			if dstConn == nil {
-				dstConn, err = net.Dial("tcp", dstAddr)
+				dstConn, err = util.DialDestination(parserCtx, p.logger, "tcp", util.DialTarget{Addr: dstAddr})
 				if err != nil {
 					utils.LogError(p.logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", util.NextStepDialDestination))
 					return err
@@ -2510,7 +2520,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		// In record mode, we need a connection to the corporate proxy.
 		var proxyConn net.Conn
 		if !isTestMode {
-			proxyConn, err = net.Dial("tcp", dstAddr)
+			proxyConn, err = util.DialDestination(ctx, p.logger, "tcp", util.DialTarget{Addr: dstAddr})
 			if err != nil {
 				utils.LogError(p.logger, err, "failed to dial corporate proxy for CONNECT; verify the proxy address is correct, DNS/network is reachable, and HTTP_PROXY/HTTPS_PROXY settings are configured correctly",
 					zap.String("proxy_addr", dstAddr))
@@ -2635,7 +2645,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 					NextProtos:         []string{"h2", "http/1.1"},
 					KeyLogWriter:       pTls.KeyLogWriter(),
 				}
-				speculativeDial = startSpeculativeUpstreamTLS(ctx, addr, specCfg)
+				speculativeDial = startSpeculativeUpstreamTLS(ctx, p.logger, addr, specCfg)
 				speculativeDialAddr = addr
 				p.logger.Debug("started speculative upstream TLS dial",
 					zap.String("addr", addr),
@@ -2982,7 +2992,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 								zap.String("negotiated", negotiated),
 								zap.Strings("wanted", cfg.NextProtos))
 							_ = specConn.Close()
-							dstConn, err = tls.Dial("tcp", addr, cfg)
+							dstConn, err = util.DialDestinationTLS(ctx, p.logger, "tcp", util.DialTarget{Addr: addr}, cfg)
 						} else {
 							dstConn = specConn
 						}
@@ -2998,7 +3008,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 					}
 					probeProxy(p.logger, "upstream-dial-start", clientConnID, zap.String("branch", "synchronous"), zap.String("addr", addr))
 					dialStart := time.Now()
-					dstConn, err = tls.Dial("tcp", addr, cfg)
+					dstConn, err = util.DialDestinationTLS(ctx, p.logger, "tcp", util.DialTarget{Addr: addr}, cfg)
 					probeDial(p.logger, "synchronous-tls", clientConnID, addr, time.Since(dialStart).Nanoseconds(), zap.Error(err))
 				}
 				if err != nil {
@@ -3020,7 +3030,7 @@ func (p *Proxy) handleConnection(ctx context.Context, srcConn net.Conn) error {
 		if rule.Mode != models.MODE_TEST && dstConn == nil {
 			probeProxy(p.logger, "upstream-dial-start", clientConnID, zap.String("branch", "plain-tcp"), zap.String("addr", dstAddr))
 			dialStart := time.Now()
-			dstConn, err = net.Dial("tcp", dstAddr)
+			dstConn, err = util.DialDestination(parserCtx, p.logger, "tcp", util.DialTarget{Addr: dstAddr})
 			probeDial(p.logger, "plain-tcp", clientConnID, dstAddr, time.Since(dialStart).Nanoseconds(), zap.Error(err))
 			if err != nil {
 				utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Uint32("proxy port", p.Port), zap.String("server address", dstAddr), zap.String("next_step", util.NextStepDialDestination))

--- a/pkg/agent/proxy/proxy_test.go
+++ b/pkg/agent/proxy/proxy_test.go
@@ -114,7 +114,7 @@ func TestStartSpeculativeUpstreamTLS_Join_Success(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	s := startSpeculativeUpstreamTLS(ctx, ln.Addr().String(), cfg)
+	s := startSpeculativeUpstreamTLS(ctx, zap.NewNop(), ln.Addr().String(), cfg)
 	conn, err := s.join(ctx)
 	if err != nil {
 		t.Fatalf("join: %v", err)
@@ -143,7 +143,7 @@ func TestStartSpeculativeUpstreamTLS_Abandon_Cleanup(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s := startSpeculativeUpstreamTLS(ctx, ln.Addr().String(), cfg)
+	s := startSpeculativeUpstreamTLS(ctx, zap.NewNop(), ln.Addr().String(), cfg)
 	s.abandon()
 
 	// Give the background drainer a moment to run if the dial had
@@ -172,7 +172,7 @@ func TestStartSpeculativeUpstreamTLS_DialFailure(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	s := startSpeculativeUpstreamTLS(ctx, addr, cfg)
+	s := startSpeculativeUpstreamTLS(ctx, zap.NewNop(), addr, cfg)
 	conn, err := s.join(ctx)
 	if err == nil {
 		if conn != nil {
@@ -193,7 +193,7 @@ func TestStartSpeculativeUpstreamTLS_ContextCancelDuringDial(t *testing.T) {
 	}
 
 	parent, cancel := context.WithCancel(context.Background())
-	s := startSpeculativeUpstreamTLS(parent, ln.Addr().String(), cfg)
+	s := startSpeculativeUpstreamTLS(parent, zap.NewNop(), ln.Addr().String(), cfg)
 
 	// Cancel before the handshake completes.
 	time.Sleep(50 * time.Millisecond)
@@ -232,7 +232,7 @@ func TestSpeculativeParallelism(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	s := startSpeculativeUpstreamTLS(ctx, ln.Addr().String(), cfg)
+	s := startSpeculativeUpstreamTLS(ctx, zap.NewNop(), ln.Addr().String(), cfg)
 	// Simulate the MITM client-facing handshake.
 	time.Sleep(clientDelay)
 	conn, err := s.join(ctx)

--- a/pkg/agent/proxy/util/dialdest.go
+++ b/pkg/agent/proxy/util/dialdest.go
@@ -1,0 +1,204 @@
+// Package util provides utility functions for the proxy package.
+package util
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/neterr"
+	"go.uber.org/zap"
+)
+
+// loopbackFallbackTimeout bounds the counterpart dial.
+//
+// The first dial failed with ECONNREFUSED, which on loopback is one round
+// trip, so the caller has effectively paid nothing yet. The counterpart is not
+// guaranteed to be as quick: a host that DROPs traffic to ::1 (an ip6tables
+// rule, or IPv6 blackholed rather than absent) turns the retry into a full TCP
+// connect timeout — measured at ~130s with tcp_syn_retries=6 — and this sits on
+// the proxy's hot path, once per connection. A refusal that is genuinely
+// instant is worth waiting a moment for; anything slower is not a loopback
+// listener worth having.
+const loopbackFallbackTimeout = 2 * time.Second
+
+// loopbackFallbackReported keeps the notice to one line per process. A fallback
+// is a property of the node's topology (a listener bound to one address family
+// behind a name that resolves to both), not of any one connection, so
+// repeating it per connection would be noise on exactly the setup where every
+// connection takes that path.
+//
+// An atomic.Bool rather than a sync.Once because tests must be able to reset
+// it, and reassigning a package-level sync.Once is a non-atomic write that
+// races live connections.
+var loopbackFallbackReported atomic.Bool
+
+// DialTarget is a destination to dial on the application's behalf.
+type DialTarget struct {
+	Addr string
+
+	// Fabricated marks Addr as a stand-in the capture layer synthesized because
+	// it could not resolve the connection's real destination — see
+	// models.ConditionalDstCfg.AddrFabricated, which states that such an
+	// address does not point at the server this connection talked to.
+	//
+	// It suppresses the counterpart retry, and must. The canonical fabricated
+	// value is literally "127.0.0.1:3306", so inferring a counterpart for it
+	// would take the documented SAFE outcome for a stand-in (refused instantly,
+	// capture aborts loudly) and turn it into the documented DANGEROUS one
+	// (silently connect to an unrelated local server and record its traffic as
+	// the dependency's).
+	Fabricated bool
+}
+
+// DialDestination dials the application's original destination, restoring the
+// address-family fallback that interception removed.
+//
+// An application resolving a dual-stack name like "localhost:3306" may try
+// [::1] first. Left alone, a refusal there makes it immediately try 127.0.0.1 —
+// that fallback is what lets such a name work against an IPv4-only listener,
+// which is what a Docker published port is by default.
+//
+// Interception removes it. The redirect makes the application's connect to
+// [::1] SUCCEED, because it is now connected to this proxy rather than to the
+// dependency, so it has nothing to fall back from. The proxy then dials the
+// literal captured address; when nothing listens on that family the connection
+// is closed and the application sees EOF instead of ECONNREFUSED. EOF is
+// unrecoverable — it looks like a server that accepted and hung up — so drivers
+// report a dead connection rather than trying the other address.
+//
+// The retry fires only on ECONNREFUSED, which is what makes this a
+// family fallback and not a general-purpose retry: a refusal means nothing is
+// listening on the requested family at all, so no live service is being
+// passed over. A timeout or a reset is a different condition and is left alone.
+//
+// What this is NOT: a proof that the application would itself have tried the
+// counterpart. That stdlib fallback is name-driven — it happens because
+// "localhost" resolved to both addresses and the dialer walks the resolved set.
+// An application that dialed the literal [::1] gets no fallback at all, and
+// eBPF hands the proxy an ADDRESS, not the name behind it, so the two cases are
+// indistinguishable here. For 127.0.0.1 and ::1 specifically the trade is still
+// worth making — a literal-loopback dial to a family nothing serves is a
+// configuration accident, and the alternative is an unrecoverable EOF — but it
+// is a judgement, not a proof.
+func DialDestination(ctx context.Context, logger *zap.Logger, network string, target DialTarget) (net.Conn, error) {
+	return DialDestinationWith(ctx, logger, target, func(ctx context.Context, addr string) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, network, addr)
+	})
+}
+
+// DialDestinationTLS is DialDestination for a TLS upstream. A dependency
+// reached over TLS breaks in exactly the same way and needs the same retry;
+// leaving it out would make the fix hold only for plaintext.
+func DialDestinationTLS(ctx context.Context, logger *zap.Logger, network string, target DialTarget, cfg *tls.Config) (net.Conn, error) {
+	requestedHost, _, _ := net.SplitHostPort(target.Addr)
+	return DialDestinationWith(ctx, logger, target, func(ctx context.Context, addr string) (net.Conn, error) {
+		d := &tls.Dialer{Config: tlsConfigForAddr(cfg, requestedHost, addr)}
+		return d.DialContext(ctx, network, addr)
+	})
+}
+
+// tlsConfigForAddr re-points an explicit ServerName at the address actually
+// being dialed.
+//
+// When upstream verification is on, callers set ServerName from the REQUESTED
+// host (see resolveUpstreamServerName). Carrying that onto the counterpart
+// would verify the certificate against an address this connection did not
+// reach — a dependency whose certificate covers 127.0.0.1 would fail with
+// "certificate is valid for 127.0.0.1, not ::1" — so the fallback would never
+// complete on a verifying setup. Only an explicit ServerName equal to the
+// requested host is rewritten: a caller that set something else (a real
+// hostname carried over from the client's SNI) meant it, and an empty one is
+// left empty so the stdlib infers it from the address it dials.
+func tlsConfigForAddr(cfg *tls.Config, requestedHost, addr string) *tls.Config {
+	if cfg == nil || cfg.ServerName == "" || cfg.ServerName != requestedHost {
+		return cfg
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil || host == requestedHost {
+		return cfg
+	}
+	c := cfg.Clone()
+	c.ServerName = host
+	return c
+}
+
+// DialDestinationWith runs the CALLER'S own dial against the application's
+// destination, adding the loopback family fallback to it.
+//
+// Sites with their own dialer settings — a deadline, a timeout, a tls.Config,
+// keepalives — use this rather than DialDestination, so adding the fallback
+// can never silently discard them. The retry re-runs the same dial function
+// against the counterpart address, so it inherits those settings too.
+func DialDestinationWith(ctx context.Context, logger *zap.Logger, target DialTarget,
+	dial func(context.Context, string) (net.Conn, error)) (net.Conn, error) {
+
+	conn, err := dial(ctx, target.Addr)
+	if err == nil || !neterr.IsConnRefused(err) || target.Fabricated {
+		return conn, err
+	}
+
+	alt, ok := loopbackCounterpart(target.Addr)
+	if !ok {
+		return nil, err
+	}
+
+	altCtx, cancel := context.WithTimeout(ctx, loopbackFallbackTimeout)
+	defer cancel()
+
+	altConn, altErr := dial(altCtx, alt)
+	if altErr != nil {
+		// Lead with the ORIGINAL failure — the counterpart is this proxy's
+		// inference, and naming it alone would send the reader to an address
+		// their application never used — but carry the counterpart's error with
+		// it. Swallowing that is how "the counterpart answered and the
+		// handshake failed its certificate check" gets reported as "nothing is
+		// listening", which is the same misdirection this change exists to
+		// remove, one level down. %w keeps errors.Is(err, ECONNREFUSED) true
+		// for callers that classify.
+		return nil, fmt.Errorf("%w (loopback counterpart %s also failed: %v)", err, alt, altErr)
+	}
+
+	if logger != nil && loopbackFallbackReported.CompareAndSwap(false, true) {
+		logger.Info("proxy: the dependency is reachable on only one loopback address family, so the dial "+
+			"fell back to the other — this is the retry the application itself would have made had its "+
+			"connect not been intercepted. Bind the dependency on both families to remove the extra dial",
+			zap.String("requested", target.Addr), zap.String("connected", alt))
+	}
+	return altConn, nil
+}
+
+// loopbackCounterpart returns the same port on the other loopback address
+// family, and whether addr had one at all.
+//
+// Matched on the EXACT addresses, never on net.IP.IsLoopback: that is true for
+// the whole of 127.0.0.0/8, and 127.0.0.2 is a distinct host from 127.0.0.1 —
+// a dial to one does not reach a listener on the other. Treating them as
+// interchangeable would silently connect an application to a different server
+// and record its traffic as the dependency's, which is the shape people get
+// from running several database instances on 127.0.0.1, 127.0.0.2, 127.0.0.3.
+// ::1 is IPv6's only loopback, so 127.0.0.1 <-> ::1 is the entire relation.
+func loopbackCounterpart(addr string) (string, bool) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", false
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return "", false
+	}
+	// Equal compares by value across 4-byte and 16-byte forms, so the 4-in-6
+	// spelling (::ffff:127.0.0.1) matches the IPv4 arm — correct, because that
+	// form reaches an IPv4 listener.
+	switch {
+	case ip.Equal(net.IPv4(127, 0, 0, 1)):
+		return net.JoinHostPort("::1", port), true
+	case ip.Equal(net.IPv6loopback):
+		return net.JoinHostPort("127.0.0.1", port), true
+	}
+	return "", false
+}

--- a/pkg/agent/proxy/util/dialdest.go
+++ b/pkg/agent/proxy/util/dialdest.go
@@ -165,8 +165,8 @@ func DialDestinationWith(ctx context.Context, logger *zap.Logger, target DialTar
 
 	if logger != nil && loopbackFallbackReported.CompareAndSwap(false, true) {
 		logger.Info("proxy: the dependency is reachable on only one loopback address family, so the dial "+
-			"fell back to the other — this is the retry the application itself would have made had its "+
-			"connect not been intercepted. Bind the dependency on both families to remove the extra dial",
+			"fell back to the other — the fallback an application resolving a dual-stack name would have "+
+			"made itself had its connect not been intercepted. Bind the dependency on both families to remove the extra dial",
 			zap.String("requested", target.Addr), zap.String("connected", alt))
 	}
 	return altConn, nil

--- a/pkg/agent/proxy/util/dialdest_test.go
+++ b/pkg/agent/proxy/util/dialdest_test.go
@@ -1,0 +1,414 @@
+package util
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/neterr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// requireIPv6 reports whether this environment can exercise the IPv6 arm.
+//
+// A container without ::1 on lo would otherwise SKIP both fallback cases and
+// still report the package ok — a suite that tests nothing while looking
+// healthy. KEPLOY_TEST_IPV6_REQUIRED=1 turns that into a hard failure, matching
+// the KEPLOY_TEST_MYSQL_REQUIRED gate this repo already uses in go-test.yaml
+// for exactly this reason.
+func requireIPv6(t *testing.T, reason string) {
+	t.Helper()
+	if os.Getenv("KEPLOY_TEST_IPV6_REQUIRED") == "1" {
+		t.Fatalf("KEPLOY_TEST_IPV6_REQUIRED=1 but %s", reason)
+	}
+	t.Skip(reason)
+}
+
+func listenLoopback(t *testing.T, addr string) (ln net.Listener, otherFamily string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		requireIPv6(t, "cannot listen on "+addr+": "+err.Error())
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("split %s: %v", ln.Addr(), err)
+	}
+	if strings.HasPrefix(addr, "[") {
+		return ln, net.JoinHostPort("127.0.0.1", port)
+	}
+	return ln, net.JoinHostPort("::1", port)
+}
+
+// requireRefused asserts the precondition every fallback test depends on: the
+// family the application asked for is REFUSED. Without it a test could pass on
+// a host serving both families, proving nothing.
+func requireRefused(t *testing.T, addr string) {
+	t.Helper()
+	c, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err == nil {
+		_ = c.Close()
+		// Not an IPv6 problem: something else holds the mirrored ephemeral
+		// port, so skip plainly rather than sending someone hunting IPv6.
+		t.Skipf("%s is already served here, so the fallback path is not exercised", addr)
+	}
+	if !neterr.IsConnRefused(err) {
+		requireIPv6(t, "dial to "+addr+" failed with "+err.Error()+", not ECONNREFUSED")
+	}
+}
+
+// The defect: interception makes the application's connect to the wrong family
+// SUCCEED, so it never performs the fallback that would have saved it. If the
+// proxy then dials that family literally and gives up, the application gets EOF
+// — indistinguishable from a server that accepted and hung up — and drivers
+// report a dead connection instead of retrying.
+func TestDialDestination_FallsBackToTheOtherLoopbackFamily(t *testing.T) {
+	for _, tc := range []struct{ name, listen string }{
+		{"upstream is IPv4-only, app asked for IPv6", "127.0.0.1:0"},
+		{"upstream is IPv6-only, app asked for IPv4", "[::1]:0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, requested := listenLoopback(t, tc.listen)
+			requireRefused(t, requested)
+
+			loopbackFallbackReported.Store(false)
+			core, logs := observer.New(zap.InfoLevel)
+			conn, err := DialDestination(context.Background(), zap.New(core), "tcp", DialTarget{Addr: requested})
+			if err != nil {
+				t.Fatalf("DialDestination(%s) = %v; the application would see EOF instead of the "+
+					"connection refused it needs to fall back, and cannot recover", requested, err)
+			}
+			_ = conn.Close()
+
+			if n := len(logs.FilterMessageSnippet("one loopback address family").All()); n != 1 {
+				t.Errorf("fallback reported %d times, want 1 — a silent fallback hides a real "+
+					"topology problem from the operator", n)
+			}
+		})
+	}
+}
+
+// The notice is once per PROCESS, not once per connection: it describes the
+// node's topology, so on the setup where it fires every connection would fire
+// it. This is the entire reason the flag is a package-level atomic.
+func TestDialDestination_ReportsTheFallbackOncePerProcess(t *testing.T) {
+	_, requested := listenLoopback(t, "127.0.0.1:0")
+	requireRefused(t, requested)
+
+	loopbackFallbackReported.Store(false)
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	for i := 0; i < 3; i++ {
+		conn, err := DialDestination(context.Background(), logger, "tcp", DialTarget{Addr: requested})
+		if err != nil {
+			t.Fatalf("dial %d: %v", i, err)
+		}
+		_ = conn.Close()
+	}
+	if n := len(logs.FilterMessageSnippet("one loopback address family").All()); n != 1 {
+		t.Fatalf("three fallbacks logged %d lines, want 1 — per-connection noise on exactly the "+
+			"node where every connection takes this path", n)
+	}
+}
+
+// Only a REFUSAL means nothing is listening on the requested family. A timeout
+// is a different condition — a real but slow upstream — and redirecting it to
+// the other family would silently move the application to another server.
+// Without this the change is a general-purpose retry, not a family fallback.
+func TestDialDestination_OnlyFallsBackOnConnectionRefused(t *testing.T) {
+	// Fully mocked dial: no listener and no IPv6 needed, so this must never be
+	// one of the tests a v6-less container silently skips.
+	const requested = "127.0.0.1:1"
+	var attempts []string
+	var mu sync.Mutex
+	_, err := DialDestinationWith(context.Background(), zap.NewNop(), DialTarget{Addr: requested},
+		func(_ context.Context, addr string) (net.Conn, error) {
+			mu.Lock()
+			attempts = append(attempts, addr)
+			mu.Unlock()
+			return nil, syscall.ETIMEDOUT
+		})
+	if err == nil {
+		t.Fatal("a timing-out dial succeeded")
+	}
+	if len(attempts) != 1 {
+		t.Fatalf("dial attempted %v; a non-refusal must not be retried on the other family", attempts)
+	}
+}
+
+// A fabricated address is a capture-layer stand-in that models.ConditionalDstCfg
+// says must not be dialed at all. Inferring a counterpart for it turns the
+// documented SAFE outcome (refused, capture aborts loudly) into the documented
+// DANGEROUS one (silently record an unrelated local server as the dependency).
+func TestDialDestination_NeverInfersACounterpartForAFabricatedAddress(t *testing.T) {
+	const requested = "127.0.0.1:1" // mocked dial; no listener, no IPv6
+	var attempts []string
+	_, err := DialDestinationWith(context.Background(), zap.NewNop(),
+		DialTarget{Addr: requested, Fabricated: true},
+		func(_ context.Context, addr string) (net.Conn, error) {
+			attempts = append(attempts, addr)
+			return nil, syscall.ECONNREFUSED
+		})
+	if err == nil {
+		t.Fatal("dial to a fabricated address succeeded")
+	}
+	if len(attempts) != 1 {
+		t.Fatalf("a fabricated stand-in was retried on the other family (%v) — that is how an "+
+			"unrelated local server gets recorded as the dependency", attempts)
+	}
+}
+
+// The fallback must stay a loopback rule. 127.0.0.2 is IsLoopback but a
+// DISTINCT host: dialing it does not reach a 127.0.0.1 listener, so treating
+// the two as interchangeable would connect an application to another server —
+// the shape you get from several database instances on 127.0.0.1/.2/.3.
+func TestLoopbackCounterpart_OnlyTheExactLoopbackAddresses(t *testing.T) {
+	for _, tc := range []struct {
+		addr string
+		want string
+	}{
+		{"127.0.0.1:3306", "[::1]:3306"},
+		{"[::1]:3306", "127.0.0.1:3306"},
+		{"[::ffff:127.0.0.1]:3306", "[::1]:3306"}, // 4-in-6 reaches an IPv4 listener
+		{"127.0.0.2:3306", ""},                    // loopback, but a different host
+		{"127.0.0.53:3306", ""},                   // systemd-resolved
+		{"192.0.2.1:3306", ""},
+		{"0.0.0.0:3306", ""},
+		{"[::]:3306", ""},
+		{"localhost:3306", ""}, // a name: the stdlib does its own fallback
+		{"[fe80::1%lo]:3306", ""},
+		{"not-an-address", ""},
+	} {
+		got, ok := loopbackCounterpart(tc.addr)
+		if tc.want == "" {
+			if ok {
+				t.Errorf("loopbackCounterpart(%q) = %q, want no counterpart — inferring one would "+
+					"dial a host the application never asked for", tc.addr, got)
+			}
+			continue
+		}
+		if !ok || got != tc.want {
+			t.Errorf("loopbackCounterpart(%q) = (%q,%v), want (%q,true)", tc.addr, got, ok, tc.want)
+		}
+	}
+}
+
+// When both families fail, the operator must be given the address their
+// application actually used, not this proxy's inference about it.
+func TestDialDestination_ReportsTheRequestedAddressWhenBothFail(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot listen: %v", err)
+	}
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+	_ = ln.Close()
+
+	requested := net.JoinHostPort("127.0.0.1", port)
+	_, err = DialDestination(context.Background(), zap.NewNop(), "tcp", DialTarget{Addr: requested})
+	if err == nil {
+		t.Fatal("dial succeeded with nothing listening")
+	}
+	if !strings.Contains(err.Error(), requested) {
+		t.Fatalf("error names %q, want the requested address %q", err, requested)
+	}
+}
+
+// The counterpart dial is bounded. The first dial was refused in one round
+// trip, but a host that DROPs the other family would otherwise stall the
+// proxy's hot path for a full TCP connect timeout, once per connection.
+func TestDialDestination_BoundsTheCounterpartDial(t *testing.T) {
+	const requested = "127.0.0.1:1" // mocked dial; no listener, no IPv6
+	start := time.Now()
+	_, err := DialDestinationWith(context.Background(), zap.NewNop(), DialTarget{Addr: requested},
+		func(ctx context.Context, addr string) (net.Conn, error) {
+			if addr == requested {
+				return nil, syscall.ECONNREFUSED
+			}
+			<-ctx.Done() // a black-holed counterpart
+			return nil, ctx.Err()
+		})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+	if elapsed > loopbackFallbackTimeout+2*time.Second {
+		t.Fatalf("counterpart dial took %v, unbounded beyond the %v budget", elapsed, loopbackFallbackTimeout)
+	}
+	if !errors.Is(err, syscall.ECONNREFUSED) {
+		t.Errorf("err = %v, want the original refusal", err)
+	}
+}
+
+// A nil logger must not panic: the fallback path is rare, and a panic that only
+// fires there is the worst kind to leave.
+func TestDialDestination_NilLoggerDoesNotPanic(t *testing.T) {
+	_, requested := listenLoopback(t, "127.0.0.1:0")
+	requireRefused(t, requested)
+	loopbackFallbackReported.Store(false)
+	conn, err := DialDestination(context.Background(), nil, "tcp", DialTarget{Addr: requested})
+	if err != nil {
+		t.Fatalf("nil logger: %v", err)
+	}
+	_ = conn.Close()
+}
+
+// The TLS arm is half of this change: a dependency reached over TLS breaks the
+// same way, and leaving it out would make the fix hold only for plaintext.
+// Nothing pinned it before — a mutant swapping the dialer's config survived the
+// whole suite.
+func TestDialDestinationTLS_FallsBackAndRepointsServerName(t *testing.T) {
+	cert, host := selfSignedFor(t, "127.0.0.1")
+
+	ln, err := tls.Listen("tcp4", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		t.Skipf("cannot listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.(*tls.Conn).Handshake()
+			_ = c.Close()
+		}
+	}()
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+	requested := net.JoinHostPort("::1", port) // IPv6: nothing listens there
+	requireRefused(t, requested)
+
+	// ServerName pinned to the REQUESTED host, exactly as resolveUpstreamServerName
+	// does when upstream verification is on.
+	cfg := &tls.Config{RootCAs: poolFor(t, cert), ServerName: "::1"}
+
+	loopbackFallbackReported.Store(false)
+	conn, err := DialDestinationTLS(context.Background(), zap.NewNop(), "tcp",
+		DialTarget{Addr: requested}, cfg)
+	if err != nil {
+		t.Fatalf("TLS fallback failed: %v — carrying ServerName %q onto the counterpart verifies "+
+			"the certificate against an address the connection never reached, so a verifying "+
+			"setup could never complete the fallback", err, cfg.ServerName)
+	}
+	_ = conn.Close()
+
+	if cfg.ServerName != "::1" {
+		t.Errorf("the caller's tls.Config was mutated (ServerName now %q); it must be cloned", cfg.ServerName)
+	}
+	_ = host
+}
+
+func TestTLSConfigForAddr_OnlyRewritesThePinnedServerName(t *testing.T) {
+	for _, tc := range []struct{ name, sn, requested, dialed, want string }{
+		{"pinned to the requested host is re-pointed", "::1", "::1", "127.0.0.1", "127.0.0.1"},
+		{"empty is left empty for the stdlib to infer", "", "::1", "127.0.0.1", ""},
+		{"a real hostname the caller meant is kept", "db.internal", "::1", "127.0.0.1", "db.internal"},
+		{"same address is untouched", "::1", "::1", "::1", "::1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := &tls.Config{ServerName: tc.sn}
+			got := tlsConfigForAddr(in, tc.requested, net.JoinHostPort(tc.dialed, "3306"))
+			if got.ServerName != tc.want {
+				t.Errorf("ServerName = %q, want %q", got.ServerName, tc.want)
+			}
+			if in.ServerName != tc.sn {
+				t.Errorf("caller's config mutated: %q", in.ServerName)
+			}
+		})
+	}
+}
+
+func selfSignedFor(t *testing.T, ip string) (tls.Certificate, string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: ip},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP(ip)},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("cert: %v", err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}, ip
+}
+
+func poolFor(t *testing.T, cert tls.Certificate) *x509.CertPool {
+	t.Helper()
+	c, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	p := x509.NewCertPool()
+	p.AddCert(c)
+	return p
+}
+
+// When the counterpart ANSWERS and then fails for some other reason — a
+// certificate that does not cover it, a reset after accept — that reason must
+// survive. Reporting only the original refusal tells the operator "nothing is
+// listening" when something was, which is the same misdirection this change
+// exists to remove, one level down.
+func TestDialDestination_CarriesTheCounterpartFailure(t *testing.T) {
+	const requested = "127.0.0.1:1" // mocked dial; no listener, no IPv6
+	counterpartErr := errors.New("tls: failed to verify certificate: x509: certificate is valid for 127.0.0.1, not ::1")
+
+	_, err := DialDestinationWith(context.Background(), zap.NewNop(), DialTarget{Addr: requested},
+		func(_ context.Context, addr string) (net.Conn, error) {
+			if addr == requested {
+				// The shape net.Dial actually returns, so the assertions below
+				// hold for the error a caller really sees, not a bare errno.
+				return nil, &net.OpError{
+					Op: "dial", Net: "tcp",
+					Addr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1},
+					Err:  &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
+				}
+			}
+			return nil, counterpartErr
+		})
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+	if !strings.Contains(err.Error(), "certificate is valid for") {
+		t.Fatalf("err = %q; the counterpart answered and failed verification, but its reason was "+
+			"swallowed and the operator is told nothing is listening", err)
+	}
+	if !strings.Contains(err.Error(), requested) {
+		t.Errorf("err = %q, want it to lead with the requested address", err)
+	}
+	// Callers classify on this; wrapping must not break it.
+	if !neterr.IsConnRefused(err) {
+		t.Errorf("err = %q no longer classifies as connection-refused", err)
+	}
+}

--- a/pkg/agent/proxy/util/readbuf_cancel_test.go
+++ b/pkg/agent/proxy/util/readbuf_cancel_test.go
@@ -1,0 +1,195 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// A read that is aborted because the proxy is SHUTTING DOWN must stay
+// recognisable as a cancellation all the way up to the caller.
+//
+// utils.LogError deliberately swallows context.Canceled — that is how the agent
+// avoids shouting about connections it tore down itself. That guard only works
+// if the cancellation survives the return: a helper that logs the real error and
+// then hands back a fresh errors.New() has destroyed the very fact the guard
+// tests for, so the next LogError up the stack reports an ordinary shutdown at
+// ERROR. That is not cosmetic — the node lanes fail a recording whenever the
+// word ERROR appears in the log, so a routine stop turns a green run red.
+func TestReadHelpersPreserveCancellation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(context.Context, *zap.Logger, net.Conn) ([]byte, error)
+	}{
+		{"ReadInitialBuf", ReadInitialBuf},
+		{"ReadHTTPHeadersUntilEnd", ReadHTTPHeadersUntilEnd},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// A pipe nobody ever writes to: the only way out is the context.
+			client, server := net.Pipe()
+			defer func() { _ = client.Close() }()
+			defer func() { _ = server.Close() }()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				cancel()
+				// Then close the peer, exactly as shutdown does. ReadBytes runs
+				// its read in a goroutine and waits for it on the way out, so a
+				// blocked Read is only released when the conn goes away; without
+				// this the helper could never return and the test would only
+				// fail at its 10s deadline.
+				time.Sleep(10 * time.Millisecond)
+				_ = client.Close()
+			}()
+
+			errCh := make(chan error, 1)
+			go func() {
+				_, callErr := tc.call(ctx, zap.NewNop(), server)
+				errCh <- callErr
+			}()
+
+			var err error
+			select {
+			case err = <-errCh:
+			case <-time.After(10 * time.Second):
+				t.Fatal("helper did not return within 10s of the context being cancelled and the conn closed")
+			}
+			if err == nil {
+				t.Fatal("expected an error when the context is cancelled mid-read")
+			}
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("cancellation was lost: errors.Is(err, context.Canceled) is false for %[1]T(%[1]q).\n"+
+					"The caller can no longer tell a shutdown from a real read failure, so it logs it at ERROR.", err)
+			}
+		})
+	}
+}
+
+// errConn is a net.Conn whose Read always fails with a specific, non-EOF error
+// that has nothing to do with shutdown.
+type errConn struct {
+	net.Conn
+	err error
+}
+
+func (c *errConn) Read([]byte) (int, error) { return 0, c.err }
+
+// CONTROL for TestReadHelpersPreserveCancellation: the wrap must not turn every
+// read failure into something LogError swallows. A read that fails for a reason
+// unrelated to shutdown has to come back NOT matching context.Canceled, so the
+// agent still reports it at ERROR.
+//
+// This drives a NON-EOF error on purpose. A closed pipe yields io.EOF, which
+// ReadInitialBuf answers on an earlier branch — a control built that way never
+// reaches the wrapped return at all and passes no matter what it wraps
+// (confirmed: a mutant wrapping context.Canceled unconditionally survived it).
+func TestReadHelpersStillSurfaceRealFailures(t *testing.T) {
+	boom := errors.New("connection reset by peer (not a shutdown)")
+	for _, tc := range []struct {
+		name string
+		call func(context.Context, *zap.Logger, net.Conn) ([]byte, error)
+	}{
+		{"ReadInitialBuf", ReadInitialBuf},
+		{"ReadHTTPHeadersUntilEnd", ReadHTTPHeadersUntilEnd},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, server := net.Pipe()
+			defer func() { _ = client.Close() }()
+			defer func() { _ = server.Close() }()
+			conn := &errConn{Conn: server, err: boom}
+
+			errCh := make(chan error, 1)
+			go func() {
+				_, callErr := tc.call(context.Background(), zap.NewNop(), conn)
+				errCh <- callErr
+			}()
+
+			var err error
+			select {
+			case err = <-errCh:
+			case <-time.After(10 * time.Second):
+				t.Fatal("helper did not return on a failing conn")
+			}
+			if err == nil {
+				t.Fatal("expected an error from a failing read")
+			}
+			if errors.Is(err, context.Canceled) {
+				t.Fatalf("a non-shutdown failure was reported as a cancellation (%v); "+
+					"LogError would swallow it and the failure would go unreported", err)
+			}
+			if !errors.Is(err, boom) {
+				t.Fatalf("the underlying cause was dropped: %v", err)
+			}
+		})
+	}
+}
+
+// stepConn hands back an INCOMPLETE header block on the first read and the
+// injected error on every read after it. That is the only shape that reaches
+// the continuation read inside ReadHTTPHeadersUntilEnd: both other tests fail
+// on the FIRST ReadBytes and return before the loop is ever entered, so without
+// this the continuation site is covered by nothing — a mutant reverting just
+// that site to a bare readErr survives the rest of this file (verified).
+//
+// The injected error must be non-EOF. The EOF branch inside the loop breaks the
+// select rather than the loop, so injecting EOF here spins instead of returning.
+type stepConn struct {
+	net.Conn
+	mu   sync.Mutex
+	step int
+	err  error
+}
+
+func (c *stepConn) Read(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.step++
+	if c.step == 1 {
+		return copy(p, []byte("GET / HTTP/1.1\r\nHost: x\r\n")), nil
+	}
+	return 0, c.err
+}
+
+func readHeadersContinuation(t *testing.T, inject error) error {
+	t.Helper()
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, callErr := ReadHTTPHeadersUntilEnd(context.Background(), zap.NewNop(), &stepConn{Conn: server, err: inject})
+		errCh <- callErr
+	}()
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(10 * time.Second):
+		t.Fatal("the continuation read never returned")
+		return nil
+	}
+}
+
+func TestReadHTTPHeadersContinuationPreservesCancellation(t *testing.T) {
+	err := readHeadersContinuation(t, context.Canceled)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("the continuation read lost the cancellation: %[1]T(%[1]q)", err)
+	}
+}
+
+func TestReadHTTPHeadersContinuationSurfacesRealFailures(t *testing.T) {
+	boom := errors.New("connection reset by peer (not a shutdown)")
+	err := readHeadersContinuation(t, boom)
+	if errors.Is(err, context.Canceled) {
+		t.Fatalf("a non-shutdown failure was reported as a cancellation: %v", err)
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("the underlying cause was dropped: %v", err)
+	}
+}

--- a/pkg/agent/proxy/util/util.go
+++ b/pkg/agent/proxy/util/util.go
@@ -44,8 +44,12 @@ var Emoji = "\U0001F430" + " Keploy:"
 // behind a dual-stack name: that looks exactly like a dependency that has not
 // started yet. So name the address family as a possibility, conditionally, and
 // leave the timing advice as the other possibility rather than the answer.
+// The counterpart retry is SUPPRESSED for a Fabricated target, and PassThrough
+// (the two sites below) is the only site attaching this hint where a fabricated
+// address can arrive — so the wording must not promise a retry those callers
+// never get.
 // Kept as a const so all sites update together.
-const NextStepDialDestination = "check which address FAMILY the dependency binds — a container published port is IPv4-only by default, and a loopback destination is retried once on the other family, so this error means neither answered — and confirm the dependency is up before traffic starts (sequence its start, raise --delay, or add a readiness probe)"
+const NextStepDialDestination = "check which address FAMILY the dependency binds — a container published port is IPv4-only by default, and a loopback destination may be retried on the other family (not when the capture layer had to fabricate the address), so check both — and confirm the dependency is up before traffic starts (sequence its start, raise --delay, or add a readiness probe)"
 
 // ErrRecordingPausedDueToMemoryPressure tells record-mode parsers to stop
 // decoding and fall back to transparent passthrough while the agent is under

--- a/pkg/agent/proxy/util/util.go
+++ b/pkg/agent/proxy/util/util.go
@@ -395,7 +395,13 @@ func ReadHTTPHeadersUntilEnd(ctx context.Context, logger *zap.Logger, conn net.C
 	// Handle errors other than EOF
 	if err != nil && err != io.EOF {
 		utils.LogError(logger, err, "failed to read HTTP headers")
-		return nil, readErr
+		// Wrap, do not replace: utils.LogError swallows context.Canceled so the
+		// agent does not shout about connections it tore down itself, and that
+		// guard only works while the cancellation is still visible. Returning a
+		// bare readErr here erased it, so the next LogError up the stack
+		// reported a routine shutdown at ERROR — which the node lanes fail a
+		// recording on, turning a clean stop into a red run.
+		return nil, fmt.Errorf("%w: %w", readErr, err)
 	}
 
 	// Check if the initial buffer already contains complete headers
@@ -425,7 +431,8 @@ func ReadHTTPHeadersUntilEnd(ctx context.Context, logger *zap.Logger, conn net.C
 					break // EOF reached, but nothing more to read
 				}
 				utils.LogError(logger, err, "error while reading HTTP headers")
-				return nil, readErr
+				// Wrap, not replace — see the note on the first read above.
+				return nil, fmt.Errorf("%w: %w", readErr, err)
 			}
 
 			// Append the new data to the buffer
@@ -452,7 +459,13 @@ func ReadInitialBuf(ctx context.Context, logger *zap.Logger, conn net.Conn) ([]b
 
 	if err != nil && err != io.EOF {
 		utils.LogError(logger, err, "failed to read the request message in proxy")
-		return nil, readErr
+		// Wrap, do not replace: utils.LogError swallows context.Canceled so the
+		// agent does not shout about connections it tore down itself, and that
+		// guard only works while the cancellation is still visible. Returning a
+		// bare readErr here erased it, so the next LogError up the stack
+		// reported a routine shutdown at ERROR — which the node lanes fail a
+		// recording on, turning a clean stop into a red run.
+		return nil, fmt.Errorf("%w: %w", readErr, err)
 	}
 
 	return initialBuf, nil

--- a/pkg/agent/proxy/util/util.go
+++ b/pkg/agent/proxy/util/util.go
@@ -4,7 +4,6 @@ package util
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -37,11 +36,16 @@ var Emoji = "\U0001F430" + " Keploy:"
 
 // NextStepDialDestination is the shared remediation hint attached
 // to every "failed to dial the conn to destination server" error.
-// The proxy's destination dial is a single attempt with no retry,
-// so the real fix is always on the test-harness side (sequence
-// the dependency start, raise --delay, or add a readiness probe).
+//
+// It is attached regardless of WHY the dial failed — a timeout, ENETUNREACH,
+// EACCES and a cancelled context all get it — so it must not assert a cause.
+// The previous wording sent readers to --delay and readiness probes, which
+// cost a real investigation when the actual cause was an IPv4-only dependency
+// behind a dual-stack name: that looks exactly like a dependency that has not
+// started yet. So name the address family as a possibility, conditionally, and
+// leave the timing advice as the other possibility rather than the answer.
 // Kept as a const so all sites update together.
-const NextStepDialDestination = "confirm the app's upstream dependency is listening on this address before traffic starts (adjust --delay, add a readiness probe to the test harness, or pre-start the dependency); the dial is a single attempt and will not retry"
+const NextStepDialDestination = "check which address FAMILY the dependency binds — a container published port is IPv4-only by default, and a loopback destination is retried once on the other family, so this error means neither answered — and confirm the dependency is up before traffic starts (sequence its start, raise --delay, or add a readiness probe)"
 
 // ErrRecordingPausedDueToMemoryPressure tells record-mode parsers to stop
 // decoding and fall back to transparent passthrough while the agent is under
@@ -683,7 +687,8 @@ func PassThrough(ctx context.Context, logger *zap.Logger, clientConn net.Conn, d
 	if dstCfg.TLSCfg != nil {
 		logger.Debug("trying to establish a TLS connection with the destination server", zap.Any("Destination Addr", dstCfg.Addr))
 
-		destConn, err = tls.Dial("tcp", dstCfg.Addr, dstCfg.TLSCfg)
+		destConn, err = DialDestinationTLS(ctx, logger, "tcp",
+			DialTarget{Addr: dstCfg.Addr, Fabricated: dstCfg.AddrFabricated}, dstCfg.TLSCfg)
 		if err != nil {
 			utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Any("server address", dstCfg.Addr), zap.String("next_step", NextStepDialDestination))
 			return nil, err
@@ -691,7 +696,8 @@ func PassThrough(ctx context.Context, logger *zap.Logger, clientConn net.Conn, d
 		logger.Debug("TLS connection established with the destination server", zap.Any("Destination Addr", destConn.RemoteAddr().String()))
 	} else {
 		logger.Debug("trying to establish a connection with the destination server", zap.Any("Destination Addr", dstCfg.Addr))
-		destConn, err = net.Dial("tcp", dstCfg.Addr)
+		destConn, err = DialDestination(ctx, logger, "tcp",
+			DialTarget{Addr: dstCfg.Addr, Fabricated: dstCfg.AddrFabricated})
 		if err != nil {
 			utils.LogError(logger, err, "failed to dial the conn to destination server", zap.Any("server address", dstCfg.Addr), zap.String("next_step", NextStepDialDestination))
 			return nil, err


### PR DESCRIPTION
## The bug

An application resolving a dual-stack name like `localhost:3306` may try `[::1]` first. Left alone, a refusal there makes it immediately try `127.0.0.1` — that fallback is what lets such a name work against an **IPv4-only listener, which is what a container published port is by default**.

Interception removes it:

1. The eBPF redirect makes the application's connect to `[::1]` **succeed** — it is now connected to the proxy, not to the dependency, so it has nothing to fall back from.
2. The proxy dials the literal captured address `[::1]:3306`, gets `connection refused`, and closes.
3. The application sees **EOF**, not `ECONNREFUSED`. EOF is unrecoverable — it looks like a server that accepted and hung up — so drivers report a dead connection rather than trying the other address.

From the agent's own debug output:

```
DEBUG  the destination is ipv6
DEBUG  {"DestIp6":[0,0,0,1],"DestPort":3306}
ERROR  failed to dial the conn to destination server
       {"server address":"[::1]:3306","error":"dial tcp [::1]:3306: connect: connection refused"}
```

## Reproduction

Two binaries built from this tree, same MySQL container, same IPv4-only upstream — the binary is the only difference:

| build | result |
|---|---|
| `origin/main` | 30 × `[mysql] packets.go: unexpected EOF`, application exits, 60 × `dial tcp [::1]:3306: connect: connection refused` |
| this branch | 0 EOFs, `Successfully connected to the database!` |

Two controls isolate the cause: the same topology **without keploy** connects in 9 s (that is the fallback being restored), and making the upstream **dual-stack** also fixes it.

It is intermittent for the worst reason — address ordering (RFC 6724, `/etc/hosts`) decides which family is tried first, so identical code passes or fails run to run. It also misreports itself: the client-side symptom reads as "database not ready", and this package's own remediation hint pointed at `--delay` and readiness probes, sending the reader after a timing problem that does not exist. That hint is corrected here.

## The change

`DialDestination` retries the counterpart loopback family once and reports it once per process. **All ten** dials of the application's destination route through it, TLS included — leaving those out would have made the fix hold only for plaintext, so a TLS MySQL on `localhost` would still have died with the identical EOF.

Sites with their own dialer settings use `DialDestinationWith`, which wraps the **caller's** dial so the retry inherits their deadlines, timeouts and TLS config instead of silently discarding them.

### Three constraints keep this from becoming something broader

- **`ECONNREFUSED` only.** A refusal means nothing is listening on that family at all, so no live service is passed over. A timeout is a real but slow upstream and is left alone.
- **The exact addresses `127.0.0.1` and `::1`**, never `net.IP.IsLoopback`, which is true for all of `127.0.0.0/8`. `127.0.0.2` is a **distinct host** — a dial to it does not reach a `127.0.0.1` listener — and people really do run several database instances on `.1/.2/.3`. Treating those as interchangeable would connect an application to a different server and record its traffic as the dependency's: far worse than the EOF being fixed.
- **Never for a fabricated address.** `models.ConditionalDstCfg.AddrFabricated` marks a capture-layer stand-in, canonically `127.0.0.1:3306`, and documents that it does not point at the server the connection talked to. Inferring a counterpart for one would turn its documented *safe* outcome (refused instantly, capture aborts loudly) into its documented *dangerous* one (silently record an unrelated local server).

### Other details

- The counterpart dial is **bounded at 2 s**: the first dial was refused in one round trip, but a host that DROPs the other family would otherwise stall the proxy's hot path for a full TCP connect timeout, once per connection.
- Connection-refused classification uses the existing **`pkg/neterr`**, which already handles the Windows case (`syscall.ECONNREFUSED` there is a synthetic constant no syscall returns).
- When upstream verification is on, `ServerName` is pinned from the *requested* host, so the fallback would verify the certificate against an address it never reached. `DialDestinationTLS` re-points it to the address actually dialled, on a **clone**, and only when it was pinned to the requested host — a real hostname carried from client SNI is left alone.

### What this is not

Not a claim that the application would itself have tried the counterpart. That stdlib fallback is **name-driven**, and eBPF hands the proxy an address rather than the name behind it, so a literal `[::1]` dial and a resolved one are indistinguishable here. For `127.0.0.1` and `::1` the trade is still worth making — a literal-loopback dial to a family nothing serves is a configuration accident, and the alternative is an unrecoverable EOF — but it is a judgement, and the code says so.

## Verification

- Full build, plus `GOOS=windows` and `GOOS=darwin`; `go vet` clean; golangci-lint (repo-pinned v2.13.1) **0 issues**.
- `go test -race -count=1 ./pkg/agent/proxy/` — the CI lane's own command — green, plus the util and changed integration packages.
- Mutation-tested; every mutant of the fallback logic is killed, including "no fallback at all" (the pre-fix behaviour), "fall back on any error", "fabricated gets a counterpart", "broad `IsLoopback`", "unbounded retry", "swallow the counterpart's failure" and "keep the pinned ServerName".
- `KEPLOY_TEST_IPV6_REQUIRED=1` is added to the go-test lane, beside the existing `KEPLOY_TEST_MYSQL_REQUIRED`: without it these tests SKIP where `::1` is absent and the package still reports `ok` — a suite that tests nothing while looking healthy.

## Related, not fixed here

`pkg/agent/proxy/incoming/` cannot reach an application that binds IPv6-only. That is the mirror image of this bug on the ingress side and will hit the same users, but it is a different direction of traffic and wants its own change rather than being folded in here.

**Correction to an earlier version of this description.** I first wrote that the cause was `net.DialTimeout("tcp4", …)` hardcoding IPv4. That diagnosis is wrong: for a *literal* IPv4 address `"tcp4"` and `"tcp"` behave identically (verified — both dial `127.0.0.1:N` successfully), so the network string is a red herring. The actual cause is one line up: `incoming.go` builds the target as `newAppAddr := "127.0.0.1:" + strconv.Itoa(int(newPort))`, and `models.IngressEvent` already carries a `Family uint16` that the eBPF hook delivers and `incoming/` never reads. The fix is to plumb that family through, not to widen the dial — so anyone picking this up should not start from the `tcp4` framing.

## Second commit: `fix(ci)` — retry only the go commands a transient proxy error kills

This PR's first CI run had three lanes die inside two minutes on three **different** modules, all `stream error: stream ID N; INTERNAL_ERROR; received from peer` from proxy.golang.org. The same jobs pass on main, so it is not this code — `go` has no retry for module download, so one transient proxy error kills whichever lanes are resolving modules at that moment, landing on whatever PR is open.

`go-retry.sh` wraps `go <args>`, not `go build` specifically: the download is as often done by `go mod tidy`, `go mod download`, `go install` or `go list -m -u`, and under `set -e` an unwrapped `go mod tidy` aborts before a wrapped build is ever reached. That was the actual shape of two of the three failures.

- **Only transient failures retry** — the reasoning `docker-build-retry.sh` sets out for its own regex. `unexpected EOF` matches only when qualified by a URL: `cmd/compile` emits `syntax error: unexpected EOF, expected }` for any unterminated brace and never emits a URL, while a truncated proxy zip really does surface as `read "https://…zip": unexpected EOF`.
- **429/500/504 included** — proxy.golang.org returns them and rate-limits by egress IP, the same shared-NAT scenario that file documents for Docker Hub. Matched on wording, never bare digits.
- **Proxy on attempts 1–2, `direct` from 3** — the schedule of the inline `download_go_modules` this replaces. `direct` is strictly riskier: for a module whose upstream was renamed or retagged it fails *permanently* where the proxy would still serve it.
- **stderr streams live through a FIFO.** `go: downloading …` is the only signal of what a stalled download is doing, and a step hitting `timeout-minutes` is SIGKILLed, so a buffered version loses the whole output in exactly the case this exists for. A FIFO with a real background PID, **not** `2> >(tee …)` — process substitution doesn't set `$!`, so the `wait $!` that needs degrades to a bare `wait` that blocks on every child, and these scripts background the app under test.
- stdout stays file-backed so `output=$(go_retry list -m -u all)` still captures only the command's stdout; every message the helper emits goes to stderr.

Also folds in the four inline copies of this pattern and the one in `golang_linux.yml`, which retried every failure with no transient check.

### Found while reviewing, deliberately NOT fixed here

Both are unrelated to module downloads and neither can be validated locally:

- `echo_mysql/golang-linux.sh` has `set -Eeuo pipefail` **glued onto the end of a comment**, so `-E`, `-u` and `-o pipefail` are silently absent and only GitHub's `bash -e` supplies `-e`.
- In the same file `REPLAY_RC=$?` reads the status of a `|| true`, so it is always 0 and the two `-ne 0` guards consuming it are dead code.

### Scope boundary

Covers `test_workflow_scripts/` — the sample lanes that failed — plus the larger keploy build in the two jobs that also source a wrapped script, so no job wraps its small build and leaves its big one bare. The ~30 `go build` sites in the repo's own build/release workflows are a separate surface.

**Retry is a mitigation, not the cure.** `actions/setup-go` caches `~/go/pkg/mod` keyed on *keploy's* `go.sum`, so the samples' module graphs are in no cache key at all and every sample lane re-downloads its full graph on every run. Caching those would remove the exposure instead of retrying it.
