### PR TITLE
fix(mock): eleven mock record/replay defects that report a clean run

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -108,6 +108,16 @@ jobs:
       - name: Running Unit Tests
         run: go test ./...
 
+      # RegisterClient copies the pass-through port list into a fixed-size
+      # kernel array, and the only honest assertion is on what that array ends
+      # up holding -- which needs a real BPF map, which needs CAP_BPF. The step
+      # above runs unprivileged, so those tests skip there and the package
+      # still reports ok. A skip that reads as a pass is the exact defect this
+      # package guards against, so run them once with the capability and set
+      # KEPLOY_TEST_BPF_REQUIRED to make an unavailable map fatal instead.
+      - name: Running BPF-backed hook tests (privileged)
+        run: sudo -E env "PATH=$PATH" KEPLOY_TEST_BPF_REQUIRED=1 go test -count=1 ./pkg/agent/hooks/linux/
+
       # The mock-manager's concurrency guards — the tier-key/HitCount race and
       # the hitMu/treesMu lock order — are only meaningful under -race: without
       # it their tests pass on a build that races, so they read as coverage

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -252,6 +252,8 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		cmd.Flags().String("container-name", c.cfg.ContainerName, "Name of the application's docker container")
 		cmd.Flags().StringP("network-name", "n", c.cfg.NetworkName, "Name of the application's docker network")
 		cmd.Flags().UintSlice("pass-through-ports", config.GetByPassPorts(c.cfg), "Ports to bypass the proxy server and ignore the traffic")
+		// Read directly; see utils.NoViperBindAnnotation.
+		_ = cmd.Flags().SetAnnotation("pass-through-ports", utils.NoViperBindAnnotation, []string{"true"})
 		cmd.Flags().String("app-name", c.cfg.AppName, "Name of the user's application")
 		cmd.Flags().MarkDeprecated("app-id", "DEPRICATED : was used for unique name for the user's application")
 		cmd.Flags().Bool("generate-github-actions", c.cfg.GenerateGithubActions, "Generate Github Actions workflow file")
@@ -341,6 +343,8 @@ func (c *CmdConfigurator) AddFlags(cmd *cobra.Command) error {
 		_ = cmd.Flags().MarkHidden("mock-mode")
 		cmd.Flags().Uint64P("build-delay", "b", c.cfg.Agent.BuildDelay, "User provided time to wait docker container build")
 		cmd.Flags().UintSlice("pass-through-ports", c.cfg.Agent.PassThroughPorts, "Ports to bypass the proxy server and ignore the traffic")
+		// Read directly; see utils.NoViperBindAnnotation.
+		_ = cmd.Flags().SetAnnotation("pass-through-ports", utils.NoViperBindAnnotation, []string{"true"})
 		// --ca-java-home is the manual override for the app-aware Java
 		// truststore install. When the auto-detector in
 		// pkg/agent/proxy/tls/java_detect.go cannot resolve the app's JDK
@@ -2001,6 +2005,8 @@ func (c *CmdConfigurator) addMockFlags(cmd *cobra.Command) error {
 	cmd.Flags().Uint32("proxy-port", c.cfg.ProxyPort, "Port used by the Keploy proxy to intercept outgoing calls")
 	cmd.Flags().Uint32("dns-port", c.cfg.DNSPort, "Port used by the Keploy DNS server")
 	cmd.Flags().UintSlice("pass-through-ports", config.GetByPassPorts(c.cfg), "Destination ports to leave untouched (never mocked)")
+	// Read directly; see utils.NoViperBindAnnotation.
+	_ = cmd.Flags().SetAnnotation("pass-through-ports", utils.NoViperBindAnnotation, []string{"true"})
 	cmd.Flags().Bool("local", c.cfg.Mock.Local, "Use the local file-backed mock store even when a cloud registry is configured")
 
 	switch cmd.Name() {

--- a/cli/provider/cmd.go
+++ b/cli/provider/cmd.go
@@ -2015,6 +2015,7 @@ func (c *CmdConfigurator) addMockFlags(cmd *cobra.Command) error {
 	case "replay":
 		cmd.Flags().String("on-miss", c.cfg.Mock.OnMiss, "What to do when an outgoing call matches no recorded mock: fail | passthrough | record")
 		cmd.Flags().Bool("strict", c.cfg.Mock.Strict, "Exit non-zero if any recorded mock was missed (dependency contract drift)")
+		cmd.Flags().Bool("schema-noise-strict", c.cfg.Test.SchemaNoiseStrict, "Match outgoing request bodies by VALUE, not just by key presence: a mock is rejected when any request-body field outside test.globalNoise.requestbody drifted. Off by default; turning it on will surface request drift that was previously served the stale recorded response")
 		cmd.Flags().Uint64P("delay", "d", 0, "Seconds to wait for the runner to be ready before it starts issuing calls")
 	}
 	return nil
@@ -2129,6 +2130,17 @@ func (c *CmdConfigurator) validateMockFlags(ctx context.Context, cmd *cobra.Comm
 			return errors.New("failed to get the strict flag")
 		}
 		c.cfg.Mock.Strict = strict
+
+		// Changed()-guarded so an unset flag doesn't clobber
+		// test.schemaNoiseStrict from keploy.yml with the flag's default.
+		if cmd.Flags().Changed("schema-noise-strict") {
+			schemaNoiseStrict, err := cmd.Flags().GetBool("schema-noise-strict")
+			if err != nil {
+				utils.LogError(c.logger, err, "failed to get the schema-noise-strict flag")
+				return errors.New("failed to get the schema-noise-strict flag")
+			}
+			c.cfg.Test.SchemaNoiseStrict = schemaNoiseStrict
+		}
 
 		if cmd.Flags().Changed("delay") {
 			d, err := cmd.Flags().GetUint64("delay")

--- a/cli/provider/mock_strict_flag_test.go
+++ b/cli/provider/mock_strict_flag_test.go
@@ -1,0 +1,67 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"go.keploy.io/server/v3/config"
+	"go.uber.org/zap"
+)
+
+// AddFlags intercepts every subcommand whose parent is `mock` and returns
+// addMockFlags(cmd), so `keploy mock replay` never reaches AddUncommonFlags —
+// the only place --schema-noise-strict used to be registered. The flag was
+// therefore unavailable on the one command whose default matcher (bodyMatch,
+// top-level key presence only) is what makes a drifted request VALUE get served
+// the stale recorded response.
+//
+// Registration alone is not the feature — pkg/service/mock's
+// TestReplay_ForwardsSchemaNoiseStrictToTheProxy pins the other half, that the
+// resolved value actually reaches the proxy.
+func TestMockReplayRegistersSchemaNoiseStrict(t *testing.T) {
+	newMockSubcommand := func(verb string) *cobra.Command {
+		parent := &cobra.Command{Use: "mock"}
+		child := &cobra.Command{Use: verb}
+		parent.AddCommand(child)
+		return child
+	}
+
+	replay := newMockSubcommand("replay")
+	c := NewCmdConfigurator(zap.NewNop(), &config.Config{})
+	if err := c.AddFlags(replay); err != nil {
+		t.Fatalf("AddFlags(mock replay): %v", err)
+	}
+	if replay.Flags().Lookup("schema-noise-strict") == nil {
+		t.Fatalf("`keploy mock replay` does not register --schema-noise-strict; "+
+			"registered flags: %v", flagNames(replay))
+	}
+
+	// Parsing it must succeed and be observable through Changed(), which is what
+	// validateMockFlags keys off so an unset flag can't clobber the keploy.yml
+	// value with its compile-time default.
+	if err := replay.Flags().Parse([]string{"--schema-noise-strict"}); err != nil {
+		t.Fatalf("parse --schema-noise-strict: %v", err)
+	}
+	if !replay.Flags().Changed("schema-noise-strict") {
+		t.Fatal("--schema-noise-strict did not register as Changed after being passed")
+	}
+	if v, err := replay.Flags().GetBool("schema-noise-strict"); err != nil || !v {
+		t.Fatalf("GetBool(schema-noise-strict) = %v, %v; want true, nil", v, err)
+	}
+
+	// Recording cannot match anything, so the flag is replay-only by design.
+	record := newMockSubcommand("record")
+	if err := NewCmdConfigurator(zap.NewNop(), &config.Config{}).AddFlags(record); err != nil {
+		t.Fatalf("AddFlags(mock record): %v", err)
+	}
+	if record.Flags().Lookup("schema-noise-strict") != nil {
+		t.Fatal("`keploy mock record` should not register --schema-noise-strict; it is a match-time knob")
+	}
+}
+
+func flagNames(cmd *cobra.Command) []string {
+	var out []string
+	cmd.Flags().VisitAll(func(f *pflag.Flag) { out = append(out, f.Name) })
+	return out
+}

--- a/cli/provider/passthrough_ports_unmarshal_test.go
+++ b/cli/provider/passthrough_ports_unmarshal_test.go
@@ -1,0 +1,157 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/utils"
+	"go.uber.org/zap"
+)
+
+// --pass-through-ports aborted `keploy record` and `keploy mock record` with
+//
+//	'record.passThroughPorts[0]' expected a map or struct, got "uint"
+//
+// because BindFlagsToViper derives <cmd.Name()>.<camelCase(flag)>, and both
+// commands are named "record", so the []uint flag landed on
+// Record.PassThroughPorts ([]models.PassThroughRule). These tests assert on the
+// failure itself -- viper.Unmarshal -- rather than on key presence.
+func bindPassThroughPortsOnRecordCmd(t *testing.T, annotate bool) error {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	cmd := &cobra.Command{Use: "record"}
+	cmd.Flags().UintSlice("pass-through-ports", nil, "")
+	if annotate {
+		if err := cmd.Flags().SetAnnotation("pass-through-ports", utils.NoViperBindAnnotation, []string{"true"}); err != nil {
+			t.Fatalf("SetAnnotation: %v", err)
+		}
+	}
+	if err := cmd.Flags().Set("pass-through-ports", "3000"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := utils.BindFlagsToViper(zap.NewNop(), cmd, ""); err != nil {
+		t.Fatalf("BindFlagsToViper: %v", err)
+	}
+	return viper.Unmarshal(&config.Config{})
+}
+
+func TestPassThroughPorts_UnmarshalSucceedsWhenAnnotated(t *testing.T) {
+	if err := bindPassThroughPortsOnRecordCmd(t, true); err != nil {
+		t.Fatalf("viper.Unmarshal failed with the annotation in place: %v", err)
+	}
+}
+
+// Control: without the annotation the defect must still be reproducible, so the
+// test above cannot pass for the wrong reason.
+func TestPassThroughPorts_UnmarshalFailsWithoutAnnotation(t *testing.T) {
+	err := bindPassThroughPortsOnRecordCmd(t, false)
+	if err == nil {
+		t.Fatal("viper.Unmarshal unexpectedly succeeded without the annotation; " +
+			"the collision this test guards may have been fixed another way")
+	}
+	t.Logf("defect reproduced as expected: %v", err)
+}
+
+// COEXISTENCE: a user may legitimately have telemetry-egress rules under
+// record.passThroughPorts in keploy.yml AND pass --pass-through-ports on the
+// CLI. They are unrelated features that merely share a name, so both must
+// survive: the yaml rules must decode intact and the flag must stay readable.
+// On unpatched code the flag's viper bind overwrites the yaml value and the
+// unmarshal dies.
+func TestPassThroughPorts_YamlRulesCoexistWithFlag(t *testing.T) {
+	const keployYML = `
+record:
+  passThroughPorts:
+    - port: 4317
+      mode: skip
+    - port: 8126
+      mode: recordOne
+`
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetConfigType("yaml")
+	if err := viper.ReadConfig(strings.NewReader(keployYML)); err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+
+	cmd := &cobra.Command{Use: "record"}
+	cmd.Flags().UintSlice("pass-through-ports", nil, "")
+	if err := cmd.Flags().SetAnnotation("pass-through-ports", utils.NoViperBindAnnotation, []string{"true"}); err != nil {
+		t.Fatalf("SetAnnotation: %v", err)
+	}
+	if err := cmd.Flags().Set("pass-through-ports", "7001"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := utils.BindFlagsToViper(zap.NewNop(), cmd, ""); err != nil {
+		t.Fatalf("BindFlagsToViper: %v", err)
+	}
+
+	var cfg config.Config
+	if err := viper.Unmarshal(&cfg); err != nil {
+		t.Fatalf("viper.Unmarshal failed with yaml rules + CLI flag together: %v", err)
+	}
+
+	// The yaml telemetry rules must survive untouched.
+	if got := len(cfg.Record.PassThroughPorts); got != 2 {
+		t.Fatalf("Record.PassThroughPorts has %d rules, want 2 (the flag clobbered the yaml): %+v",
+			got, cfg.Record.PassThroughPorts)
+	}
+	if p := cfg.Record.PassThroughPorts[0]; p.Port != 4317 || p.Mode != models.PassThroughSkip {
+		t.Errorf("rule[0] = %+v, want {Port:4317 Mode:skip}", p)
+	}
+	if p := cfg.Record.PassThroughPorts[1]; p.Port != 8126 || p.Mode != models.PassThroughRecordOne {
+		t.Errorf("rule[1] = %+v, want {Port:8126 Mode:recordOne}", p)
+	}
+
+	// ...and the CLI flag must still be readable by its direct consumers.
+	ports, err := cmd.Flags().GetUintSlice("pass-through-ports")
+	if err != nil {
+		t.Fatalf("GetUintSlice: %v", err)
+	}
+	if len(ports) != 1 || ports[0] != 7001 {
+		t.Errorf("flag value = %v, want [7001]", ports)
+	}
+}
+
+// Control for the test above: WITHOUT the annotation the flag's viper bind
+// overwrites the yaml rules and the unmarshal dies, so the coexistence test
+// cannot pass for the wrong reason. This is the unpatched behaviour, kept in CI
+// permanently rather than demonstrated once by reverting the fix locally.
+func TestPassThroughPorts_YamlRulesClobberedWithoutAnnotation(t *testing.T) {
+	const keployYML = `
+record:
+  passThroughPorts:
+    - port: 4317
+      mode: skip
+`
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetConfigType("yaml")
+	if err := viper.ReadConfig(strings.NewReader(keployYML)); err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+
+	cmd := &cobra.Command{Use: "record"}
+	cmd.Flags().UintSlice("pass-through-ports", nil, "") // deliberately NOT annotated
+	if err := cmd.Flags().Set("pass-through-ports", "7001"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := utils.BindFlagsToViper(zap.NewNop(), cmd, ""); err != nil {
+		t.Fatalf("BindFlagsToViper: %v", err)
+	}
+
+	var cfg config.Config
+	if err := viper.Unmarshal(&cfg); err == nil {
+		t.Fatalf("unmarshal unexpectedly succeeded; yaml rules survived as %+v -- "+
+			"the collision this fix guards may have been resolved another way",
+			cfg.Record.PassThroughPorts)
+	} else {
+		t.Logf("unpatched behaviour reproduced: %v", err)
+	}
+}

--- a/docs/explanation/mock-lifetimes.md
+++ b/docs/explanation/mock-lifetimes.md
@@ -107,10 +107,14 @@ than being consumed per-test, since consumption would break the
 paired execute).
 
 Any other tag — including `mocks`, `HTTP_CLIENT`, or none at all —
-routes to per-test. Recorders pick human-readable labels for
-debugging; only the two reserved values above change routing.
+routes to per-test, unless one of the overrides below applies.
+Recorders pick human-readable labels for debugging; only the two
+reserved values above change routing on the tag switch itself.
 
-Two tag-independent overrides run BEFORE the tag switch:
+Three overrides can change that routing. The first two are genuinely
+tag-independent and run BEFORE the tag switch, so they win over any tag.
+The third runs AFTER it and is tag-*conditional* — it fires only when the
+tag is empty:
 
 1. **MySQL session-reusable commands** (`COM_PING`, `COM_STATISTICS`,
    `COM_DEBUG`, `COM_RESET_CONNECTION`) — promoted to session
@@ -118,7 +122,26 @@ Two tag-independent overrides run BEFORE the tag switch:
    are typically recorded at app startup (HikariCP pool warm-up, JDBC
    connection validation) BEFORE any test window begins, so leaving
    them per-test would have the strict-window pre-filter drop them.
-2. **Untagged legacy-kind fallback** — recordings captured before the
+2. **HTTP CORS preflights** — an `OPTIONS` request carrying an
+   `Access-Control-Request-Method` header is promoted to session
+   regardless of tag. The response is the endpoint's allow-policy, so it
+   is a property of the endpoint rather than of whichever test happened
+   to trigger it. Browsers also cache preflights, so they are recorded
+   far more sparsely than replay demands them: in one 6-test recording
+   only 3 tests owned any of the 8 captured preflights. Leaving them
+   per-test made them consumed on first match AND visible only inside
+   the owning test's pool, so every preflighted request in the other
+   tests failed with `net::ERR_FAILED`. A bare `OPTIONS` with no
+   `Access-Control-Request-Method` is NOT promoted — it may be a real
+   data endpoint, and promoting one would make it replay its first
+   recording forever. Caveat: this exempts the mock from consumption,
+   window filtering, and mapping-based scope narrowing, but NOT from
+   per-PID worker scoping — `scopedMockDb.keep` matches on mock name
+   only and never consults `Lifetime`. That path is taken whenever a
+   runner sends `ScopeReq.Pid > 0`, which is independent of how many
+   workers it uses: a single-worker runner that reports its PID hits
+   the same drop.
+3. **Untagged legacy-kind fallback** — recordings captured before the
    tag convention rely on a kind-based inference inside
    `DeriveLifetime` that routes untagged (empty-string `type`) HTTP /
    HTTP2 / MySQL / Redis / Postgres / PostgresV2 / Generic / DNS

--- a/docs/explanation/mock-lifetimes.md
+++ b/docs/explanation/mock-lifetimes.md
@@ -134,13 +134,16 @@ tag is empty:
    tests failed with `net::ERR_FAILED`. A bare `OPTIONS` with no
    `Access-Control-Request-Method` is NOT promoted — it may be a real
    data endpoint, and promoting one would make it replay its first
-   recording forever. Caveat: this exempts the mock from consumption,
-   window filtering, and mapping-based scope narrowing, but NOT from
-   per-PID worker scoping — `scopedMockDb.keep` matches on mock name
-   only and never consults `Lifetime`. That path is taken whenever a
-   runner sends `ScopeReq.Pid > 0`, which is independent of how many
-   workers it uses: a single-worker runner that reports its PID hits
-   the same drop.
+   recording forever. This exempts the mock from consumption, window
+   filtering, and mapping-based scope narrowing; per-PID worker scoping
+   is covered separately, because `scopedMockDb.keep` matches on mock
+   NAME and a preflight is attributed to whichever test's window it
+   happened to fire in. Both paths therefore consult one predicate,
+   `(*Mock).IsSharedAcrossTests`, which is narrower than
+   `Lifetime == LifetimeSession` on purpose: rules 2 and 3 below make
+   most of the pool session-lifetime for reasons unrelated to
+   reusability, and exempting those from worker scoping would make the
+   isolation a no-op.
 3. **Untagged legacy-kind fallback** — recordings captured before the
    tag convention rely on a kind-based inference inside
    `DeriveLifetime` that routes untagged (empty-string `type`) HTTP /

--- a/pkg/agent/hooks/linux/hooks.go
+++ b/pkg/agent/hooks/linux/hooks.go
@@ -623,22 +623,38 @@ func (h *Hooks) RegisterClient(ctx context.Context, opts config.Agent, rules []m
 		clientInfo.Mode = uint32(0)
 	}
 
-	ports := agent.GetPortToSendToKernel(ctx, rules)
-
-	if agent.ExtraPassThroughPortsHook != nil {
-		ports = append(ports, agent.ExtraPassThroughPortsHook()...)
-	}
-
 	// Mock mode: the wrapped test runner calls the agent's own HTTP server
 	// (the /agent/scope/* API) at localhost:<AgentPort>. That process is inside
 	// the intercepted PID tree, so without bypassing this port the runner's
 	// scope calls would be redirected into the proxy instead of reaching the
 	// agent. Kernel-level bypass the agent's own control port.
+	//
+	// It claims its slot FIRST, ahead of the user's ports, because the array
+	// below is fixed at len(clientInfo.PassThroughPorts) and truncates. Appended
+	// last, a user who passes that many --pass-through-ports would drop the very
+	// bypass the runner needs, and mock mode would fail outright rather than
+	// merely over-record.
+	var ports []uint
 	if opts.MockMode && opts.AgentPort != 0 {
 		ports = append(ports, uint(opts.AgentPort))
 	}
 
-	for i := 0; i < 10; i++ {
+	ports = append(ports, agent.GetPortToSendToKernel(ctx, rules)...)
+
+	if agent.ExtraPassThroughPortsHook != nil {
+		ports = append(ports, agent.ExtraPassThroughPortsHook()...)
+	}
+
+	// The kernel array is fixed-size and the copy below truncates, so say so
+	// rather than ignoring part of an explicit flag in silence.
+	if len(ports) > len(clientInfo.PassThroughPorts) {
+		h.logger.Warn("more pass-through ports than the kernel bypass list can hold; the extra ports will still be intercepted and recorded",
+			zap.Int("given", len(ports)),
+			zap.Int("capacity", len(clientInfo.PassThroughPorts)),
+			zap.Any("dropped", ports[len(clientInfo.PassThroughPorts):]))
+	}
+
+	for i := range clientInfo.PassThroughPorts {
 		if len(ports) <= i {
 			clientInfo.PassThroughPorts[i] = -1
 			continue

--- a/pkg/agent/hooks/linux/register_client_ports_test.go
+++ b/pkg/agent/hooks/linux/register_client_ports_test.go
@@ -1,0 +1,198 @@
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/agent/hooks/structs"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// The kernel side of the bypass list is a fixed-size array; RegisterClient
+// copies at most this many ports into it and drops the rest.
+const kernelPortCapacity = len(structs.ClientInfo{}.PassThroughPorts)
+
+const testAgentPort = 16790
+
+// newRegisterClientHooks builds a Hooks wired to a REAL bpf hash map standing in
+// for client_info, so RegisterClient runs unmodified all the way through
+// SendClientInfo and we can read back exactly what the kernel would see.
+func newRegisterClientHooks(t *testing.T) (*Hooks, *ebpf.Map, *observer.ObservedLogs) {
+	t.Helper()
+	// Asserting on the array the kernel actually receives needs a real BPF map,
+	// which needs CAP_BPF. Without it these tests can only skip -- and a skip
+	// here reports the package green while the thing under test never ran,
+	// which is precisely the failure this commit is about. So a lane that DOES
+	// have the capability sets KEPLOY_TEST_BPF_REQUIRED and turns the skip
+	// fatal. Keyed on its own var rather than on CI, for the same reason
+	// KEPLOY_TEST_MYSQL_REQUIRED is: CI is set on every fork and every lane,
+	// including ones that were never offered the capability.
+	required := os.Getenv("KEPLOY_TEST_BPF_REQUIRED") != ""
+	unavailable := func(err error) {
+		t.Helper()
+		if required {
+			t.Fatalf("KEPLOY_TEST_BPF_REQUIRED is set but this lane cannot create a bpf map: %v", err)
+		}
+		t.Skipf("no CAP_BPF, cannot assert on the real kernel array: %v", err)
+	}
+
+	if err := rlimit.RemoveMemlock(); err != nil {
+		unavailable(err)
+	}
+	m, err := ebpf.NewMap(&ebpf.MapSpec{
+		Name:       "client_info_t",
+		Type:       ebpf.Hash,
+		KeySize:    8,
+		ValueSize:  uint32(binary.Size(structs.ClientInfo{})),
+		MaxEntries: 1,
+	})
+	if err != nil {
+		unavailable(err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	return &Hooks{
+		logger:                zap.New(core),
+		objectsMutex:          sync.RWMutex{},
+		m:                     sync.Mutex{},
+		clientRegistrationMap: m,
+	}, m, logs
+}
+
+func portRules(ports ...uint) []models.BypassRule {
+	rules := make([]models.BypassRule, 0, len(ports))
+	for _, p := range ports {
+		rules = append(rules, models.BypassRule{Port: p})
+	}
+	return rules
+}
+
+func readBack(t *testing.T, m *ebpf.Map) structs.ClientInfo {
+	t.Helper()
+	var got structs.ClientInfo
+	if err := m.Lookup(uint64(0), &got); err != nil {
+		t.Fatalf("lookup client_info: %v", err)
+	}
+	return got
+}
+
+func hasPort(a [10]int32, p int32) bool {
+	for _, v := range a {
+		if v == p {
+			return true
+		}
+	}
+	return false
+}
+
+// THE BUG. The agent's own control port is the one bypass the wrapped test
+// runner itself depends on: in mock mode the runner calls /agent/scope/* at
+// localhost:<AgentPort>, and without a kernel bypass that call is redirected
+// into the proxy instead of reaching the agent. Appended LAST, it is the first
+// thing the fixed-size array truncates away when a user supplies a full set of
+// --pass-through-ports.
+func TestRegisterClient_AgentPortSurvivesAFullUserPortList(t *testing.T) {
+	h, m, _ := newRegisterClientHooks(t)
+
+	userPorts := make([]uint, 0, kernelPortCapacity)
+	for i := 0; i < kernelPortCapacity; i++ {
+		userPorts = append(userPorts, uint(7001+i))
+	}
+
+	opts := config.Agent{SetupOptions: models.SetupOptions{
+		Mode: models.MODE_RECORD, MockMode: true, AgentPort: testAgentPort,
+	}}
+	if err := h.RegisterClient(context.Background(), opts, portRules(userPorts...)); err != nil {
+		t.Fatalf("RegisterClient: %v", err)
+	}
+
+	got := readBack(t, m)
+	if !hasPort(got.PassThroughPorts, testAgentPort) {
+		t.Fatalf("agent control port %d was truncated out of the kernel bypass list; mock mode would fail outright.\n  got: %v", testAgentPort, got.PassThroughPorts)
+	}
+	if got.PassThroughPorts[0] != testAgentPort {
+		t.Fatalf("agent control port should claim slot 0 ahead of user ports, got slot value %d\n  got: %v", got.PassThroughPorts[0], got.PassThroughPorts)
+	}
+}
+
+// Truncation itself is legitimate; silently dropping part of an explicit flag
+// is not.
+func TestRegisterClient_WarnsWhenUserPortsAreTruncated(t *testing.T) {
+	h, _, logs := newRegisterClientHooks(t)
+
+	userPorts := make([]uint, 0, kernelPortCapacity+3)
+	for i := 0; i < kernelPortCapacity+3; i++ {
+		userPorts = append(userPorts, uint(7001+i))
+	}
+
+	opts := config.Agent{SetupOptions: models.SetupOptions{
+		Mode: models.MODE_RECORD, MockMode: true, AgentPort: testAgentPort,
+	}}
+	if err := h.RegisterClient(context.Background(), opts, portRules(userPorts...)); err != nil {
+		t.Fatalf("RegisterClient: %v", err)
+	}
+
+	if logs.FilterMessageSnippet("kernel bypass list can hold").Len() == 0 {
+		t.Fatalf("no warning logged for %d ports into a %d-slot array; the drop is silent.\n  logs: %v",
+			len(userPorts)+1, kernelPortCapacity, logs.All())
+	}
+}
+
+// CONTROL: under the capacity everything fits, so both orderings would pass.
+// This one must be green before AND after the fix, or the tests above are
+// measuring the wrong thing.
+func TestRegisterClient_ShortListKeepsEveryPort(t *testing.T) {
+	h, m, _ := newRegisterClientHooks(t)
+
+	opts := config.Agent{SetupOptions: models.SetupOptions{
+		Mode: models.MODE_RECORD, MockMode: true, AgentPort: testAgentPort,
+	}}
+	if err := h.RegisterClient(context.Background(), opts, portRules(7001, 7002, 7003)); err != nil {
+		t.Fatalf("RegisterClient: %v", err)
+	}
+
+	got := readBack(t, m)
+	for _, want := range []int32{testAgentPort, 7001, 7002, 7003} {
+		if !hasPort(got.PassThroughPorts, want) {
+			t.Fatalf("port %d missing: %v", want, got.PassThroughPorts)
+		}
+	}
+	for i := 4; i < kernelPortCapacity; i++ {
+		if got.PassThroughPorts[i] != -1 {
+			t.Fatalf("unused slot %d should be -1, got %d: %v", i, got.PassThroughPorts[i], got.PassThroughPorts)
+		}
+	}
+}
+
+// CONTROL: outside mock mode there is no agent control port to reserve, and the
+// user's ports must still start at slot 0.
+func TestRegisterClient_NonMockModeReservesNothing(t *testing.T) {
+	h, m, _ := newRegisterClientHooks(t)
+
+	opts := config.Agent{SetupOptions: models.SetupOptions{
+		Mode: models.MODE_RECORD, MockMode: false, AgentPort: testAgentPort,
+	}}
+	if err := h.RegisterClient(context.Background(), opts, portRules(7001, 7002)); err != nil {
+		t.Fatalf("RegisterClient: %v", err)
+	}
+
+	got := readBack(t, m)
+	if hasPort(got.PassThroughPorts, testAgentPort) {
+		t.Fatalf("agent port must not be bypassed outside mock mode: %v", got.PassThroughPorts)
+	}
+	if got.PassThroughPorts[0] != 7001 || got.PassThroughPorts[1] != 7002 {
+		t.Fatalf("user ports should start at slot 0: %v", got.PassThroughPorts)
+	}
+}

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -437,11 +437,21 @@ func (h *HTTP) buildMockResponseBytes(stub *models.Mock) ([]byte, error) {
 	if stub != nil {
 		name = stub.Name
 	}
+	// Hydrate BEFORE the nil-response guard, never after. A recorded body of at
+	// least responseSpillMinBytes is parked on the agent's per-test disk store
+	// with Spec.HTTPResp deliberately set to nil (proxy.DiskMocks.Add), and
+	// this call is the only thing that restores it — guarding first rejected
+	// every spilled mock as "no response to serialize". HydrateResponse is a
+	// no-op when the mock never spilled and self-clears after a successful
+	// load, so it is safe to call on every serve. It cannot rescue a response
+	// that is nil for any other reason, which is why the guard below stays.
+	if stub != nil {
+		if err := stub.HydrateResponse(); err != nil {
+			return nil, err
+		}
+	}
 	if stub == nil || stub.Spec.HTTPResp == nil {
 		return nil, fmt.Errorf("http: mock %q has no response to serialize", name)
-	}
-	if err := stub.HydrateResponse(); err != nil {
-		return nil, err
 	}
 	protoMajor, protoMinor := 1, 1
 	if stub.Spec.HTTPReq != nil {

--- a/pkg/agent/proxy/integrations/http/decode.go
+++ b/pkg/agent/proxy/integrations/http/decode.go
@@ -437,20 +437,25 @@ func (h *HTTP) buildMockResponseBytes(stub *models.Mock) ([]byte, error) {
 	if stub != nil {
 		name = stub.Name
 	}
-	// Hydrate BEFORE the nil-response guard, never after. A recorded body of at
-	// least responseSpillMinBytes is parked on the agent's per-test disk store
-	// with Spec.HTTPResp deliberately set to nil (proxy.DiskMocks.Add), and
-	// this call is the only thing that restores it — guarding first rejected
-	// every spilled mock as "no response to serialize". HydrateResponse is a
-	// no-op when the mock never spilled and self-clears after a successful
-	// load, so it is safe to call on every serve. It cannot rescue a response
-	// that is nil for any other reason, which is why the guard below stays.
+	// Resolve the response BEFORE the nil guard, never after. A recorded body
+	// of at least responseSpillMinBytes is parked on the agent's per-test disk
+	// store with Spec.HTTPResp deliberately set to nil (proxy.DiskMocks.Add),
+	// and this is the only thing that fetches it back — guarding first rejected
+	// every spilled mock as "no response to serialize".
+	//
+	// The resolved response is held LOCALLY and never written back onto the
+	// mock. stub is a pooled pointer shared with every other connection
+	// goroutine, and updateMock dereferences it whole by value while this runs;
+	// see (*models.Mock).HydratedHTTPResp. A response that is nil for any other
+	// reason still resolves to nil, which is why the guard below stays.
+	var resp *models.HTTPResp
 	if stub != nil {
-		if err := stub.HydrateResponse(); err != nil {
-			return nil, err
+		var herr error
+		if resp, herr = stub.HydratedHTTPResp(); herr != nil {
+			return nil, herr
 		}
 	}
-	if stub == nil || stub.Spec.HTTPResp == nil {
+	if resp == nil {
 		return nil, fmt.Errorf("http: mock %q has no response to serialize", name)
 	}
 	protoMajor, protoMinor := 1, 1
@@ -458,9 +463,9 @@ func (h *HTTP) buildMockResponseBytes(stub *models.Mock) ([]byte, error) {
 		protoMajor, protoMinor = stub.Spec.HTTPReq.ProtoMajor, stub.Spec.HTTPReq.ProtoMinor
 	}
 	statusLine := fmt.Sprintf("HTTP/%d.%d %d %s\r\n", protoMajor, protoMinor,
-		stub.Spec.HTTPResp.StatusCode, http.StatusText(stub.Spec.HTTPResp.StatusCode))
-	body := stub.Spec.HTTPResp.Body
-	header := pkg.ToHTTPHeader(stub.Spec.HTTPResp.Header)
+		resp.StatusCode, http.StatusText(resp.StatusCode))
+	body := resp.Body
+	header := pkg.ToHTTPHeader(resp.Header)
 	var respBody string
 	if encoding, ok := header["Content-Encoding"]; ok && len(encoding) > 0 {
 		compressed, err := pkg.Compress(h.Logger, encoding[0], []byte(body))

--- a/pkg/agent/proxy/integrations/http/export_test.go
+++ b/pkg/agent/proxy/integrations/http/export_test.go
@@ -1,0 +1,16 @@
+package http
+
+import "go.keploy.io/server/v3/pkg/models"
+
+// BuildMockResponseBytesForTest exposes buildMockResponseBytes to the EXTERNAL
+// http_test package. That package exists only because the spilled-response
+// regression has to drive the real proxy.DiskMocks store, and pkg/agent/proxy
+// blank-imports this package (parsers.go), so an internal `package http` test
+// importing it would be an import cycle.
+func (h *HTTP) BuildMockResponseBytesForTest(stub *models.Mock) ([]byte, error) {
+	return h.buildMockResponseBytes(stub)
+}
+
+// NewForTest builds a logger-only HTTP integration, mirroring newHTTP() in
+// match_test.go, for the external test package.
+func NewForTest() *HTTP { return newHTTP() }

--- a/pkg/agent/proxy/integrations/http/export_test.go
+++ b/pkg/agent/proxy/integrations/http/export_test.go
@@ -1,6 +1,11 @@
 package http
 
-import "go.keploy.io/server/v3/pkg/models"
+import (
+	"net/url"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	"go.keploy.io/server/v3/pkg/models"
+)
 
 // BuildMockResponseBytesForTest exposes buildMockResponseBytes to the EXTERNAL
 // http_test package. That package exists only because the spilled-response
@@ -14,3 +19,11 @@ func (h *HTTP) BuildMockResponseBytesForTest(stub *models.Mock) ([]byte, error) 
 // NewForTest builds a logger-only HTTP integration, mirroring newHTTP() in
 // match_test.go, for the external test package.
 func NewForTest() *HTTP { return newHTTP() }
+
+// ServeOnePassThroughMockForTest exposes serveOnePassThroughMock to the
+// EXTERNAL http_test package, for the same import-cycle reason as above. The
+// req struct is unexported, so the method/URL are taken as plain values and
+// assembled here.
+func (h *HTTP) ServeOnePassThroughMockForTest(mockDb integrations.MockMemDb, method string, u *url.URL, host string, port uint32, queryKeys []string) []byte {
+	return h.serveOnePassThroughMock(mockDb, &req{method: method, url: u}, host, port, queryKeys)
+}

--- a/pkg/agent/proxy/integrations/http/match.go
+++ b/pkg/agent/proxy/integrations/http/match.go
@@ -454,6 +454,47 @@ func (h *HTTP) HeadersContainKeys(expected map[string]string, actual http.Header
 			return false
 		}
 	}
+
+	// Origin is the one header that must agree in BOTH directions.
+	//
+	// Everything above is a subset test — the mock's keys must be present in the
+	// request, extra request headers are fine — so a recording made with FEWER
+	// headers is MORE permissive. For every other header that is harmless. For
+	// Origin it is not, because Origin is what makes the server attach
+	// Access-Control-Allow-Origin to the RESPONSE. Two recordings of one endpoint
+	// therefore are not interchangeable:
+	//
+	//   browser call   Origin: http://app  ->  response HAS Access-Control-Allow-Origin
+	//   server-side    (no Origin)         ->  response has NO CORS headers at all
+	//
+	// Without this check the server-side recording (a strict subset of the
+	// browser one) matches a browser request, and the browser discards the
+	// CORS-less response with net::ERR_FAILED. keploy sees a SUCCESSFUL match and
+	// reports missed: 0, so no miss-based gate can catch it. Observed on a real
+	// Playwright suite: GET /cluster/proxy-origins and GET /auth/check are issued
+	// both by the browser and by the app's own server-side renderer; the
+	// server-side copies were served to browser calls, the app read that as
+	// logged-out, and 9 tests failed with the mock set reported clean throughout.
+	//
+	// Requiring agreement keeps each shape serving only its own caller. Users who
+	// genuinely want them interchangeable can put Origin in header noise, which
+	// shouldIgnore honours above and below.
+	if !shouldIgnore("Origin") {
+		mockHasOrigin := false
+		for k := range expected {
+			if strings.EqualFold(k, "Origin") {
+				mockHasOrigin = true
+				break
+			}
+		}
+		_, reqHasOrigin := actualKeys["origin"]
+		if mockHasOrigin != reqHasOrigin {
+			h.Logger.Debug("origin presence differs between mock and request",
+				zap.Bool("mock_has_origin", mockHasOrigin),
+				zap.Bool("request_has_origin", reqHasOrigin))
+			return false
+		}
+	}
 	return true
 }
 

--- a/pkg/agent/proxy/integrations/http/match_origin_test.go
+++ b/pkg/agent/proxy/integrations/http/match_origin_test.go
@@ -1,0 +1,135 @@
+package http
+
+import (
+	"net/http"
+	"testing"
+)
+
+// A browser XHR and the app's own server-side renderer call the SAME endpoint,
+// and the two recordings are NOT interchangeable — Origin on the request is what
+// makes the server attach Access-Control-Allow-Origin to the response.
+//
+// Header sets below are the real ones from an enterprise-ui recording of
+// GET /cluster/proxy-origins: 48 copies carried the 15 browser headers and got a
+// CORS response, 45 carried only these 8 and got no CORS headers at all.
+//
+// HeadersContainKeys is a subset test, so the 8-key server-side recording is
+// strictly MORE permissive than the 15-key browser one and used to match a
+// browser request. The browser then discarded the CORS-less response with
+// net::ERR_FAILED while keploy recorded a successful match and reported
+// missed: 0 — invisible to any miss-based gate.
+var (
+	serverSideRecording = map[string]string{
+		"Accept":          "*/*",
+		"Accept-Encoding": "gzip, deflate",
+		"Accept-Language": "*",
+		"Connection":      "keep-alive",
+		"Cookie":          "session=abc",
+		"Host":            "localhost:8083",
+		"Sec-Fetch-Mode":  "cors",
+		"User-Agent":      "node",
+	}
+
+	browserRecording = map[string]string{
+		"Accept":             "*/*",
+		"Accept-Encoding":    "gzip, deflate, br, zstd",
+		"Accept-Language":    "en-US,en;q=0.9",
+		"Connection":         "keep-alive",
+		"Cookie":             "session=abc",
+		"Host":               "localhost:8083",
+		"Origin":             "http://localhost:3000",
+		"Referer":            "http://localhost:3000/",
+		"Sec-Ch-Ua":          `"Chromium";v="141"`,
+		"Sec-Ch-Ua-Mobile":   "?0",
+		"Sec-Ch-Ua-Platform": `"Windows"`,
+		"Sec-Fetch-Dest":     "empty",
+		"Sec-Fetch-Mode":     "cors",
+		"Sec-Fetch-Site":     "same-site",
+		"User-Agent":         "Mozilla/5.0",
+	}
+
+	browserRequest = http.Header{
+		"Accept":             {"*/*"},
+		"Accept-Encoding":    {"gzip, deflate, br, zstd"},
+		"Accept-Language":    {"en-US,en;q=0.9"},
+		"Connection":         {"keep-alive"},
+		"Cookie":             {"session=abc"},
+		"Host":               {"localhost:8083"},
+		"Origin":             {"http://localhost:3000"},
+		"Referer":            {"http://localhost:3000/"},
+		"Sec-Ch-Ua":          {`"Chromium";v="141"`},
+		"Sec-Ch-Ua-Mobile":   {"?0"},
+		"Sec-Ch-Ua-Platform": {`"Windows"`},
+		"Sec-Fetch-Dest":     {"empty"},
+		"Sec-Fetch-Mode":     {"cors"},
+		"Sec-Fetch-Site":     {"same-site"},
+		"User-Agent":         {"Mozilla/5.0"},
+	}
+
+	serverSideRequest = http.Header{
+		"Accept":          {"*/*"},
+		"Accept-Encoding": {"gzip, deflate"},
+		"Accept-Language": {"*"},
+		"Connection":      {"keep-alive"},
+		"Cookie":          {"session=abc"},
+		"Host":            {"localhost:8083"},
+		"Sec-Fetch-Mode":  {"cors"},
+		"User-Agent":      {"node"},
+	}
+)
+
+func TestHeadersContainKeys_OriginPresenceMustAgree(t *testing.T) {
+	h := newHTTP()
+
+	for _, tc := range []struct {
+		name     string
+		mock     map[string]string
+		req      http.Header
+		expected bool
+		why      string
+	}{
+		{
+			name:     "server-side recording must NOT serve a browser request",
+			mock:     serverSideRecording,
+			req:      browserRequest,
+			expected: false,
+			why:      "its response carries no Access-Control-Allow-Origin; the browser would discard it",
+		},
+		{
+			name:     "browser recording must NOT serve a server-side request",
+			mock:     browserRecording,
+			req:      serverSideRequest,
+			expected: false,
+			why:      "the mock requires Origin, which a server-side call never sends",
+		},
+		{
+			name:     "browser recording serves a browser request",
+			mock:     browserRecording,
+			req:      browserRequest,
+			expected: true,
+		},
+		{
+			name:     "server-side recording serves a server-side request",
+			mock:     serverSideRecording,
+			req:      serverSideRequest,
+			expected: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := h.HeadersContainKeys(tc.mock, tc.req, nil); got != tc.expected {
+				t.Fatalf("HeadersContainKeys = %v, want %v. %s", got, tc.expected, tc.why)
+			}
+		})
+	}
+}
+
+// The check is an ordinary header rule, so header noise turns it off for users
+// who genuinely want the two shapes interchangeable.
+func TestHeadersContainKeys_OriginNoiseDisablesTheCheck(t *testing.T) {
+	h := newHTTP()
+	noise := map[string][]string{"origin": {}}
+
+	if !h.HeadersContainKeys(serverSideRecording, browserRequest, noise) {
+		t.Fatal("with Origin marked as noise the server-side recording should match again")
+	}
+}

--- a/pkg/agent/proxy/integrations/http/passthrough_egress.go
+++ b/pkg/agent/proxy/integrations/http/passthrough_egress.go
@@ -52,7 +52,18 @@ func (h *HTTP) serveOnePassThroughMock(mockDb integrations.MockMemDb, input *req
 	}
 	var fallback *models.Mock
 	for _, m := range candidates {
-		if m == nil || m.Kind != models.HTTP || m.Spec.HTTPReq == nil || m.Spec.HTTPResp == nil {
+		// A response of at least responseSpillMinBytes is parked on the agent's
+		// disk store with Spec.HTTPResp nil and a lazy loader, and candidates
+		// here include the PER-TEST pool, which is exactly the tier that
+		// spills. Rejecting on Spec.HTTPResp == nil alone therefore skipped
+		// every spilled recording, and the caller writes a synthetic 200 with
+		// an empty body when nothing matches -- a wrong response, logged only
+		// at Debug. HasSpilledResponse distinguishes "elided, loadable" from
+		// "genuinely has no response".
+		if m == nil || m.Kind != models.HTTP || m.Spec.HTTPReq == nil {
+			continue
+		}
+		if m.Spec.HTTPResp == nil && !m.HasSpilledResponse() {
 			continue
 		}
 		if m.Spec.HTTPReq.Method != models.Method(input.method) {
@@ -76,9 +87,19 @@ func (h *HTTP) serveOnePassThroughMock(mockDb integrations.MockMemDb, input *req
 		if !mockQueryMatches(m.Spec.HTTPReq, input.url, queryKeys) {
 			continue
 		}
+		// Resolve the response only now. For a spilled mock this reads the
+		// disk store, so it sits AFTER every cheap gate above rather than in
+		// the filter -- otherwise each candidate would cost a read. It does
+		// not write to the mock (see models.Mock.HydratedHTTPResp), which is
+		// what makes it safe on a pooled pointer other connections are also
+		// reading.
+		resp, herr := m.HydratedHTTPResp()
+		if herr != nil || resp == nil {
+			continue
+		}
 		// Prefer a 2xx response (a warmup error may also have been recorded
 		// before the first success under recordOne's first-2xx policy).
-		if isSuccessStatus(m.Spec.HTTPResp.StatusCode) {
+		if isSuccessStatus(resp.StatusCode) {
 			if out, err := h.buildMockResponseBytes(m); err == nil {
 				return out
 			}

--- a/pkg/agent/proxy/integrations/http/passthrough_spilled_test.go
+++ b/pkg/agent/proxy/integrations/http/passthrough_spilled_test.go
@@ -1,0 +1,93 @@
+package http_test
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy"
+	"go.keploy.io/server/v3/pkg/agent/proxy/integrations"
+	kphttp "go.keploy.io/server/v3/pkg/agent/proxy/integrations/http"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// poolDB is the minimum MockMemDb serveOnePassThroughMock reads: the per-test
+// and session tiers. Everything else is unused by that path.
+type poolDB struct {
+	// Embedded as an interface, left nil: serveOnePassThroughMock calls only
+	// the two accessors below, and anything else panicking is the signal that
+	// this fake stopped matching the code under test.
+	integrations.MockMemDb
+	perTest []*models.Mock
+	session []*models.Mock
+}
+
+func (p *poolDB) GetPerTestMocksInWindow() ([]*models.Mock, error) { return p.perTest, nil }
+func (p *poolDB) GetSessionMocks() ([]*models.Mock, error)         { return p.session, nil }
+
+// An egress-passthrough serve must return the RECORDED body even when that
+// body was spilled to the agent's disk store.
+//
+// serveOnePassThroughMock draws candidates from the per-test pool as well as
+// the session pool, and per-test is exactly the tier DiskMocks spills: a
+// recorded body of at least responseSpillMinBytes comes back with
+// Spec.HTTPResp nil and a lazy loader. Filtering on `Spec.HTTPResp == nil`
+// therefore skips it, serveOnePassThroughMock returns nil, and decode.go falls
+// back to writing a SYNTHETIC 200 with an empty body — the app is handed a
+// wrong response, and the only log saying so is at Debug.
+//
+// This became reachable on the default path when tagged HTTP stopped being
+// lax-promoted to session lifetime: session mocks are not disk-eligible, so
+// before that change a passthrough candidate could never have been spilled.
+func TestServeOnePassThroughMockServesASpilledBody(t *testing.T) {
+	body := bodyOfSize(spillMinBytes + 1)
+	store, err := proxy.NewDiskMocks(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDiskMocks: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	m := perTestHTTPMock("mock-telemetry", body)
+	m.Spec.HTTPReq.URL = "http://collector.example.com:4318/v1/metrics"
+	if err := store.Add(m); err != nil {
+		t.Fatalf("DiskMocks.Add: %v", err)
+	}
+	loaded, err := store.LoadByNames([]string{"mock-telemetry"})
+	if err != nil || len(loaded) != 1 {
+		t.Fatalf("LoadByNames: %v (n=%d)", err, len(loaded))
+	}
+	if !loaded[0].HasSpilledResponse() {
+		t.Fatalf("precondition: the mock should have spilled")
+	}
+
+	db := &poolDB{perTest: loaded}
+	u, _ := url.Parse("http://collector.example.com:4318/v1/metrics")
+
+	h := kphttp.NewForTest()
+	out := h.ServeOnePassThroughMockForTest(db, "GET", u, "collector.example.com", 4318, nil)
+	if out == nil {
+		t.Fatalf("a spilled recording was skipped, so the caller writes a synthetic empty 200 instead of the recorded body")
+	}
+	if !strings.Contains(string(out), body[:64]) {
+		t.Fatalf("served response does not carry the recorded body")
+	}
+}
+
+// A mock that never spilled must still serve, unchanged.
+func TestServeOnePassThroughMockServesAResidentBody(t *testing.T) {
+	m := perTestHTTPMock("mock-small", "tiny body")
+	m.Spec.HTTPReq.URL = "http://collector.example.com:4318/v1/metrics"
+
+	db := &poolDB{session: []*models.Mock{m}}
+	u, _ := url.Parse("http://collector.example.com:4318/v1/metrics")
+
+	h := kphttp.NewForTest()
+	out := h.ServeOnePassThroughMockForTest(db, "GET", u, "collector.example.com", 4318, nil)
+	if out == nil {
+		t.Fatalf("a resident recording must still be served")
+	}
+	if !strings.Contains(string(out), "tiny body") {
+		t.Fatalf("served response does not carry the recorded body")
+	}
+}

--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -137,7 +137,11 @@ func (h *HTTP) recordV2(ctx context.Context, sess *supervisor.Session) error {
 		finalResp := append([]byte(nil), firstRespChunk.Bytes...)
 		resTs := firstRespChunk.WrittenAt
 
-		gotLastWritten, err := h.readResponseV2(ctx, sess.DestStream, &finalResp)
+		// The request method decides whether the response may carry a body at
+		// all (RFC 9112 section 6.3 — a response to HEAD never does), so it has
+		// to travel with the response read.
+		reqMethod := httpRequestMethod(finalReq)
+		gotLastWritten, err := h.readResponseV2(ctx, sess.DestStream, &finalResp, reqMethod)
 		if err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, fakeconn.ErrClosed) {
 				// Legacy encodeHTTP treats EOF after some bytes as
@@ -271,28 +275,63 @@ func (h *HTTP) readRequestV2(ctx context.Context, stream *fakeconn.FakeConn, fin
 // Returns (lastWrittenAt, err). err may be io.EOF for the legitimate
 // "server closed after sending a full response" case; the caller
 // decides whether to emit a mock.
-func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, finalResp *[]byte) (time.Time, error) {
+func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, finalResp *[]byte, reqMethod string) (time.Time, error) {
 	var lastWr time.Time
 
-	// 1. Complete headers.
-	for !hasCompleteHeaders(*finalResp) {
-		if err := ctx.Err(); err != nil {
-			return lastWr, err
+	// 1. Complete headers, discarding any INTERIM 1xx response first.
+	//
+	// RFC 9110 section 15.2: an interim response (100 Continue, 103 Early Hints)
+	// is not the response — the real one follows on the same connection. Framing
+	// the interim as if it were the response leaves the real response unread and,
+	// via the read-until-EOF fallback below, swallows every later exchange on the
+	// connection. 101 is deliberately NOT skipped: it IS the final response for
+	// an upgrade, so it is framed and recorded like any other bodyless
+	// response. What follows on the wire is no longer HTTP, and the parser
+	// blocks there until the hang watchdog retires it -- deliberately, because
+	// returning cleanly would end the supervisor run with a status that does
+	// not preserve the byte relay, killing the upgraded connection.
+	for interim := 0; ; interim++ {
+		for !hasCompleteHeaders(*finalResp) {
+			if err := ctx.Err(); err != nil {
+				return lastWr, err
+			}
+			chunk, err := stream.ReadChunk()
+			if err != nil {
+				return lastWr, err
+			}
+			if !chunk.WrittenAt.IsZero() {
+				lastWr = chunk.WrittenAt
+			}
+			if len(chunk.Bytes) == 0 {
+				return lastWr, io.EOF
+			}
+			*finalResp = append(*finalResp, chunk.Bytes...)
 		}
-		chunk, err := stream.ReadChunk()
-		if err != nil {
-			return lastWr, err
+		code := httpStatusCode(*finalResp)
+		if code < 100 || code >= 200 || code == 101 {
+			break
 		}
-		if !chunk.WrittenAt.IsZero() {
-			lastWr = chunk.WrittenAt
+		if interim >= maxInterimResponses {
+			return lastWr, fmt.Errorf("more than %d consecutive interim (1xx) responses", maxInterimResponses)
 		}
-		if len(chunk.Bytes) == 0 {
-			return lastWr, io.EOF
+		end := bytes.Index(*finalResp, []byte("\r\n\r\n"))
+		if end < 0 {
+			break
 		}
-		*finalResp = append(*finalResp, chunk.Bytes...)
+		h.Logger.Debug("V2 HTTP record: discarding an interim 1xx response and reading the real one",
+			zap.Int("status", code))
+		*finalResp = append([]byte(nil), (*finalResp)[end+4:]...)
 	}
 
-	// 2. Parse headers for body framing.
+	// 2. Bodyless by status/method (RFC 9112 section 6.3) — must be checked
+	//    BEFORE Content-Length / Transfer-Encoding, which are present on plenty
+	//    of 304s and HEAD responses and describe the body the response WOULD
+	//    have had. See responseHasNoBody.
+	if code := httpStatusCode(*finalResp); responseHasNoBody(code, reqMethod) {
+		return lastWr, nil
+	}
+
+	// 3. Parse headers for body framing.
 	contentLengthHeader, transferEncodingHeader := parseHeaders(*finalResp)
 
 	if contentLengthHeader != "" {
@@ -354,6 +393,17 @@ func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, fi
 	// Neither Content-Length nor chunked: read until EOF (RFC 7230
 	// permits this for HTTP/1.0 and for responses with "Connection:
 	// close"). The loop relies on the stream eventually closing.
+	//
+	// Say so. On a keep-alive connection the stream does NOT close after this
+	// response, so this loop consumes every later exchange as body and none of
+	// them is ever recorded — and because the parser then returns nil, the
+	// supervisor records StatusOK and no retire warning is emitted. That is
+	// silent recording loss, and it stayed invisible for exactly as long as this
+	// branch said nothing.
+	h.Logger.Warn("V2 HTTP record: response has neither Content-Length nor chunked framing; reading until the connection closes",
+		zap.Int("status", httpStatusCode(*finalResp)),
+		zap.String("method", reqMethod),
+		zap.String("impact", "if this connection is keep-alive, later requests on it will be consumed as this response's body and not recorded"))
 	for {
 		if err := ctx.Err(); err != nil {
 			return lastWr, err
@@ -370,6 +420,75 @@ func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, fi
 		}
 		*finalResp = append(*finalResp, chunk.Bytes...)
 	}
+}
+
+// maxInterimResponses bounds the 1xx skip loop so a peer that only ever sends
+// interim responses cannot spin here.
+const maxInterimResponses = 8
+
+// httpStatusCode returns the status code from a response's start line, or 0 if
+// it cannot be parsed. Deliberately a byte-level parse of the first line rather
+// than http.ReadResponse: this runs before the body has been framed, which is
+// precisely what ReadResponse would need.
+func httpStatusCode(resp []byte) int {
+	end := bytes.IndexByte(resp, '\n')
+	if end < 0 {
+		end = len(resp)
+	}
+	fields := strings.Fields(string(resp[:end]))
+	if len(fields) < 2 || !strings.HasPrefix(fields[0], "HTTP/") {
+		return 0
+	}
+	code, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return 0
+	}
+	return code
+}
+
+// httpRequestMethod returns the method from a request's start line, uppercased,
+// or "" if it cannot be parsed. Needed because RFC 9112 section 6.3 makes the
+// response to HEAD bodyless regardless of its own headers.
+func httpRequestMethod(req []byte) string {
+	end := bytes.IndexByte(req, '\n')
+	if end < 0 {
+		end = len(req)
+	}
+	fields := strings.Fields(string(req[:end]))
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.ToUpper(fields[0])
+}
+
+// responseHasNoBody reports whether RFC 9112 section 6.3 forbids a message body
+// on this response, in which case Content-Length / Transfer-Encoding must be
+// ignored rather than used for framing.
+//
+// Getting this wrong is not a cosmetic bug. Framing a bodyless response from its
+// headers sends readResponseV2 into either the Content-Length wait or the
+// read-until-EOF fallback, and it then consumes every LATER exchange on the same
+// keep-alive connection as if it were this response's body. Chromium revalidates
+// static assets (304) and preflights CORS (204) constantly, so on a browser
+// workload this silently destroys most of a connection's recording.
+func responseHasNoBody(code int, reqMethod string) bool {
+	switch {
+	case code == 204, code == 304:
+		return true
+	case code >= 100 && code < 200:
+		// 101 reaches here; 1xx below it is consumed by the interim skip.
+		return true
+	case strings.EqualFold(reqMethod, "HEAD"):
+		return true
+	case code >= 200 && code < 300 && strings.EqualFold(reqMethod, "CONNECT"):
+		// RFC 9112 section 6.3: a 2xx to CONNECT turns the connection into a
+		// tunnel, so the response itself has no body and everything after it is
+		// opaque tunnelled bytes. Like a 101 it carries neither Content-Length
+		// nor chunked framing, so without this it lands in the read-until-close
+		// branch and swallows the rest of the connection.
+		return true
+	}
+	return false
 }
 
 // parseHeaders extracts Content-Length and Transfer-Encoding header

--- a/pkg/agent/proxy/integrations/http/recordv2.go
+++ b/pkg/agent/proxy/integrations/http/recordv2.go
@@ -238,20 +238,11 @@ func (h *HTTP) readRequestV2(ctx context.Context, stream *fakeconn.FakeConn, fin
 
 	if transferEncodingHeader != "" &&
 		strings.Contains(strings.ToLower(transferEncodingHeader), "chunked") {
-		for !bytes.HasSuffix(*finalReq, chunkedTerminator) {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			chunk, err := stream.ReadChunk()
-			if err != nil {
-				return err
-			}
-			if len(chunk.Bytes) == 0 {
-				return io.EOF
-			}
-			*finalReq = append(*finalReq, chunk.Bytes...)
+		headerEnd := bytes.Index(*finalReq, []byte("\r\n\r\n"))
+		if headerEnd < 0 {
+			return fmt.Errorf("header terminator missing")
 		}
-		return nil
+		return h.consumeChunkedBody(ctx, stream, finalReq, headerEnd+4, nil)
 	}
 
 	// No body framing: the request is headers-only (e.g. GET / HTTP/1.1
@@ -269,8 +260,8 @@ func (h *HTTP) readRequestV2(ctx context.Context, stream *fakeconn.FakeConn, fin
 //   - Pull more chunks until response headers are complete.
 //   - Parse Content-Length / Transfer-Encoding from headers.
 //   - If Content-Length, read until the declared body length is met.
-//   - If Transfer-Encoding chunked, read until the last-chunk marker
-//     "0\r\n\r\n" appears as a suffix (the fix in SAP bug #4110).
+//   - If Transfer-Encoding chunked, walk the chunk framing to its true end
+//     (see consumeChunkedBody / chunkedFramer).
 //
 // Returns (lastWrittenAt, err). err may be io.EOF for the legitimate
 // "server closed after sending a full response" case; the caller
@@ -367,27 +358,16 @@ func (h *HTTP) readResponseV2(ctx context.Context, stream *fakeconn.FakeConn, fi
 
 	if transferEncodingHeader != "" &&
 		strings.Contains(strings.ToLower(transferEncodingHeader), "chunked") {
-		// Chunked: read until we see the last-chunk terminator as a
-		// suffix of finalResp. pUtil terminator detection (see chunk.go
-		// chunkedTerminator) uses HasSuffix so a body chunk that shares
-		// a TLS record with the terminator still exits cleanly.
-		for !bytes.HasSuffix(*finalResp, chunkedTerminator) {
-			if err := ctx.Err(); err != nil {
-				return lastWr, err
-			}
-			chunk, err := stream.ReadChunk()
-			if err != nil {
-				return lastWr, err
-			}
-			if !chunk.WrittenAt.IsZero() {
-				lastWr = chunk.WrittenAt
-			}
-			if len(chunk.Bytes) == 0 {
-				return lastWr, io.EOF
-			}
-			*finalResp = append(*finalResp, chunk.Bytes...)
+		headerEnd := bytes.Index(*finalResp, []byte("\r\n\r\n"))
+		if headerEnd < 0 {
+			return lastWr, fmt.Errorf("header terminator missing")
 		}
-		return lastWr, nil
+		err := h.consumeChunkedBody(ctx, stream, finalResp, headerEnd+4, func(c fakeconn.Chunk) {
+			if !c.WrittenAt.IsZero() {
+				lastWr = c.WrittenAt
+			}
+		})
+		return lastWr, err
 	}
 
 	// Neither Content-Length nor chunked: read until EOF (RFC 7230
@@ -703,4 +683,210 @@ func (h *HTTP) buildHTTPMock(m *FinalHTTP, destPort uint, connID string, opts mo
 		return nil, nil
 	}
 	return mock, nil
+}
+
+// consumeChunkedBody reads from stream until the RFC 9112 section 7.1 chunked
+// body that begins at bodyStart in *msg is completely framed, appending every
+// chunk it reads to *msg. onChunk, when non-nil, is called for each chunk read
+// so a caller that anchors timestamps to chunk metadata can record them.
+//
+// On return *msg ends exactly at the last byte of the chunked body, so the
+// caller can hand it to http.ReadResponse / http.ReadRequest unchanged.
+func (h *HTTP) consumeChunkedBody(
+	ctx context.Context,
+	stream *fakeconn.FakeConn,
+	msg *[]byte,
+	bodyStart int,
+	onChunk func(fakeconn.Chunk),
+) error {
+	f := newChunkedFramer(bodyStart)
+	for {
+		done, err := f.advance(*msg)
+		if err != nil {
+			return err
+		}
+		if done {
+			// Overshoot: one tee'd chunk carried the tail of this message
+			// and the head of the next one. Framing knows exactly where the
+			// split is; the recorder loop does not yet carry those bytes into
+			// the next exchange, so say so rather than lose them silently.
+			if end := f.End(); end < len(*msg) {
+				h.Logger.Warn("V2 HTTP record: bytes arrived past the end of a chunked body",
+					zap.Int("overshoot_bytes", len(*msg)-end),
+					zap.String("impact", "these bytes are the head of the next exchange on this connection; it will not frame and will not be recorded"))
+				*msg = (*msg)[:end]
+			}
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		chunk, err := stream.ReadChunk()
+		if err != nil {
+			return err
+		}
+		if onChunk != nil {
+			onChunk(chunk)
+		}
+		if len(chunk.Bytes) == 0 {
+			return io.EOF
+		}
+		*msg = append(*msg, chunk.Bytes...)
+	}
+}
+
+// Chunked framing, RFC 9112 section 7.1. The recorder has to know exactly
+// where a chunked body ends, because on a keep-alive connection the next byte
+// is the first byte of the next exchange.
+//
+// Searching the accumulated buffer for the last-chunk marker "0\r\n\r\n"
+// cannot do that, and is wrong in both directions:
+//
+//   - It misses a real end. The last chunk may carry a chunk extension
+//     ("0;pad=x\r\n\r\n"), and between the last chunk and the final CRLF sits
+//     the trailer section — arbitrary header lines ("0\r\nGrpc-Status: 5\r\n\r\n").
+//     Neither ends in the marker, so the read loop never stops and consumes
+//     every later exchange on the connection as this body.
+//   - It finds an end that is not there. A data chunk whose payload ends in
+//     "0\r\n" is followed by the framing CRLF, so the wire genuinely reads
+//     "...0\r\n\r\n" in mid-body; if a tee'd chunk boundary falls there, the
+//     marker IS the buffer's suffix and the body is cut short.
+//
+// chunkedFramer walks the framing instead: chunk-size line, that many data
+// bytes, CRLF, repeat until a zero-size chunk, then trailer lines up to the
+// terminating empty line. It keeps its cursor across calls so each byte is
+// examined once — rescanning the buffer per arriving chunk would be quadratic
+// on a large streamed body.
+const (
+	// maxChunkLineLen bounds a chunk-size or trailer line so a peer that
+	// never sends the LF cannot make the recorder buffer without bound.
+	// Same value Go's own chunked reader uses.
+	maxChunkLineLen = 4096
+	// maxChunkedTrailerBytes bounds the whole trailer section, which is
+	// otherwise an unbounded run of header lines.
+	maxChunkedTrailerBytes = 16 << 10
+)
+
+type chunkedFramerState uint8
+
+const (
+	chunkExpectSize chunkedFramerState = iota
+	chunkExpectData
+	chunkExpectDataCRLF
+	chunkExpectTrailer
+	chunkComplete
+)
+
+type chunkedFramer struct {
+	state        chunkedFramerState
+	pos          int // cursor into the accumulated message buffer
+	remaining    int // data bytes still owed by the chunk being read
+	trailerBytes int
+}
+
+// newChunkedFramer starts a framer at bodyStart, the offset of the first byte
+// after the header section's CRLFCRLF.
+func newChunkedFramer(bodyStart int) *chunkedFramer { return &chunkedFramer{pos: bodyStart} }
+
+// advance consumes as much of buf as the framing allows.
+//
+// done=true means the trailer section's terminating CRLF has been consumed and
+// End() is the offset one past the body. done=false with a nil error means the
+// framing is well formed so far but incomplete: read more, append to buf, call
+// again.
+//
+// A non-nil error means these bytes are not valid chunked framing. It is
+// returned at once rather than read through, so garbled framing costs one
+// connection's capture and never a hung parser.
+func (f *chunkedFramer) advance(buf []byte) (bool, error) {
+	for {
+		switch f.state {
+		case chunkComplete:
+			return true, nil
+
+		case chunkExpectSize:
+			line, next, ok, err := chunkLine(buf, f.pos)
+			if err != nil || !ok {
+				return false, err
+			}
+			if i := bytes.IndexByte(line, ';'); i >= 0 {
+				line = line[:i] // chunk extension: "size;name=value"
+			}
+			line = bytes.TrimRight(line, " \t")
+			if len(line) == 0 {
+				return false, errors.New("chunked framing: empty chunk-size line")
+			}
+			// bitSize 31: a single chunk larger than 2 GiB is not real
+			// traffic, and accepting one would overflow int on a 32-bit build.
+			size, err := strconv.ParseUint(string(line), 16, 31)
+			if err != nil {
+				return false, fmt.Errorf("chunked framing: bad chunk size %q: %w", line, err)
+			}
+			f.pos = next
+			if size == 0 {
+				f.state = chunkExpectTrailer
+				continue
+			}
+			f.remaining = int(size)
+			f.state = chunkExpectData
+
+		case chunkExpectData:
+			n := len(buf) - f.pos
+			if n > f.remaining {
+				n = f.remaining
+			}
+			f.pos += n
+			f.remaining -= n
+			if f.remaining > 0 {
+				return false, nil
+			}
+			f.state = chunkExpectDataCRLF
+
+		case chunkExpectDataCRLF:
+			if len(buf)-f.pos < 2 {
+				return false, nil
+			}
+			if buf[f.pos] != '\r' || buf[f.pos+1] != '\n' {
+				return false, errors.New("chunked framing: chunk data not followed by CRLF")
+			}
+			f.pos += 2
+			f.state = chunkExpectSize
+
+		case chunkExpectTrailer:
+			line, next, ok, err := chunkLine(buf, f.pos)
+			if err != nil || !ok {
+				return false, err
+			}
+			f.trailerBytes += next - f.pos
+			f.pos = next
+			if len(line) == 0 {
+				f.state = chunkComplete
+				return true, nil
+			}
+			if f.trailerBytes > maxChunkedTrailerBytes {
+				return false, fmt.Errorf("chunked framing: trailer section exceeds %d bytes", maxChunkedTrailerBytes)
+			}
+		}
+	}
+}
+
+// End is the offset one past the chunked body, valid once advance has reported
+// done. Bytes at or after it belong to the next message on the connection.
+func (f *chunkedFramer) End() int { return f.pos }
+
+// chunkLine returns the LF-terminated line at buf[pos:] with its trailing CR
+// stripped, plus the offset just past the LF. ok=false with a nil error means
+// the line has not fully arrived yet.
+func chunkLine(buf []byte, pos int) (line []byte, next int, ok bool, err error) {
+	i := bytes.IndexByte(buf[pos:], '\n')
+	if i < 0 {
+		if len(buf)-pos > maxChunkLineLen {
+			return nil, 0, false, fmt.Errorf("chunked framing: no LF within %d bytes", maxChunkLineLen)
+		}
+		return nil, 0, false, nil
+	}
+	if i > maxChunkLineLen {
+		return nil, 0, false, fmt.Errorf("chunked framing: line exceeds %d bytes", maxChunkLineLen)
+	}
+	return bytes.TrimSuffix(buf[pos:pos+i], []byte("\r")), pos + i + 1, true, nil
 }

--- a/pkg/agent/proxy/integrations/http/recordv2_framing_test.go
+++ b/pkg/agent/proxy/integrations/http/recordv2_framing_test.go
@@ -1,0 +1,169 @@
+package http
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap/zaptest"
+)
+
+// RFC 9112 section 6.3 forbids a message body on 1xx, 204 and 304, and on any
+// response to HEAD, regardless of Content-Length / Transfer-Encoding. Framing
+// such a response from its headers sends readResponseV2 into the read-until-EOF
+// fallback, which then consumes every LATER framingExchange on the same keep-alive
+// connection as if it were this response's body.
+//
+// The damage is silent: recordV2 returns nil, so the supervisor records
+// StatusOK, no "parser retired" warning is logged, and no orphan window is
+// opened. On a Chromium workload (304 revalidation of static assets, 204 CORS
+// preflights) that is most of a connection's recording, lost without a trace.
+//
+// These tests drive recordV2 over a scripted keep-alive connection and assert
+// that every framingExchange is recorded and correctly paired.
+
+type framingExchange struct {
+	req  []byte
+	resp []byte
+}
+
+func framingGetReq(path string) []byte {
+	return []byte("GET " + path + " HTTP/1.1\r\nHost: x\r\n\r\n")
+}
+
+func framingOKBody(b string) []byte {
+	return []byte(fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n%s", len(b), b))
+}
+
+// runFramingExchanges plays the script over one connection and returns the emitted mocks.
+func runFramingExchanges(t *testing.T, script []framingExchange) []*models.Mock {
+	t.Helper()
+	h := &HTTP{Logger: zaptest.NewLogger(t)}
+	sess, sendReq, closeReq, sendResp, closeResp, mocks := newTestSession(t)
+	base := time.Unix(1_700_000_000, 0)
+
+	// sent is closed once the feeder has finished and closed both streams. The
+	// helper waits on it before returning: without that the feeder outlives the
+	// test and its closes race t.Cleanup's, which `go test -race` reports.
+	sent := make(chan struct{})
+	go func() {
+		defer close(sent)
+		for i, ex := range script {
+			ts := base.Add(time.Duration(i) * time.Second)
+			sendReq(ex.req, ts, ts)
+			time.Sleep(15 * time.Millisecond)
+			sendResp(ex.resp, ts, ts)
+			time.Sleep(15 * time.Millisecond)
+		}
+		closeResp()
+		closeReq()
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- h.recordV2(sess.Ctx, sess) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("parser never returned — it is blocked framing a body that will never arrive")
+	}
+	select {
+	case <-sent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("feeder goroutine never finished")
+	}
+
+	var got []*models.Mock
+	for {
+		select {
+		case m := <-mocks:
+			got = append(got, m)
+		default:
+			return got
+		}
+	}
+}
+
+func framingURLsOf(ms []*models.Mock) []string {
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, m.Spec.HTTPReq.URL)
+	}
+	return out
+}
+
+// A frameless 304 on a keep-alive connection must not swallow the exchanges
+// that follow it. Before the fix this recorded exactly ONE mock (the 304) and
+// returned nil, losing three of four exchanges silently.
+func TestRecordV2_FramelessNotModifiedDoesNotSwallowKeepAlive(t *testing.T) {
+	got := runFramingExchanges(t, []framingExchange{
+		{framingGetReq("/one"), []byte("HTTP/1.1 304 Not Modified\r\nETag: \"a\"\r\n\r\n")},
+		{framingGetReq("/two"), framingOKBody("TWO")},
+		{framingGetReq("/three"), framingOKBody("THREE")},
+		{framingGetReq("/four"), framingOKBody("FOUR")},
+	})
+	require.Equal(t, []string{"/one", "/two", "/three", "/four"}, framingURLsOf(got))
+	require.Equal(t, 304, got[0].Spec.HTTPResp.StatusCode)
+	require.Equal(t, "TWO", got[1].Spec.HTTPResp.Body)
+	require.Equal(t, "FOUR", got[3].Spec.HTTPResp.Body)
+}
+
+// A 204 CORS preflight is the same shape and the most likely trigger on this
+// project's workload — the browser preflights every cross-origin API call.
+func TestRecordV2_NoContentPreflightDoesNotSwallowKeepAlive(t *testing.T) {
+	preflight := []byte("OPTIONS /api HTTP/1.1\r\nHost: x\r\nAccess-Control-Request-Method: POST\r\n\r\n")
+	got := runFramingExchanges(t, []framingExchange{
+		{preflight, []byte("HTTP/1.1 204 No Content\r\nAccess-Control-Allow-Origin: *\r\n\r\n")},
+		{framingGetReq("/after"), framingOKBody("AFTER")},
+	})
+	require.Equal(t, []string{"/api", "/after"}, framingURLsOf(got))
+	require.Equal(t, "AFTER", got[1].Spec.HTTPResp.Body)
+}
+
+// A 304 that DOES carry Content-Length still has no body — the header describes
+// the body the response would have had. Trusting it blocks the parser forever.
+func TestRecordV2_NotModifiedWithContentLengthHasNoBody(t *testing.T) {
+	got := runFramingExchanges(t, []framingExchange{
+		{framingGetReq("/one"), []byte("HTTP/1.1 304 Not Modified\r\nContent-Length: 1024\r\n\r\n")},
+		{framingGetReq("/two"), framingOKBody("TWO")},
+	})
+	require.Equal(t, []string{"/one", "/two"}, framingURLsOf(got))
+	require.Equal(t, "TWO", got[1].Spec.HTTPResp.Body)
+}
+
+// A response to HEAD is bodyless whatever its Content-Length says.
+func TestRecordV2_HeadResponseHasNoBody(t *testing.T) {
+	head := []byte("HEAD /asset HTTP/1.1\r\nHost: x\r\n\r\n")
+	got := runFramingExchanges(t, []framingExchange{
+		{head, []byte("HTTP/1.1 200 OK\r\nContent-Length: 1024\r\n\r\n")},
+		{framingGetReq("/after"), framingOKBody("AFTER")},
+	})
+	require.Equal(t, []string{"/asset", "/after"}, framingURLsOf(got))
+	require.Equal(t, "AFTER", got[1].Spec.HTTPResp.Body)
+}
+func TestRecordV2_ChunkedPayloadContainingTerminatorIsNotTruncated(t *testing.T) {
+	chunked := []byte("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n" +
+		"1\r\n0\r\n" + // a chunk whose single byte is "0"
+		"3\r\nabc\r\n" +
+		"0\r\n\r\n")
+	got := runFramingExchanges(t, []framingExchange{
+		{framingGetReq("/stream"), chunked},
+		{framingGetReq("/after"), framingOKBody("AFTER")},
+	})
+	require.Equal(t, []string{"/stream", "/after"}, framingURLsOf(got),
+		"a chunked payload containing the last-chunk marker must not end the body early")
+	require.Equal(t, "AFTER", got[1].Spec.HTTPResp.Body)
+}
+
+// Control: an ordinary keep-alive conversation with no bodyless response is
+// unaffected. Proves the harness detects success, not just failure.
+func TestRecordV2_OrdinaryKeepAliveUnaffected(t *testing.T) {
+	got := runFramingExchanges(t, []framingExchange{
+		{framingGetReq("/one"), framingOKBody("ONE")},
+		{framingGetReq("/two"), framingOKBody("TWO")},
+	})
+	require.Equal(t, []string{"/one", "/two"}, framingURLsOf(got))
+	require.Equal(t, "ONE", got[0].Spec.HTTPResp.Body)
+	require.Equal(t, "TWO", got[1].Spec.HTTPResp.Body)
+}

--- a/pkg/agent/proxy/integrations/http/recordv2_framing_test.go
+++ b/pkg/agent/proxy/integrations/http/recordv2_framing_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -166,4 +167,188 @@ func TestRecordV2_OrdinaryKeepAliveUnaffected(t *testing.T) {
 	require.Equal(t, []string{"/one", "/two"}, framingURLsOf(got))
 	require.Equal(t, "ONE", got[0].Spec.HTTPResp.Body)
 	require.Equal(t, "TWO", got[1].Spec.HTTPResp.Body)
+}
+
+// chunkedRespParts builds a chunked response and returns it as the caller's
+// chosen split across tee'd chunks, so a boundary can be placed anywhere.
+func chunkedBody(data []string, lastChunkExt string, trailers ...string) string {
+	var b strings.Builder
+	for _, d := range data {
+		fmt.Fprintf(&b, "%x\r\n%s\r\n", len(d), d)
+	}
+	b.WriteString("0" + lastChunkExt + "\r\n")
+	for _, tr := range trailers {
+		b.WriteString(tr + "\r\n")
+	}
+	b.WriteString("\r\n")
+	return b.String()
+}
+
+func chunkedResp(data []string, lastChunkExt string, trailers ...string) []byte {
+	extra := ""
+	if len(trailers) > 0 {
+		extra = "Trailer: " + strings.SplitN(trailers[0], ":", 2)[0] + "\r\n"
+	}
+	return []byte("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n" + extra + "\r\n" +
+		chunkedBody(data, lastChunkExt, trailers...))
+}
+
+// splitExchange is framingExchange with the response delivered as several
+// tee'd chunks, so a boundary can be placed mid-frame.
+type splitExchange struct {
+	req   []byte
+	parts [][]byte
+}
+
+func runSplitExchanges(t *testing.T, script []splitExchange) []*models.Mock {
+	t.Helper()
+	h := &HTTP{Logger: zaptest.NewLogger(t)}
+	sess, sendReq, closeReq, sendResp, closeResp, mocks := newTestSession(t)
+	base := time.Unix(1_700_000_000, 0)
+
+	sent := make(chan struct{})
+	go func() {
+		defer close(sent)
+		for i, ex := range script {
+			ts := base.Add(time.Duration(i) * time.Second)
+			sendReq(ex.req, ts, ts)
+			time.Sleep(10 * time.Millisecond)
+			for _, p := range ex.parts {
+				sendResp(p, ts, ts)
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+		closeResp()
+		closeReq()
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- h.recordV2(sess.Ctx, sess) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("parser never returned — it is blocked framing a chunked body that has already ended")
+	}
+	<-sent
+
+	var got []*models.Mock
+	for {
+		select {
+		case m := <-mocks:
+			got = append(got, m)
+		default:
+			return got
+		}
+	}
+}
+
+// A trailer section after the last chunk is part of the framing, not the start
+// of the next exchange. Scanning for "0\r\n\r\n" only terminates when the last
+// trailer value happens to end in '0'.
+func TestRecordV2_ChunkedTrailerDoesNotSwallowKeepAlive(t *testing.T) {
+	for _, status := range []string{"5", "0"} {
+		t.Run("grpc-status-"+status, func(t *testing.T) {
+			got := runSplitExchanges(t, []splitExchange{
+				{framingGetReq("/grpc"), [][]byte{chunkedResp([]string{"hello"}, "", "Grpc-Status: "+status)}},
+				{framingGetReq("/after"), [][]byte{framingOKBody("AFTER")}},
+			})
+			require.Equal(t, []string{"/grpc", "/after"}, framingURLsOf(got))
+			require.Equal(t, "hello", got[0].Spec.HTTPResp.Body)
+			require.Equal(t, "AFTER", got[1].Spec.HTTPResp.Body)
+		})
+	}
+}
+
+// RFC 9112 allows a chunk extension on the last chunk. "0;pad=x\r\n\r\n" is a
+// legal end that no literal-marker search can find.
+func TestRecordV2_ChunkedLastChunkExtensionTerminates(t *testing.T) {
+	got := runSplitExchanges(t, []splitExchange{
+		{framingGetReq("/ext"), [][]byte{chunkedResp([]string{"hello"}, ";pad=x")}},
+		{framingGetReq("/after"), [][]byte{framingOKBody("AFTER")}},
+	})
+	require.Equal(t, []string{"/ext", "/after"}, framingURLsOf(got))
+	require.Equal(t, "AFTER", got[1].Spec.HTTPResp.Body)
+}
+
+// The inverse failure: a data chunk whose payload ends in "0\r\n" is followed
+// by the framing CRLF, so the wire really does read "...0\r\n\r\n" in mid-body.
+// With the boundary placed right there, a suffix check ends the body early.
+func TestRecordV2_ChunkedBoundaryAfterZeroCRLFIsNotTheEnd(t *testing.T) {
+	full := chunkedBody([]string{"X0\r\n", "abc"}, "")
+	split := strings.Index(full, "3\r\nabc") // boundary right after the first chunk
+	got := runSplitExchanges(t, []splitExchange{
+		{framingGetReq("/split"), [][]byte{
+			[]byte("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n" + full[:split]),
+			[]byte(full[split:]),
+		}},
+		{framingGetReq("/after"), [][]byte{framingOKBody("AFTER")}},
+	})
+	require.Equal(t, []string{"/split", "/after"}, framingURLsOf(got))
+	require.Equal(t, "X0\r\nabc", got[0].Spec.HTTPResp.Body)
+}
+
+// A tee'd chunk boundary can fall anywhere, including inside the chunk-size
+// line. Every split of one response must frame identically.
+func TestRecordV2_ChunkedEverySplitFramesIdentically(t *testing.T) {
+	resp := string(chunkedResp([]string{"hello", "world"}, "", "Grpc-Status: 5"))
+	for i := 1; i < len(resp); i++ {
+		got := runSplitExchanges(t, []splitExchange{
+			{framingGetReq("/s"), [][]byte{[]byte(resp[:i]), []byte(resp[i:])}},
+			{framingGetReq("/after"), [][]byte{framingOKBody("AFTER")}},
+		})
+		require.Equal(t, []string{"/s", "/after"}, framingURLsOf(got), "split at byte %d", i)
+		require.Equal(t, "helloworld", got[0].Spec.HTTPResp.Body, "split at byte %d", i)
+	}
+}
+
+// Malformed framing must fail fast. The streams are deliberately left OPEN, so
+// a parser that reads on instead of erroring never returns and the test times
+// out rather than passing by accident.
+func TestRecordV2_MalformedChunkedFailsFastWithoutClosing(t *testing.T) {
+	cases := map[string]string{
+		"non-hex chunk size":  "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\nzz\r\nhello\r\n",
+		"data not CRLF-ended": "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhelloXX",
+	}
+	for name, wire := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := &HTTP{Logger: zaptest.NewLogger(t)}
+			sess, sendReq, _, sendResp, _, _ := newTestSession(t)
+			ts := time.Unix(1_700_000_000, 0)
+			sendReq(framingGetReq("/bad"), ts, ts)
+			sendResp([]byte(wire), ts, ts)
+
+			done := make(chan error, 1)
+			go func() { done <- h.recordV2(sess.Ctx, sess) }()
+			select {
+			case err := <-done:
+				require.Error(t, err, "malformed framing must be reported, not accepted")
+				require.True(t, sess.IsMockIncomplete(), "a malformed frame must mark the mock incomplete")
+			case <-time.After(2 * time.Second):
+				t.Fatal("parser did not return on malformed chunked framing — it is reading a body that will never end")
+			}
+		})
+	}
+}
+
+// A chunked body cut short by the connection closing must end the parser, not
+// hang it. The exchange is unrecordable; what matters is that recordV2 returns.
+func TestRecordV2_ChunkedTruncatedByEOFReturns(t *testing.T) {
+	got := runSplitExchanges(t, []splitExchange{
+		{framingGetReq("/cut"), [][]byte{[]byte("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhel")}},
+	})
+	require.Empty(t, framingURLsOf(got))
+}
+
+// The request side has the same framing and the same defect. An AWS S3
+// streaming upload sends its checksum as a trailer after the last chunk.
+func TestRecordV2_ChunkedRequestTrailerDoesNotSwallowKeepAlive(t *testing.T) {
+	req := []byte("PUT /obj HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n" +
+		"x-amz-trailer: x-amz-checksum-crc32\r\n\r\n" +
+		chunkedBody([]string{"hello"}, "", "x-amz-checksum-crc32: AAAAAA=="))
+	got := runSplitExchanges(t, []splitExchange{
+		{req, [][]byte{framingOKBody("OK1")}},
+		{framingGetReq("/after"), [][]byte{framingOKBody("AFTER")}},
+	})
+	require.Equal(t, []string{"/obj", "/after"}, framingURLsOf(got))
+	require.Equal(t, "hello", got[0].Spec.HTTPReq.Body)
 }

--- a/pkg/agent/proxy/integrations/http/spilled_response_race_test.go
+++ b/pkg/agent/proxy/integrations/http/spilled_response_race_test.go
@@ -1,0 +1,108 @@
+package http_test
+
+import (
+	"sync"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy"
+	kphttp "go.keploy.io/server/v3/pkg/agent/proxy/integrations/http"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// Serving a spilled response must not write to the mock, because the mock is
+// shared and another goroutine reads it whole while the serve is in flight.
+//
+// Proxy.handleConnection runs in its own goroutine per accepted connection,
+// and the MockManager getters hand out the STORED pointer, not a copy. So two
+// connections can match the same mock: one consumes and serves it, while the
+// other is still inside updateMock, which dereferences the whole struct by
+// value -- `updatedMock := *matchedMock` and `deleteMock := *matchedMock`
+// (match.go:1233, :1269). Those reads cover Spec.HTTPResp and the spill
+// hydrator, the two fields the old mutating hydrate wrote.
+//
+// The goroutines below are siblings with no happens-before edge, which is what
+// the race detector keys on -- so this reports deterministically rather than
+// depending on an interleaving. It is meaningless without -race; the CI lane
+// in .github/workflows/go-test.yaml runs this package under -race for that
+// reason.
+func TestServingASpilledMockDoesNotWriteToTheSharedMock(t *testing.T) {
+	body := bodyOfSize(spillMinBytes + 1)
+	store, err := proxy.NewDiskMocks(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDiskMocks: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	if err := store.Add(perTestHTTPMock("mock-shared", body)); err != nil {
+		t.Fatalf("DiskMocks.Add: %v", err)
+	}
+	loaded, err := store.LoadByNames([]string{"mock-shared"})
+	if err != nil || len(loaded) != 1 {
+		t.Fatalf("LoadByNames: %v (n=%d)", err, len(loaded))
+	}
+	shared := loaded[0]
+
+	h := kphttp.NewForTest()
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	// The serving connection.
+	go func() {
+		defer wg.Done()
+		if _, err := h.BuildMockResponseBytesForTest(shared); err != nil {
+			t.Errorf("serialize: %v", err)
+		}
+	}()
+	// A second connection that matched the same mock and is serving it too.
+	// Not reachable on today's consume path, but cheap insurance against a
+	// future non-consuming serve.
+	go func() {
+		defer wg.Done()
+		if _, err := h.BuildMockResponseBytesForTest(shared); err != nil {
+			t.Errorf("concurrent serialize: %v", err)
+		}
+	}()
+	// The losing connection, still inside updateMock. This is the exact read
+	// match.go:1269 performs; keep it a whole-struct copy, because narrowing it
+	// to one field would stop covering the racer.
+	go func() {
+		defer wg.Done()
+		deleteMock := *shared
+		_ = deleteMock.Name
+	}()
+
+	wg.Wait()
+
+	if !shared.HasSpilledResponse() {
+		t.Fatalf("serving cleared the hydrator on a shared pooled mock")
+	}
+	if shared.Spec.HTTPResp != nil {
+		t.Fatalf("serving wrote the loaded response back onto a shared pooled mock")
+	}
+}
+
+// A mock that never spilled must still serve, and must still not be written to.
+func TestServingAResidentMockDoesNotWriteToTheSharedMock(t *testing.T) {
+	resident := perTestHTTPMock("mock-small", "small body")
+	h := kphttp.NewForTest()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if _, err := h.BuildMockResponseBytesForTest(resident); err != nil {
+			t.Errorf("serialize: %v", err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		deleteMock := *resident
+		_ = deleteMock.Name
+	}()
+	wg.Wait()
+
+	if resident.Spec.HTTPResp == nil {
+		t.Fatalf("a resident mock's response must survive a serve")
+	}
+	var _ *models.Mock = resident
+}

--- a/pkg/agent/proxy/integrations/http/spilled_response_test.go
+++ b/pkg/agent/proxy/integrations/http/spilled_response_test.go
@@ -200,9 +200,16 @@ func TestBuildMockResponseBytesServesSpilledResponse(t *testing.T) {
 }
 
 // TestBuildMockResponseBytesSpilledIsIdempotent covers the fact that the fix
-// makes HydrateResponse run on EVERY serialize, including repeat serves of one
+// makes the spill load run on EVERY serialize, including repeat serves of one
 // mock. serveOnePassThroughMock deliberately does not consume its mock, so the
 // second call must produce the same bytes rather than an empty or errored body.
+//
+// It also pins the invariant that makes a repeat serve safe at all: serving
+// must not WRITE the loaded response back onto the mock. A pooled mock is
+// shared with every other connection goroutine, and updateMock dereferences it
+// whole by value (`deleteMock := *matchedMock`) while a serve is in flight, so
+// a write here is a data race with no happens-before edge. Idempotence comes
+// from re-reading the blob, not from caching it in Spec.
 func TestBuildMockResponseBytesSpilledIsIdempotent(t *testing.T) {
 	body := bodyOfSize(spillMinBytes + 1)
 	store, err := proxy.NewDiskMocks(zap.NewNop())
@@ -223,8 +230,11 @@ func TestBuildMockResponseBytesSpilledIsIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first serialize: %v", err)
 	}
-	if loaded[0].HasSpilledResponse() {
-		t.Fatalf("hydration should have cleared the hydrator after the first serve")
+	if !loaded[0].HasSpilledResponse() {
+		t.Fatalf("serving must not clear the hydrator on the shared pooled mock")
+	}
+	if loaded[0].Spec.HTTPResp != nil {
+		t.Fatalf("serving must not write the loaded response back onto the shared pooled mock")
 	}
 	second, err := h.BuildMockResponseBytesForTest(loaded[0])
 	if err != nil {

--- a/pkg/agent/proxy/integrations/http/spilled_response_test.go
+++ b/pkg/agent/proxy/integrations/http/spilled_response_test.go
@@ -1,0 +1,303 @@
+// Package http_test is the EXTERNAL test package for the HTTP integration. It
+// exists so a test can import pkg/agent/proxy (for the real DiskMocks store)
+// without the import cycle an internal `package http` test would create.
+package http_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy"
+	kphttp "go.keploy.io/server/v3/pkg/agent/proxy/integrations/http"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// spillMinBytes mirrors responseSpillMinBytes (pkg/agent/proxy/diskmocks.go).
+// It is unexported there, so the value is restated here — and every case below
+// asserts proxy.EligibleForResponseSpill agrees, so a retune of the real
+// constant fails this test loudly instead of silently testing nothing.
+const spillMinBytes = 8 * 1024
+
+// bodyOfSize returns a deterministic, non-uniform body of exactly n bytes. A
+// repeated single character would let a truncation or an off-by-one slip past
+// a hash comparison far too easily.
+func bodyOfSize(n int) string {
+	var b strings.Builder
+	b.Grow(n + 16)
+	for i := 0; b.Len() < n; i++ {
+		b.WriteString(strconv.Itoa(i))
+		b.WriteByte('-')
+	}
+	return b.String()[:n]
+}
+
+func sha(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+const hdrSep = "\r\n\r\n"
+
+// splitWire returns the status line, the SORTED header lines, and the body.
+// Sorting matters: buildMockResponseBytes emits headers by ranging over a Go
+// map, so their order is randomised per call. That is pre-existing behaviour
+// and out of scope here — but comparing two serialisations byte-for-byte
+// without normalising it would make this test flaky rather than meaningful.
+func splitWire(t *testing.T, wire string) (status string, headers []string, body string) {
+	t.Helper()
+	idx := strings.Index(wire, hdrSep)
+	if idx < 0 {
+		t.Fatalf("no header/body separator in serialized response")
+	}
+	head, body := wire[:idx], wire[idx+len(hdrSep):]
+	lines := strings.Split(head, "\r\n")
+	sorted := append([]string(nil), lines[1:]...)
+	sort.Strings(sorted)
+	return lines[0], sorted, body
+}
+
+// wireDigest is an order-insensitive fingerprint of a serialized response.
+func wireDigest(t *testing.T, wire string) string {
+	t.Helper()
+	status, headers, body := splitWire(t, wire)
+	return sha(status + "\n" + strings.Join(headers, "\n") + "\n" + sha(body))
+}
+
+// perTestHTTPMock builds a mock shaped exactly the way DiskMocks requires to
+// consider it for the disk tier: HTTP kind, per-test lifetime, and a valid
+// req<=res timestamp pair (see EligibleForDisk).
+func perTestHTTPMock(name, body string) *models.Mock {
+	req := time.Unix(1700000000, 0).UTC()
+	m := &models.Mock{
+		Name: name,
+		Kind: models.HTTP,
+		Spec: models.MockSpec{
+			ReqTimestampMock: req,
+			ResTimestampMock: req.Add(time.Millisecond),
+			HTTPReq:          &models.HTTPReq{ProtoMajor: 1, ProtoMinor: 1, Method: "GET", URL: "http://svc.example.com/big"},
+			HTTPResp: &models.HTTPResp{
+				StatusCode: 200,
+				Body:       body,
+				// A deliberately stale Content-Length: the serializer must
+				// recompute it from the HYDRATED body, not from the elided one.
+				Header: map[string]string{"Content-Type": "application/json", "Content-Length": "999"},
+			},
+		},
+	}
+	m.TestModeInfo.Lifetime = models.LifetimePerTest
+	return m
+}
+
+// TestBuildMockResponseBytesServesSpilledResponse is the B27 regression.
+//
+// A recorded HTTP response of at least responseSpillMinBytes is written to the
+// agent's per-test disk store as a SEPARATE blob, and the mock is re-encoded
+// with Spec.HTTPResp set to nil plus a lazy responseHydrator (DiskMocks.Add /
+// readAt). buildMockResponseBytes used to check `Spec.HTTPResp == nil` BEFORE
+// calling HydrateResponse, so every spilled mock was rejected with
+// "has no response to serialize" and the client got a hard mock-miss instead
+// of its recorded response.
+//
+// The three sizes bracket the threshold so the boundary itself is pinned.
+func TestBuildMockResponseBytesServesSpilledResponse(t *testing.T) {
+	cases := []struct {
+		name      string
+		size      int
+		wantSpill bool
+	}{
+		{"just_under_threshold", spillMinBytes - 1, false},
+		{"exactly_at_threshold", spillMinBytes, true},
+		{"just_over_threshold", spillMinBytes + 1, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := bodyOfSize(tc.size)
+			if len(body) != tc.size {
+				t.Fatalf("body builder produced %d bytes, want %d", len(body), tc.size)
+			}
+			m := perTestHTTPMock("mock-big", body)
+
+			if got := proxy.EligibleForResponseSpill(m); got != tc.wantSpill {
+				t.Fatalf("EligibleForResponseSpill(body=%d B) = %v, want %v -- the "+
+					"responseSpillMinBytes threshold moved; retune spillMinBytes here",
+					tc.size, got, tc.wantSpill)
+			}
+
+			// Expected wire bytes: the SAME mock serialized while fully
+			// resident, i.e. what replay produced before HTTP was routed into
+			// the disk tier. Spilling must be byte-transparent against this.
+			h := kphttp.NewForTest()
+			want, err := h.BuildMockResponseBytesForTest(perTestHTTPMock("mock-big", body))
+			if err != nil {
+				t.Fatalf("resident baseline failed to serialize: %v", err)
+			}
+
+			store, err := proxy.NewDiskMocks(zap.NewNop())
+			if err != nil {
+				t.Fatalf("NewDiskMocks: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			if err := store.Add(m); err != nil {
+				t.Fatalf("DiskMocks.Add: %v", err)
+			}
+			loaded, err := store.LoadByNames([]string{"mock-big"})
+			if err != nil {
+				t.Fatalf("LoadByNames: %v", err)
+			}
+			if len(loaded) != 1 {
+				t.Fatalf("LoadByNames returned %d mocks, want 1", len(loaded))
+			}
+			got := loaded[0]
+
+			// Confirm the load really did (or did not) elide the response, so
+			// a passing test can never mean "the spill path was never taken".
+			if got.HasSpilledResponse() != tc.wantSpill {
+				t.Fatalf("loaded mock HasSpilledResponse() = %v, want %v", got.HasSpilledResponse(), tc.wantSpill)
+			}
+			if tc.wantSpill && got.Spec.HTTPResp != nil {
+				t.Fatalf("a spilled mock must arrive with Spec.HTTPResp elided, got non-nil")
+			}
+			if !tc.wantSpill && got.Spec.HTTPResp == nil {
+				t.Fatalf("an unspilled mock must arrive with its response inline, got nil")
+			}
+
+			// THE REGRESSION: on the broken ordering this returns
+			// `http: mock "mock-big" has no response to serialize`.
+			out, err := h.BuildMockResponseBytesForTest(got)
+			if err != nil {
+				t.Fatalf("serialize spilled mock: %v", err)
+			}
+
+			if got, wantD := wireDigest(t, string(out)), wireDigest(t, string(want)); got != wantD {
+				t.Fatalf("served response differs from the resident baseline:\n"+
+					" got %d B digest=%s\nwant %d B digest=%s",
+					len(out), got, len(want), wantD)
+			}
+
+			// Byte-identity of the body itself, and the recomputed
+			// Content-Length, spelled out so a failure names the cause.
+			_, gotHeaders, gotBody := splitWire(t, string(out))
+			if sha(gotBody) != sha(body) {
+				t.Fatalf("body not byte-identical: got %d B sha=%s, want %d B sha=%s",
+					len(gotBody), sha(gotBody), len(body), sha(body))
+			}
+			wantCL := fmt.Sprintf("Content-Length: %d", tc.size)
+			if !slices.Contains(gotHeaders, wantCL) {
+				t.Fatalf("Content-Length not recomputed from the hydrated body: want %q in %v", wantCL, gotHeaders)
+			}
+		})
+	}
+}
+
+// TestBuildMockResponseBytesSpilledIsIdempotent covers the fact that the fix
+// makes HydrateResponse run on EVERY serialize, including repeat serves of one
+// mock. serveOnePassThroughMock deliberately does not consume its mock, so the
+// second call must produce the same bytes rather than an empty or errored body.
+func TestBuildMockResponseBytesSpilledIsIdempotent(t *testing.T) {
+	body := bodyOfSize(spillMinBytes + 1)
+	store, err := proxy.NewDiskMocks(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDiskMocks: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	if err := store.Add(perTestHTTPMock("mock-big", body)); err != nil {
+		t.Fatalf("DiskMocks.Add: %v", err)
+	}
+	loaded, err := store.LoadByNames([]string{"mock-big"})
+	if err != nil || len(loaded) != 1 {
+		t.Fatalf("LoadByNames: %v (n=%d)", err, len(loaded))
+	}
+
+	h := kphttp.NewForTest()
+	first, err := h.BuildMockResponseBytesForTest(loaded[0])
+	if err != nil {
+		t.Fatalf("first serialize: %v", err)
+	}
+	if loaded[0].HasSpilledResponse() {
+		t.Fatalf("hydration should have cleared the hydrator after the first serve")
+	}
+	second, err := h.BuildMockResponseBytesForTest(loaded[0])
+	if err != nil {
+		t.Fatalf("second serialize: %v", err)
+	}
+	if a, b := wireDigest(t, string(first)), wireDigest(t, string(second)); a != b {
+		t.Fatalf("repeat serve of the same mock changed the response: %s vs %s", a, b)
+	}
+	if _, _, body2 := splitWire(t, string(second)); sha(body2) != sha(body) {
+		t.Fatalf("repeat serve did not return the recorded body")
+	}
+}
+
+// TestBuildMockResponseBytesSpilledAfterStoreClosed pins the teardown ordering.
+// finalizeClientMocks closes a superseded generation's DiskMocks file, so an
+// in-flight serve can reach a hydrator whose store is gone. That must surface
+// as an error (the caller then reports a mock-miss), never as a panic and never
+// as a silently empty body written to the client.
+func TestBuildMockResponseBytesSpilledAfterStoreClosed(t *testing.T) {
+	body := bodyOfSize(spillMinBytes + 1)
+	store, err := proxy.NewDiskMocks(zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewDiskMocks: %v", err)
+	}
+	if err := store.Add(perTestHTTPMock("mock-big", body)); err != nil {
+		t.Fatalf("DiskMocks.Add: %v", err)
+	}
+	loaded, err := store.LoadByNames([]string{"mock-big"})
+	if err != nil || len(loaded) != 1 {
+		t.Fatalf("LoadByNames: %v (n=%d)", err, len(loaded))
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	out, err := kphttp.NewForTest().BuildMockResponseBytesForTest(loaded[0])
+	if err == nil {
+		t.Fatalf("serializing a spilled mock after store close must fail, got %d bytes", len(out))
+	}
+	if out != nil {
+		t.Fatalf("failed serialize must return nil bytes, got %d", len(out))
+	}
+	if !strings.Contains(err.Error(), "store closed") {
+		t.Fatalf("want a store-closed error, got: %v", err)
+	}
+}
+
+// TestBuildMockResponseBytesStillRejectsGenuinelyMissingResponse guards the
+// other half of the reorder: HydrateResponse is a NO-OP when the mock was never
+// spilled, so a mock whose response is absent for any other reason must still
+// be rejected rather than sliding into a nil dereference.
+func TestBuildMockResponseBytesStillRejectsGenuinelyMissingResponse(t *testing.T) {
+	h := kphttp.NewForTest()
+
+	t.Run("nil_response_no_hydrator", func(t *testing.T) {
+		m := perTestHTTPMock("mock-empty", "x")
+		m.Spec.HTTPResp = nil
+		if m.HasSpilledResponse() {
+			t.Fatalf("precondition: this mock must not carry a hydrator")
+		}
+		out, err := h.BuildMockResponseBytesForTest(m)
+		if err == nil {
+			t.Fatalf("want an error for a mock with no response, got %d bytes", len(out))
+		}
+		if !strings.Contains(err.Error(), "no response to serialize") {
+			t.Fatalf("want the no-response error, got: %v", err)
+		}
+	})
+
+	t.Run("nil_mock", func(t *testing.T) {
+		out, err := h.BuildMockResponseBytesForTest(nil)
+		if err == nil {
+			t.Fatalf("want an error for a nil mock, got %d bytes", len(out))
+		}
+	})
+}

--- a/pkg/agent/proxy/scoped_mockdb.go
+++ b/pkg/agent/proxy/scoped_mockdb.go
@@ -77,6 +77,25 @@ func (s *scopedMockDb) keep(mocks []*models.Mock, err error) ([]*models.Mock, er
 			out = append(out, m)
 			continue
 		}
+		// Rule-1 mocks — CORS preflights, MySQL connection-alive commands —
+		// are reusable by nature: the recorded response is a property of the
+		// endpoint, not of the test that happened to trigger it.
+		// correlateScopes buckets a capture into a test's mapping by request
+		// TIMESTAMP alone, so one lands in whichever test's window it fired
+		// in and every other worker would lose it. For a preflight that is
+		// starvation the browser reports as net::ERR_FAILED.
+		//
+		// Keyed off the derivation reason (models.Mock.IsSharedAcrossTests),
+		// NOT off Lifetime: rules 4 and 5 make most of the pool
+		// session-lifetime for reasons that say nothing about reusability,
+		// and exempting those would make worker isolation a no-op. This grants
+		// read VISIBILITY only — the matcher routes session mocks to
+		// UpdateUnFilteredMock, never DeleteFilteredMock, so a worker still
+		// cannot consume another worker's mock.
+		if m.IsSharedAcrossTests() {
+			out = append(out, m)
+			continue
+		}
 		if _, mapped := s.universe[m.Name]; !mapped {
 			out = append(out, m) // shared / unmapped mock — visible to everyone
 		}

--- a/pkg/agent/proxy/scoped_mockdb_test.go
+++ b/pkg/agent/proxy/scoped_mockdb_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"os"
 	"runtime"
+	"slices"
 	"testing"
 	"time"
 
@@ -182,5 +183,97 @@ func TestScopedMockDb_StartupTierIsScopedToTheWorker(t *testing.T) {
 	}
 	if !containsMockNamed(startup, "mock-A") {
 		t.Fatal("worker A cannot see its own mock")
+	}
+}
+
+// A CORS preflight recorded inside test_A's window is attributed to test_A in
+// mappings.yaml, because correlateScopes buckets by request timestamp alone and
+// never looks at Lifetime. That puts its name in `universe`. A worker running
+// test_B does not own it, so name-only filtering drops it — and test_B's
+// browser preflight then finds no mock and fails CORS with net::ERR_FAILED.
+//
+// A preflight's recorded response is the endpoint's allow-policy, not test_A's
+// property, so it must survive. Same for a MySQL connection-alive command.
+func TestScopedMockDb_KeepsASharedPreflightAnotherTestOwns(t *testing.T) {
+	preflight := &models.Mock{
+		Name: "preflight-options-query",
+		Kind: models.HTTP,
+		Spec: models.MockSpec{
+			Metadata: map[string]string{"type": "HTTP_CLIENT"},
+			HTTPReq: &models.HTTPReq{
+				Method: models.Method("OPTIONS"),
+				URL:    "/query",
+				Header: map[string]string{"Access-Control-Request-Method": "POST"},
+			},
+			HTTPResp: &models.HTTPResp{StatusCode: 204},
+		},
+	}
+	preflight.DeriveLifetime()
+	if preflight.TestModeInfo.Lifetime != models.LifetimeSession {
+		t.Fatalf("precondition: a preflight should derive to session, got %v", preflight.TestModeInfo.Lifetime)
+	}
+	if !preflight.IsSharedAcrossTests() {
+		t.Fatalf("precondition: a preflight is a rule-1 override")
+	}
+
+	dataMock := &models.Mock{Name: "test-A-post-query", Kind: models.HTTP}
+	db := &fakeMockDb{mocks: []*models.Mock{preflight, dataMock}}
+
+	// mappings.yaml says test_A owns both. This worker is running test_B.
+	workerB := &scopedMockDb{
+		MockMemDb: db,
+		allow:     map[string]struct{}{"test-B-get-query": {}},
+		universe: map[string]struct{}{
+			"preflight-options-query": {},
+			"test-A-post-query":       {},
+		},
+	}
+
+	got, err := workerB.GetSessionMocks()
+	if err != nil {
+		t.Fatalf("GetSessionMocks: %v", err)
+	}
+	names := scopedNames(got)
+	if !slices.Contains(names, "preflight-options-query") {
+		t.Fatalf("a CORS preflight is the endpoint's allow-policy and must be visible to every worker; got %v", names)
+	}
+	if slices.Contains(names, "test-A-post-query") {
+		t.Fatalf("test A's data mock must STILL be hidden — the fix is not 'exempt every session mock'; got %v", names)
+	}
+}
+
+// CONTROL. An untagged legacy HTTP mock derives to session via rule 4, but it
+// is ordinary data-plane traffic owned by one test. If keep() exempted mocks by
+// Lifetime instead of by derivation reason, worker isolation would become a
+// no-op for every pre-tag recording. This must pass before AND after.
+func TestScopedMockDb_StillHidesATierPromotedSessionMock(t *testing.T) {
+	legacy := &models.Mock{
+		Name: "test-A-untagged-get",
+		Kind: models.HTTP,
+		Spec: models.MockSpec{
+			HTTPReq:  &models.HTTPReq{Method: models.Method("GET"), URL: "/items"},
+			HTTPResp: &models.HTTPResp{StatusCode: 200},
+		},
+	}
+	legacy.DeriveLifetime()
+	if legacy.TestModeInfo.Lifetime != models.LifetimeSession {
+		t.Fatalf("precondition: rule 4 promotes untagged HTTP to session, got %v", legacy.TestModeInfo.Lifetime)
+	}
+	if legacy.IsSharedAcrossTests() {
+		t.Fatalf("precondition: session-by-tiering is NOT session-by-semantics")
+	}
+
+	db := &fakeMockDb{mocks: []*models.Mock{legacy}}
+	workerB := &scopedMockDb{
+		MockMemDb: db,
+		allow:     map[string]struct{}{"test-B-get-query": {}},
+		universe:  map[string]struct{}{"test-A-untagged-get": {}},
+	}
+	got, err := workerB.GetSessionMocks()
+	if err != nil {
+		t.Fatalf("GetSessionMocks: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("a tier-promoted session mock owned by another test must stay hidden; got %v", scopedNames(got))
 	}
 }

--- a/pkg/agent/proxy/upstream_dial_nil_test.go
+++ b/pkg/agent/proxy/upstream_dial_nil_test.go
@@ -1,0 +1,128 @@
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/agent/proxy/util"
+	"go.uber.org/zap"
+)
+
+// closedTCPPort returns an address that is guaranteed to refuse connections:
+// bind an ephemeral port, note it, then close the listener.
+func closedTCPPort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	return addr
+}
+
+// TestTLSDialReturnsTypedNil pins the stdlib hazard these tests exist for.
+//
+// tls.Dial's declared result is the CONCRETE *tls.Conn, so `dstConn, err =
+// tls.Dial(...)` leaves dstConn a non-nil net.Conn interface holding a nil
+// pointer when the dial fails. handleConnection declares `var dstConn
+// net.Conn` and registers a deferred `if dstConn != nil { dstConn.Close() }`
+// before dialing, so that guard passes and (*tls.Conn).Close dereferences a
+// nil receiver — losing that connection's captured traffic while the run
+// still reports success.
+func TestTLSDialReturnsTypedNil(t *testing.T) {
+	var raw net.Conn
+	var err error
+	raw, err = tls.Dial("tcp", closedTCPPort(t), &tls.Config{InsecureSkipVerify: true}) // nolint:gosec
+	if err == nil {
+		t.Fatalf("expected the dial to a closed port to fail")
+	}
+	if raw == nil {
+		t.Skipf("tls.Dial no longer yields a typed nil; these guards may be obsolete")
+	}
+	if _, ok := raw.(*tls.Conn); !ok {
+		t.Fatalf("expected the typed nil to be a *tls.Conn, got %T", raw)
+	}
+}
+
+// TestDialDestinationTLSFailedDialIsNilInterface is the assertion that keeps
+// the hazard above out of handleConnection.
+//
+// The upstream TLS dial sites go through util.DialDestinationTLS, which builds
+// on tls.Dialer rather than tls.Dial. tls.Dialer.DialContext returns an
+// interface and explicitly refuses to put a typed nil in it ("Don't return c
+// (a typed nil) in an interface", crypto/tls/tls.go), and every error return
+// in DialDestinationWith is either that value or an explicit nil.
+//
+// Nothing pins this today: the util package's own tests cover the loopback
+// family fallback, not the nil shape. Switch either helper back to tls.Dial
+// and the panic returns silently — this is what catches that.
+func TestDialDestinationTLSFailedDialIsNilInterface(t *testing.T) {
+	conn, err := util.DialDestinationTLS(context.Background(), zap.NewNop(), "tcp",
+		util.DialTarget{Addr: closedTCPPort(t)}, &tls.Config{InsecureSkipVerify: true}) // nolint:gosec
+	if err == nil {
+		t.Fatalf("expected the dial to a closed port to fail")
+	}
+	if conn != nil {
+		t.Fatalf("a failed dial must yield a nil net.Conn interface, got %T", conn)
+	}
+}
+
+// TestUpstreamDialFailureDeferredCloseDoesNotPanic reproduces the panic in
+// miniature: the same declare / defer-guarded-close / dial ordering
+// handleConnection uses. With a typed nil this panicked on the deferred close,
+// which util.Recover turned into "Recovered from panic in parser, closing
+// active connections" — one connection's recording lost per occurrence.
+func TestUpstreamDialFailureDeferredCloseDoesNotPanic(t *testing.T) {
+	addr := closedTCPPort(t)
+
+	dialErr := func() (err error) {
+		var dstConn net.Conn
+		defer func() {
+			if dstConn != nil {
+				_ = dstConn.Close()
+			}
+		}()
+		dstConn, err = util.DialDestinationTLS(context.Background(), zap.NewNop(), "tcp",
+			util.DialTarget{Addr: addr}, &tls.Config{InsecureSkipVerify: true}) // nolint:gosec
+		if err != nil {
+			return err
+		}
+		return nil
+	}()
+
+	if dialErr == nil {
+		t.Fatalf("expected the dial to a closed port to fail")
+	}
+}
+
+// TestDialDestinationTLSSuccess guards against the nil-safety above being
+// bought by swallowing a good connection.
+func TestDialDestinationTLSSuccess(t *testing.T) {
+	ln, _ := newTLSTestServer(t, 0, []string{"http/1.1"}, nil)
+	defer ln.Close()
+
+	cfg := &tls.Config{
+		InsecureSkipVerify: true, // nolint:gosec
+		ServerName:         "test.local",
+		NextProtos:         []string{"http/1.1"},
+	}
+
+	conn, err := util.DialDestinationTLS(context.Background(), zap.NewNop(), "tcp",
+		util.DialTarget{Addr: ln.Addr().String()}, cfg)
+	if err != nil {
+		t.Fatalf("DialDestinationTLS: %v", err)
+	}
+	if conn == nil {
+		t.Fatalf("expected a non-nil conn on success")
+	}
+	defer conn.Close()
+
+	if _, ok := conn.(*tls.Conn); !ok {
+		t.Fatalf("expected a *tls.Conn, got %T", conn)
+	}
+}

--- a/pkg/agent/routes/scope.go
+++ b/pkg/agent/routes/scope.go
@@ -17,7 +17,7 @@ import (
 // agent.Service interface stays unchanged (same pattern as BeginTestErrorCapture).
 
 type scopeBeginner interface {
-	BeginScope(ctx context.Context, name string, pid int) error
+	BeginScope(ctx context.Context, name string, pid int) (models.ScopeAck, error)
 }
 type scopeEnder interface {
 	EndScope(ctx context.Context, name string, pid int) error
@@ -42,15 +42,21 @@ func (a *Agent) HandleScopeBegin(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
+	ack := models.ScopeAck{Reason: models.ScopeReasonUnsupported}
 	if s, ok := a.svc.(scopeBeginner); ok {
-		if err := s.BeginScope(r.Context(), req.Name, req.Pid); err != nil {
+		got, err := s.BeginScope(r.Context(), req.Name, req.Pid)
+		if err != nil {
 			a.logger.Debug("scope begin failed", zap.String("name", req.Name), zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		ack = got
 	}
+	// "status" is kept so a runner written against the original contract is
+	// unaffected; scoped/mocks/reason say whether the call did anything.
+	ack.Status = "ok"
 	render.Status(r, http.StatusOK)
-	render.JSON(w, r, map[string]string{"status": "ok"})
+	render.JSON(w, r, ack)
 }
 
 // HandleScopeEnd marks the end of a named per-test scope.

--- a/pkg/agent/routes/scope_test.go
+++ b/pkg/agent/routes/scope_test.go
@@ -1,0 +1,118 @@
+package routes
+
+// The /agent/scope/begin response is the contract a user's test runner reads.
+// These tests pin two things at once: the new fields are present, AND the
+// original `{"status":"ok"}` key survives so a runner written against the old
+// contract keeps working.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/service/agent"
+	"go.uber.org/zap"
+)
+
+// stubScopeSvc satisfies agent.Service via the embedded nil interface and
+// implements only BeginScope, which is all HandleScopeBegin calls.
+type stubScopeSvc struct {
+	agent.Service
+	ack models.ScopeAck
+	err error
+}
+
+func (s *stubScopeSvc) BeginScope(_ context.Context, _ string, _ int) (models.ScopeAck, error) {
+	return s.ack, s.err
+}
+
+func postScopeBegin(t *testing.T, svc agent.Service, body string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	a := &Agent{logger: zap.NewNop(), svc: svc}
+	req := httptest.NewRequest(http.MethodPost, "/agent/scope/begin", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	a.HandleScopeBegin(rr, req)
+
+	var decoded map[string]any
+	if rr.Code == http.StatusOK {
+		if err := json.Unmarshal(rr.Body.Bytes(), &decoded); err != nil {
+			t.Fatalf("response is not JSON: %v (%s)", err, rr.Body.String())
+		}
+	}
+	return rr, decoded
+}
+
+// A scoped begin reports scoped=true with the pool size, and still carries
+// status=ok.
+func TestHandleScopeBeginRendersAck(t *testing.T) {
+	svc := &stubScopeSvc{ack: models.ScopeAck{Scoped: true, Mocks: 3, Reason: models.ScopeReasonPoolRestricted}}
+	rr, got := postScopeBegin(t, svc, `{"name":"alpha"}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rr.Code)
+	}
+	if got["status"] != "ok" {
+		t.Fatalf("the original contract key must survive; got %v", got["status"])
+	}
+	if got["scoped"] != true {
+		t.Fatalf("scoped: got %v, want true", got["scoped"])
+	}
+	if got["mocks"] != float64(3) {
+		t.Fatalf("mocks: got %v, want 3", got["mocks"])
+	}
+	if got["reason"] != models.ScopeReasonPoolRestricted {
+		t.Fatalf("reason: got %v", got["reason"])
+	}
+}
+
+// The case the whole change exists for: the agent silently served the whole
+// suite, and the runner can now see it. Before, this body was byte-identical to
+// the scoped one above.
+func TestHandleScopeBeginReportsUnscoped(t *testing.T) {
+	svc := &stubScopeSvc{ack: models.ScopeAck{Reason: models.ScopeReasonUnmappedScope}}
+	rr, got := postScopeBegin(t, svc, `{"name":"renamed"}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("an unscoped begin is not an error; got %d", rr.Code)
+	}
+	if got["status"] != "ok" {
+		t.Fatalf("status must stay ok for backward compatibility; got %v", got["status"])
+	}
+	if got["scoped"] != false {
+		t.Fatalf("scoped: got %v, want false", got["scoped"])
+	}
+	if got["reason"] != models.ScopeReasonUnmappedScope {
+		t.Fatalf("reason: got %v", got["reason"])
+	}
+}
+
+// A service that predates the scope API (no BeginScope method) must still get a
+// 200 with status=ok, and say that it has no scope support rather than claiming
+// the test was isolated.
+func TestHandleScopeBeginServiceWithoutScopeSupport(t *testing.T) {
+	rr, got := postScopeBegin(t, nil, `{"name":"alpha"}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rr.Code)
+	}
+	if got["status"] != "ok" || got["scoped"] != false {
+		t.Fatalf("got %v", got)
+	}
+	if got["reason"] != models.ScopeReasonUnsupported {
+		t.Fatalf("reason: got %v, want %q", got["reason"], models.ScopeReasonUnsupported)
+	}
+}
+
+// An error from BeginScope still fails the request — the ack reports "did the
+// scoping take effect", not "did the call error".
+func TestHandleScopeBeginPropagatesError(t *testing.T) {
+	svc := &stubScopeSvc{err: context.DeadlineExceeded}
+	rr, _ := postScopeBegin(t, svc, `{"name":"alpha"}`)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500", rr.Code)
+	}
+}

--- a/pkg/models/agent.go
+++ b/pkg/models/agent.go
@@ -50,6 +50,50 @@ type ScopeWindow struct {
 	PID uint32 `json:"pid,omitempty"`
 }
 
+// ScopeAck is the body of POST /agent/scope/begin. Status is retained verbatim
+// for callers written against the original `{"status":"ok"}` contract; the
+// remaining fields report whether the call actually took effect, so a test
+// runner can assert it in one line instead of reading the agent's debug log.
+//
+// Scoped is true only when the served mock pool was genuinely narrowed to this
+// scope (replay). It is therefore false for every record-mode call — recording
+// serves nothing — and Reason names which case it was.
+type ScopeAck struct {
+	Status string `json:"status"`
+	Scoped bool   `json:"scoped"`
+	// Mocks is how many recordings mappings.yaml attributes to THIS scope --
+	// the count of mapped names, not the number of mocks the agent went on to
+	// stage (the served pool also carries recordings no test owns, as overflow).
+	// It is the useful number for a runner: it knows how many dependency calls
+	// its test makes, so a short count is how a truncated mapping shows up --
+	// most often a second scope/begin at record with no end between, which
+	// resets the window and orphans everything captured before it.
+	Mocks  int    `json:"mocks"`
+	Reason string `json:"reason"`
+}
+
+// Reason values for ScopeAck. Stable tokens — test runners branch on them.
+const (
+	// Replay, narrowed. Scoped=true.
+	ScopeReasonPoolRestricted = "pool_restricted" // pid==0, single global pool
+	ScopeReasonWorkerScoped   = "worker_scoped"   // pid>0, this worker's view only
+
+	// Replay, NOT narrowed. Scoped=false — the whole set is being served.
+	ScopeReasonNoMappingTable = "no_mapping_table" // no mappings.yaml, so no scope table was installed
+	ScopeReasonUnmappedScope  = "unmapped_scope"   // table installed, this name absent from it
+	ScopeReasonEmptyMapping   = "empty_mapping"    // name present but mapped to zero mocks
+
+	// Record. Nothing is served, so Scoped is always false.
+	ScopeReasonRecordWindowOpened = "record_window_opened"
+	// ScopeReasonRecordAlreadyOpen: a second begin for a scope that was never
+	// ended. The window start is reset, so anything captured before this call
+	// is attributed to no test and disappears from mappings.yaml.
+	ScopeReasonRecordAlreadyOpen = "record_scope_already_open"
+
+	ScopeReasonEmptyName   = "empty_name"  // no name supplied; the call is a no-op
+	ScopeReasonUnsupported = "unsupported" // this agent build has no scope support
+)
+
 // ScopeTableReq is the body of POST /agent/scope/table — the replay CLI hands
 // the agent the per-test name→mock-names table (from mappings.yaml) so the
 // runner's /agent/scope/begin calls can restrict the served pool per test.

--- a/pkg/models/lifetime.go
+++ b/pkg/models/lifetime.go
@@ -150,7 +150,7 @@ func (m *Mock) DeriveLifetime() {
 	// know is input-independent. COM_QUERY / COM_INIT_DB /
 	// COM_CHANGE_USER / COM_SET_OPTION all depend on input and must
 	// stay per-test.
-	if m.Kind == MySQL && mysqlIsSessionReusableCommand(m) {
+	if m.IsSharedAcrossTests() {
 		m.TestModeInfo.Lifetime = LifetimeSession
 		return
 	}
@@ -176,29 +176,28 @@ func (m *Mock) DeriveLifetime() {
 	// request in them fails the browser's CORS check with
 	// net::ERR_FAILED.
 	//
-	// What session lifetime does and does not fix. It exempts the mock
-	// from consumption on match, from window filtering, and from the
-	// mapping-based narrowing that `scope/begin` applies when the runner
-	// reports no worker PID — that last one is why this override repairs
-	// this, because FilterConfigMocksMapping returns the whole session
-	// pool while FilterTcsMocksMapping returns only in-mapping mocks
-	// (see pkg/util.go). It does NOT exempt the mock from per-PID worker
-	// scoping: scopedMockDb.keep is Lifetime-blind and wraps the session
-	// readers too, so a preflight the current worker does not own is
-	// still dropped and the preflight starvation reproduces there.
+	// What session lifetime buys. It exempts the mock from consumption on
+	// match, from window filtering, and from the mapping-based narrowing
+	// that `scope/begin` applies when the runner reports no worker PID —
+	// FilterConfigMocksMapping returns the whole session pool while
+	// FilterTcsMocksMapping returns only in-mapping mocks (pkg/util.go).
 	//
-	// The gate for that residual case is ScopeReq.Pid > 0, NOT a worker
-	// count — keploy has no notion of how many workers a runner uses. A
-	// SINGLE-worker runner that reports its PID takes the same path and
-	// hits the same drop. Today's Playwright fixture happens to omit the
-	// pid, which is the only reason this override is sufficient for it;
-	// start sending a pid and this caveat applies immediately, at any
-	// worker count. Making keep() Lifetime-aware is the fix, and is
-	// deliberately out of scope here.
-	if m.Kind == HTTP && httpIsCORSPreflight(m) {
-		m.TestModeInfo.Lifetime = LifetimeSession
-		return
-	}
+	// That covers the pid == 0 path only. When a runner DOES report a PID,
+	// scope/begin installs the per-worker filter instead, and that filter
+	// matches on mock NAMES: correlateScopes buckets a capture into a test's
+	// mapping by request timestamp alone, so a preflight lands in whichever
+	// test's window it fired in and every other worker would lose it. The
+	// gate is ScopeReq.Pid > 0, not a worker count — a SINGLE-worker runner
+	// that reports its pid takes the same path.
+	//
+	// That is why the override is expressed as IsSharedAcrossTests rather
+	// than written inline here: scopedMockDb.keep consults the same
+	// predicate, so both paths agree on which mocks are reusable. Add a
+	// third rule-1 override and the scoping filter honours it with no second
+	// edit.
+	// Rule 1(b) is folded into the IsSharedAcrossTests call above, which
+	// covers both protocol overrides; the comment block here documents why the
+	// HTTP arm exists.
 	tag := ""
 	if m.Spec.Metadata != nil {
 		tag = m.Spec.Metadata["type"]
@@ -478,6 +477,36 @@ func mysqlIsSessionReusableCommand(m *Mock) bool {
 func IsMySQLSessionReusableCommandType(cmdType string) bool {
 	switch cmdType {
 	case "COM_PING", "COM_STATISTICS", "COM_DEBUG", "COM_RESET_CONNECTION":
+		return true
+	}
+	return false
+}
+
+// IsSharedAcrossTests reports whether DeriveLifetime's rule-1 protocol
+// overrides classify this mock as semantically reusable: its recorded response
+// is a property of the ENDPOINT, not of whichever test happened to trigger it.
+// A MySQL connection-alive command and a browser CORS preflight both qualify —
+// the answer does not depend on the caller.
+//
+// Deliberately NARROWER than Lifetime == LifetimeSession, and that gap is the
+// whole point. Most session mocks are session because of the tiering
+// fallbacks — rule 4 (untagged legacy recordings) and rule 5 (the lax-mode
+// promotion by kind) — which say nothing about reusability; under the default
+// lax mode that is the entire MySQL/Postgres/Generic/DNS data plane. Per-worker
+// scoping (pkg/agent/proxy/scoped_mockdb.go) must keep hiding those from other
+// workers, so it consults this predicate instead of Lifetime.
+//
+// Keep this the single definition of "rule 1 fired": DeriveLifetime calls it
+// too, so a future override added here is honoured by the scoping filter
+// automatically rather than needing a second edit someone will miss.
+func (m *Mock) IsSharedAcrossTests() bool {
+	if m == nil {
+		return false
+	}
+	switch {
+	case m.Kind == MySQL && mysqlIsSessionReusableCommand(m):
+		return true
+	case m.Kind == HTTP && httpIsCORSPreflight(m):
 		return true
 	}
 	return false

--- a/pkg/models/lifetime.go
+++ b/pkg/models/lifetime.go
@@ -88,13 +88,18 @@ func (l Lifetime) String() string {
 //     its Metadata["type"] tag.
 //
 // Precedence (applied top-to-bottom; first match wins):
-//  1. Kind == MySQL AND first request is a connection-alive command
-//     with an input-independent response (COM_PING, COM_STATISTICS,
-//     COM_DEBUG, COM_RESET_CONNECTION) → LifetimeSession. Applied
-//     BEFORE the tag switch so an explicitly-tagged "mocks" mock from
-//     the recorder is still promoted to session when semantically
-//     reusable — this is how HikariCP startup COM_PING mocks survive
-//     strict-window pre-filtering.
+//  1. Protocol-specific overrides, applied BEFORE the tag switch so an
+//     explicitly-tagged per-test mock from a recorder is still promoted
+//     to session when its response is semantically input-independent
+//     — both cases below resolve to LifetimeSession. (a) Kind == MySQL
+//     AND first request is a connection-alive command (COM_PING,
+//     COM_STATISTICS, COM_DEBUG, COM_RESET_CONNECTION): this is how
+//     HikariCP startup COM_PING mocks tagged "mocks" survive
+//     strict-window pre-filtering. (b) Kind == HTTP AND the recorded
+//     request is a browser CORS preflight (method OPTIONS + an
+//     Access-Control-Request-Method header), so the HTTP recorder's
+//     per-test "HTTP_CLIENT" tag cannot make a preflight consumable or
+//     test-scoped; see httpIsCORSPreflight.
 //  2. Spec.Metadata["type"] == "config"       → LifetimeSession
 //  3. Spec.Metadata["type"] == "connection"   → LifetimeConnection
 //     (requires non-empty connID; falls back to Session if missing).
@@ -146,6 +151,51 @@ func (m *Mock) DeriveLifetime() {
 	// COM_CHANGE_USER / COM_SET_OPTION all depend on input and must
 	// stay per-test.
 	if m.Kind == MySQL && mysqlIsSessionReusableCommand(m) {
+		m.TestModeInfo.Lifetime = LifetimeSession
+		return
+	}
+
+	// Rule 1(b): same tier as the MySQL override above, for HTTP. A CORS
+	// preflight is input-independent in exactly the sense COM_PING is:
+	// the browser sends `OPTIONS <path>` with
+	// Access-Control-Request-Method/-Headers and no body, and the server
+	// answers with the allow-policy for that endpoint. The reply is a
+	// property of the endpoint, not of the test that happened to trigger
+	// it, so it is legitimately reusable across tests and across
+	// connections.
+	//
+	// Why the override is needed: the HTTP recorder tags
+	// every capture Spec.Metadata["type"] = "HTTP_CLIENT", and HTTP is
+	// deliberately excluded from rule 5's lax promotion (see
+	// kindsWithLaxTaggedSessionPromotion) so HTTP data mocks stay per-test
+	// and are consumed on match. Preflights inherited that classification:
+	// consumed on first match AND visible only inside the owning test's
+	// mock pool. In the recording that surfaced this, only 3 of 6
+	// tests own any of the 8 recorded OPTIONS mocks, so the other 3 replay
+	// as "no matching mock found for OPTIONS /query" and every preflighted
+	// request in them fails the browser's CORS check with
+	// net::ERR_FAILED.
+	//
+	// What session lifetime does and does not fix. It exempts the mock
+	// from consumption on match, from window filtering, and from the
+	// mapping-based narrowing that `scope/begin` applies when the runner
+	// reports no worker PID — that last one is why this override repairs
+	// this, because FilterConfigMocksMapping returns the whole session
+	// pool while FilterTcsMocksMapping returns only in-mapping mocks
+	// (see pkg/util.go). It does NOT exempt the mock from per-PID worker
+	// scoping: scopedMockDb.keep is Lifetime-blind and wraps the session
+	// readers too, so a preflight the current worker does not own is
+	// still dropped and the preflight starvation reproduces there.
+	//
+	// The gate for that residual case is ScopeReq.Pid > 0, NOT a worker
+	// count — keploy has no notion of how many workers a runner uses. A
+	// SINGLE-worker runner that reports its PID takes the same path and
+	// hits the same drop. Today's Playwright fixture happens to omit the
+	// pid, which is the only reason this override is sufficient for it;
+	// start sending a pid and this caveat applies immediately, at any
+	// worker count. Making keep() Lifetime-aware is the fix, and is
+	// deliberately out of scope here.
+	if m.Kind == HTTP && httpIsCORSPreflight(m) {
 		m.TestModeInfo.Lifetime = LifetimeSession
 		return
 	}
@@ -218,7 +268,10 @@ func (m *Mock) DeriveLifetime() {
 	// kind-based session fallback for any non-canonical tag when
 	// the kind is in the implicit-session list. Strict mode takes
 	// the narrow path above and returns before reaching here.
-	if !laxKindFallbackDisabled() && kindsWithImplicitSessionLifetime(m.Kind) {
+	//
+	// HTTP is deliberately excluded from this promotion — see
+	// kindsWithLaxTaggedSessionPromotion.
+	if !laxKindFallbackDisabled() && kindsWithLaxTaggedSessionPromotion(m.Kind) {
 		m.TestModeInfo.Lifetime = LifetimeSession
 		return
 	}
@@ -228,9 +281,11 @@ func (m *Mock) DeriveLifetime() {
 // laxKindFallbackDisabled reports whether strict mode is forcing the
 // DeriveLifetime kind-fallback to stay narrow (tag=="" only). When
 // this returns false (no KEPLOY_STRICT_MOCK_WINDOW env override set),
-// any non-canonical tag on a kind in kindsWithImplicitSessionLifetime
+// any non-canonical tag on a kind in kindsWithLaxTaggedSessionPromotion
 // also falls through to session — preserving pre-Phase-2 byte-for-
-// byte behaviour for older recordings.
+// byte behaviour for older recordings. Note that list is NOT the same as
+// kindsWithImplicitSessionLifetime, which rule 4 (untagged) still uses:
+// HTTP is in the untagged list but deliberately not in this one.
 //
 // Scope: this env-only gate controls ONE specific behaviour — the
 // lax-mode promotion of explicitly-tagged non-canonical mocks (e.g.
@@ -330,12 +385,19 @@ func LegacyKindFallbackFires() uint64 {
 // added here. Their recorders already stamp type=config / mocks /
 // connection at record time, so DeriveLifetime's tag-based switch
 // routes them correctly without a kind-fallback. Listing them here
-// would additionally fire the lax-mode promotion below for their
-// explicitly-tagged "mocks" captures and wrongly route those to
+// would additionally have fired the lax-mode promotion for their
+// explicitly-tagged "mocks" captures and wrongly routed those to
 // the session pool — which breaks the per-test consumption the
 // matcher depends on (observed in the kafka-ecommerce e2e as
 // dataMocksConsumed=0 when tagged Kafka Produce mocks were force-
 // promoted to session).
+//
+// That promotion now consults kindsWithLaxTaggedSessionPromotion, a
+// separate and narrower list, so membership here no longer implies it.
+// HTTP is the reason the two lists diverge: it belongs here (its
+// untagged mocks are legitimately session) but not there (its tagged
+// captures must be consumed, or a repeated request replays the first
+// recording forever — the same dataMocksConsumed=0 symptom above).
 //
 // The LegacyKindFallbackFires counter still tracks uses for
 // observability, but non-zero fires are EXPECTED for HTTP/Generic
@@ -343,6 +405,33 @@ func LegacyKindFallbackFires() uint64 {
 func kindsWithImplicitSessionLifetime(k Kind) bool {
 	switch k {
 	case HTTP, HTTP2, MySQL, Postgres, PostgresV2, GENERIC, DNS:
+		return true
+	}
+	return false
+}
+
+// kindsWithLaxTaggedSessionPromotion returns true for Kinds whose
+// EXPLICITLY-TAGGED, non-canonical mocks are still promoted to session
+// lifetime under lax mode. It gates rule 5 only; rule 4 (the tag==""
+// fallback) keeps using kindsWithImplicitSessionLifetime, so untagged
+// legacy recordings of every listed kind replay byte-for-byte.
+//
+// HTTP is excluded. Its recorder stamps LifetimePerTest at emit time
+// (integrations/http/http.go:296, recordv2.go:548) and the published
+// contract (docs/explanation/mock-lifetimes.md:109) says HTTP_CLIENT is
+// per-test — so promoting a tagged HTTP_CLIENT capture to session
+// contradicts both. The promotion made every HTTP data mock reusable,
+// which meant the matcher never consumed one and a re-issued request
+// replayed the FIRST recording forever. Same failure, same reasoning as
+// 8339fe55 removing REDIS from the sibling list ("breaks the per-test
+// consumption the matcher depends on").
+//
+// MySQL/Postgres/Generic/DNS keep the promotion: it is what the fuzzer
+// and ORM-style workloads named in the rule-5 comment above depend on,
+// and their per-test captures are tagged "mocks".
+func kindsWithLaxTaggedSessionPromotion(k Kind) bool {
+	switch k {
+	case HTTP2, MySQL, Postgres, PostgresV2, GENERIC, DNS:
 		return true
 	}
 	return false
@@ -390,6 +479,78 @@ func IsMySQLSessionReusableCommandType(cmdType string) bool {
 	switch cmdType {
 	case "COM_PING", "COM_STATISTICS", "COM_DEBUG", "COM_RESET_CONNECTION":
 		return true
+	}
+	return false
+}
+
+// httpIsCORSPreflight reports whether an HTTP mock captured a browser
+// CORS preflight, whose response is input-independent and therefore safe
+// to route into the session pool regardless of the recorder's per-test
+// "HTTP_CLIENT" tag. Mirrors mysqlIsSessionReusableCommand: the Kind
+// check stays at the DeriveLifetime call site, the shape check lives
+// here.
+//
+// Only Kind == HTTP is wired up. HTTP2 is deliberately excluded because
+// keploy's h2 parser serves gRPC traffic, where browser preflights do not
+// appear — so there is no recording to validate an h2 rule against.
+//
+// Wiring it up would be mechanical, not structural: HTTP2Req carries the
+// same (Method, map[string]string) shape, and IsCORSPreflightRequest is
+// already case-insensitive, so h2's lowercase header keys (RFC 7540
+// section 8.1.2) need no second code path — it is one extra call site.
+//
+// One caveat if it is ever added: HTTP2 remains listed in
+// kindsWithLaxTaggedSessionPromotion, so a tagged h2 capture is already
+// promoted to LifetimeSession under lax mode. But that promotion is gated
+// on lax; under KEPLOY_STRICT_MOCK_WINDOW=1 an h2 preflight WOULD exhibit
+// the same starvation. So "h2 never had this problem" is only true in
+// the default mode.
+func httpIsCORSPreflight(m *Mock) bool {
+	if m == nil || m.Spec.HTTPReq == nil {
+		return false
+	}
+	return IsCORSPreflightRequest(m.Spec.HTTPReq.Method, m.Spec.HTTPReq.Header)
+}
+
+// IsCORSPreflightRequest reports whether a recorded HTTP request is a
+// browser CORS preflight: method OPTIONS *and* an
+// Access-Control-Request-Method header. It is the single source of truth
+// shared by DeriveLifetime's rule 1(b) and any recorder/matcher that later
+// needs the same classification, mirroring
+// IsMySQLSessionReusableCommandType.
+//
+// The header is required on purpose. Per the Fetch standard a browser
+// always sends Access-Control-Request-Method on a preflight, so requiring
+// it costs nothing on real recordings (every OPTIONS mock in the four
+// recordings used to diagnose this carry it) while excluding a
+// bare OPTIONS that is a genuine data endpoint — WebDAV capability
+// discovery, or an API that serves OPTIONS as a real response whose body
+// varies per caller. Those must stay per-test and be consumed on match;
+// promoting one to session would replay the first recording forever. The
+// tradeoff is deliberately directional: a false negative merely leaves
+// today's behaviour in place, a false positive breaks per-test
+// consumption.
+//
+// The method compare is exact: RFC 9110 section 9.1 defines HTTP methods as
+// case-sensitive, so "options" is not a valid method and must not be treated
+// as a preflight. The header NAME lookup is case-insensitive, because field
+// names are case-insensitive per RFC 9110 section 5.1 — proxy-recorded mocks
+// go through pkg.ToYamlHTTPHeader(http.Header) so their keys are canonical,
+// but mocks arriving as raw JSON/YAML (cloud sync, hand-written fixtures)
+// carry whatever casing the producer emitted.
+//
+// The header's VALUE must be non-empty. A preflight always names the method
+// it is asking about; an empty value is a malformed request, not a preflight,
+// and promoting it would be a false positive of exactly the kind the
+// directional argument above says to avoid.
+func IsCORSPreflightRequest(method Method, header map[string]string) bool {
+	if string(method) != "OPTIONS" {
+		return false
+	}
+	for k, v := range header {
+		if strings.EqualFold(k, "Access-Control-Request-Method") {
+			return strings.TrimSpace(v) != ""
+		}
 	}
 	return false
 }

--- a/pkg/models/lifetime_test.go
+++ b/pkg/models/lifetime_test.go
@@ -1,0 +1,266 @@
+package models
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models/mysql"
+)
+
+func httpMock(method string, header map[string]string, meta map[string]string) *Mock {
+	return &Mock{
+		Kind: HTTP,
+		Spec: MockSpec{
+			Metadata: meta,
+			HTTPReq: &HTTPReq{
+				Method: Method(method),
+				URL:    "/query",
+				Header: header,
+			},
+			HTTPResp: &HTTPResp{StatusCode: 200},
+		},
+	}
+}
+
+func mysqlMock(cmdType string, meta map[string]string) *Mock {
+	return &Mock{
+		Kind: MySQL,
+		Spec: MockSpec{
+			Metadata: meta,
+			MySQLRequests: []mysql.Request{{
+				PacketBundle: mysql.PacketBundle{
+					Header: &mysql.PacketInfo{Type: cmdType},
+				},
+			}},
+		},
+	}
+}
+
+// preflightHeaders is the header set a browser actually sends on a CORS
+// preflight, copied from a recorded OPTIONS /query mock (kind Http,
+// metadata type HTTP_CLIENT) in the recording that surfaced this.
+func preflightHeaders() map[string]string {
+	return map[string]string{
+		"Accept":                         "*/*",
+		"Access-Control-Request-Headers": "content-type",
+		"Access-Control-Request-Method":  "POST",
+		"Origin":                         "http://localhost:3000",
+		"Sec-Fetch-Mode":                 "cors",
+	}
+}
+
+// TestDeriveLifetime covers the precedence rules in DeriveLifetime's doc
+// comment. Every case builds a fresh mock because DeriveLifetime is
+// idempotent via TestModeInfo.LifetimeDerived — reusing one mock across
+// sub-tests would short-circuit every call after the first.
+func TestDeriveLifetime(t *testing.T) {
+	cases := []struct {
+		name string
+		mock func() *Mock
+		want Lifetime
+		// requiresLax marks cases that depend on rule 5, which is
+		// disabled when KEPLOY_STRICT_MOCK_WINDOW is set to an
+		// enabling value. The gate is snapshotted at package init, so
+		// the test cannot flip it — it skips instead.
+		requiresLax bool
+	}{
+		{
+			// Rule 1(b): a tagged HTTP_CLIENT preflight is
+			// promoted to session so it is neither consumed on match nor
+			// restricted to the recording test's own mock pool.
+			name: "http tagged preflight OPTIONS is session",
+			mock: func() *Mock {
+				return httpMock("OPTIONS", preflightHeaders(), map[string]string{"type": HTTPClient})
+			},
+			want: LifetimeSession,
+		},
+		{
+			// A bare OPTIONS with no Access-Control-Request-Method is not
+			// a preflight — it may be a real data endpoint whose response
+			// varies per caller, so it must stay consumable per-test.
+			name: "http tagged non-preflight OPTIONS stays per-test",
+			mock: func() *Mock {
+				return httpMock("OPTIONS", map[string]string{"Accept": "*/*"}, map[string]string{"type": HTTPClient})
+			},
+			want: LifetimePerTest,
+		},
+		{
+			// Proxy-recorded headers are canonicalised, but mocks that
+			// arrive as raw JSON/YAML keep the producer's casing, so the
+			// header probe is case-insensitive.
+			name: "http preflight with lowercase header key is session",
+			mock: func() *Mock {
+				return httpMock("OPTIONS", map[string]string{"access-control-request-method": "POST"}, map[string]string{"type": HTTPClient})
+			},
+			want: LifetimeSession,
+		},
+		{
+			// PRECEDENCE GUARD. Rule 1(b) is documented as running BEFORE the
+			// Metadata["type"] switch, but every other preflight case here is
+			// tagged HTTP_CLIENT, which falls through that switch anyway — so
+			// they all still pass if the rule is moved after it, and the
+			// ordering claim goes unpinned.
+			//
+			// A "connection" tag discriminates: rule 3 would classify this
+			// LifetimeConnection (it has a connID), so seeing LifetimeSession
+			// proves 1(b) ran first. Synthetic — no HTTP recorder writes
+			// "connection" today — which is exactly what an ordering assertion
+			// needs: it isolates precedence from every other signal.
+			name: "preflight beats the connection tag, proving rule 1(b) precedence",
+			mock: func() *Mock {
+				m := httpMock("OPTIONS", preflightHeaders(), map[string]string{
+					"type":   "connection",
+					"connID": "7",
+				})
+				return m
+			},
+			want: LifetimeSession,
+		},
+		{
+			// The core fix this branch shipped: tagged HTTP data mocks are
+			// per-test, not session, so the matcher consumes them.
+			name: "http tagged GET is per-test",
+			mock: func() *Mock {
+				return httpMock("GET", map[string]string{"Accept": "*/*"}, map[string]string{"type": HTTPClient})
+			},
+			want: LifetimePerTest,
+		},
+		{
+			// Rule 4: pre-tag recordings have no type metadata at all and
+			// must keep replaying as session.
+			name: "http untagged is session via kind fallback",
+			mock: func() *Mock {
+				return httpMock("GET", map[string]string{"Accept": "*/*"}, nil)
+			},
+			want: LifetimeSession,
+		},
+		{
+			// Rule 2.
+			name: "http tagged config is session",
+			mock: func() *Mock {
+				return httpMock("GET", map[string]string{"Accept": "*/*"}, map[string]string{"type": "config"})
+			},
+			want: LifetimeSession,
+		},
+		{
+			// Rule 1(a) must not regress: COM_PING is promoted even though
+			// the recorder tagged it per-test "mocks".
+			name: "mysql tagged mocks COM_PING is session",
+			mock: func() *Mock {
+				return mysqlMock("COM_PING", map[string]string{"type": "mocks"})
+			},
+			want: LifetimeSession,
+		},
+		{
+			// Rule 1(a) is deliberately narrow: COM_QUERY depends on
+			// input. It is NOT asserted as per-test here because rule 5
+			// promotes tagged MySQL mocks to session under lax mode — the
+			// narrowness of the allowlist itself is asserted in
+			// TestIsMySQLSessionReusableCommandType below.
+			name: "mysql tagged mocks COM_QUERY skips rule 1(a) and hits rule 5",
+			mock: func() *Mock {
+				return mysqlMock("COM_QUERY", map[string]string{"type": "mocks"})
+			},
+			want:        LifetimeSession,
+			requiresLax: true,
+		},
+		{
+			// Rule 5 must not regress for the kinds still on the lax
+			// promotion list.
+			name: "postgres tagged mocks is session under lax",
+			mock: func() *Mock {
+				return &Mock{
+					Kind: Postgres,
+					Spec: MockSpec{Metadata: map[string]string{"type": "mocks"}},
+				}
+			},
+			want:        LifetimeSession,
+			requiresLax: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.requiresLax && laxKindFallbackDisabled() {
+				t.Skip("rule 5 disabled by KEPLOY_STRICT_MOCK_WINDOW")
+			}
+			m := tc.mock()
+			m.DeriveLifetime()
+			if m.TestModeInfo.Lifetime != tc.want {
+				t.Fatalf("Lifetime = %v, want %v", m.TestModeInfo.Lifetime, tc.want)
+			}
+			if !m.TestModeInfo.LifetimeDerived {
+				t.Fatal("LifetimeDerived not set")
+			}
+		})
+	}
+}
+
+// Rule 1(a)'s allowlist, asserted directly on the predicate so the
+// negative cases do not depend on the ambient KEPLOY_STRICT_MOCK_WINDOW
+// setting (rule 5 promotes tagged MySQL mocks to session under lax).
+func TestIsMySQLSessionReusableCommandType(t *testing.T) {
+	for _, cmd := range []string{"COM_PING", "COM_STATISTICS", "COM_DEBUG", "COM_RESET_CONNECTION"} {
+		if !IsMySQLSessionReusableCommandType(cmd) {
+			t.Errorf("%s should be session-reusable", cmd)
+		}
+	}
+	for _, cmd := range []string{"COM_QUERY", "COM_INIT_DB", "COM_CHANGE_USER", "COM_SET_OPTION", ""} {
+		if IsMySQLSessionReusableCommandType(cmd) {
+			t.Errorf("%q should not be session-reusable", cmd)
+		}
+	}
+}
+
+func TestIsCORSPreflightRequest(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		header map[string]string
+		want   bool
+	}{
+		{"options with preflight header", "OPTIONS", preflightHeaders(), true},
+		// RFC 9110 §9.1: methods are case-sensitive, so "options" is not a
+		// valid HTTP method and must not classify as a preflight.
+		{"lowercase method is not a preflight", "options", preflightHeaders(), false},
+		// Field NAMES are case-insensitive (RFC 9110 §5.1), so a
+		// non-canonically-cased header from a hand-written or cloud-synced
+		// fixture must still be recognised.
+		{"lowercase header name still matches", "OPTIONS",
+			map[string]string{"access-control-request-method": "POST"}, true},
+		// An empty value is a malformed preflight, not a preflight. Promoting
+		// it would be a false positive, which is the direction the predicate
+		// deliberately errs away from.
+		{"empty header value is not a preflight", "OPTIONS",
+			map[string]string{"Access-Control-Request-Method": ""}, false},
+		{"whitespace header value is not a preflight", "OPTIONS",
+			map[string]string{"Access-Control-Request-Method": "   "}, false},
+		{"options without preflight header", "OPTIONS", map[string]string{"Accept": "*/*"}, false},
+		{"options nil header", "OPTIONS", nil, false},
+		{"post with preflight header", "POST", preflightHeaders(), false},
+		{"empty method", "", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsCORSPreflightRequest(Method(tc.method), tc.header); got != tc.want {
+				t.Fatalf("IsCORSPreflightRequest(%q) = %v, want %v", tc.method, got, tc.want)
+			}
+		})
+	}
+}
+
+// httpIsCORSPreflight must not panic on a malformed mock: HTTP mocks whose
+// response was elided to an asset still carry a nil HTTPReq on some ingest
+// paths, and DeriveLifetime runs on every mock loaded from disk.
+func TestHTTPIsCORSPreflightNilSafe(t *testing.T) {
+	if httpIsCORSPreflight(nil) {
+		t.Fatal("nil mock should not be a preflight")
+	}
+	m := &Mock{Kind: HTTP, Spec: MockSpec{Metadata: map[string]string{"type": HTTPClient}}}
+	if httpIsCORSPreflight(m) {
+		t.Fatal("mock with nil HTTPReq should not be a preflight")
+	}
+	m.DeriveLifetime()
+	if m.TestModeInfo.Lifetime != LifetimePerTest {
+		t.Fatalf("Lifetime = %v, want per-test", m.TestModeInfo.Lifetime)
+	}
+}

--- a/pkg/models/mock.go
+++ b/pkg/models/mock.go
@@ -143,8 +143,60 @@ func (m *Mock) HasSpilledResponse() bool { return m.responseHydrator != nil }
 // load all discriminate on.
 func (m *Mock) IsAsync() bool { return m.Spec.Async != nil }
 
-// HydrateResponse loads an elided response into Spec; no-op if not spilled, so
-// serve paths can call it unconditionally before reading the response.
+// HydratedHTTPResp returns the mock's HTTP response, fetching it from the
+// agent's spill store when the response was elided at ingest
+// (proxy.DiskMocks.Add). It returns nil when there is no response at all.
+//
+// It NEVER writes to the mock, and that is load-bearing rather than stylistic.
+// A pooled *Mock is shared by every proxy connection goroutine, and a
+// goroutine that matched the same mock reads it WHOLE by value on the consume
+// path -- `updatedMock := *matchedMock` and `deleteMock := *matchedMock` in
+// http.updateMock, `*old` in MockManager.UpdateUnFilteredMock. Those readers
+// cannot be made to take a lock without changing the by-value MockMemDb
+// interface, so the only contract that holds is: the serve path does not
+// write. See HydrateResponse for why that method is not the one to call here.
+//
+// A repeat serve re-reads the blob rather than caching it in Spec. That is the
+// intended trade: the spill exists to keep the resident matching window small,
+// and a per-test mock is consumed on first match, so a repeat serve is off the
+// normal path anyway.
+func (m *Mock) HydratedHTTPResp() (*HTTPResp, error) {
+	if m.Spec.HTTPResp != nil {
+		return m.Spec.HTTPResp, nil
+	}
+	fn := m.responseHydrator
+	if fn == nil {
+		return nil, nil
+	}
+	httpResp, _, err := fn()
+	return httpResp, err
+}
+
+// HydratedMongoResponses is the Mongo counterpart of HydratedHTTPResp. Nothing
+// in OSS calls it: DiskMocks.EligibleForResponseSpill spills every Mongo mock
+// with responses, but there is no Mongo parser in this repo, so a spilled
+// Mongo mock currently has no serve path that restores it. This exists so
+// wiring one up is a one-line change rather than a re-derivation.
+func (m *Mock) HydratedMongoResponses() ([]MongoResponse, error) {
+	if len(m.Spec.MongoResponses) > 0 {
+		return m.Spec.MongoResponses, nil
+	}
+	fn := m.responseHydrator
+	if fn == nil {
+		return nil, nil
+	}
+	_, mongoResp, err := fn()
+	return mongoResp, err
+}
+
+// HydrateResponse loads an elided response INTO Spec and clears the hydrator.
+//
+// Do not call this on a mock that is in a live pool. It mutates two fields
+// that other connection goroutines read by value off the same pointer, which
+// is a data race with no happens-before edge; use HydratedHTTPResp on any
+// serve path. It is retained for callers that own the mock outright -- a
+// freshly gob-decoded one, or a test fixture -- and for out-of-tree parsers
+// that already depend on the signature.
 func (m *Mock) HydrateResponse() error {
 	fn := m.responseHydrator
 	if fn == nil {

--- a/pkg/service/agent/scope.go
+++ b/pkg/service/agent/scope.go
@@ -39,34 +39,54 @@ type scopeKey struct {
 // that worker so PARALLEL workers each get their own served view without
 // stomping each other (Design A); pid == 0 falls back to the single global
 // scope (sequential single-worker runs, and the suite-level default).
-func (a *Agent) BeginScope(ctx context.Context, name string, pid int) error {
+//
+// The returned ScopeAck says whether the pool was ACTUALLY narrowed. Several
+// paths below leave the whole suite's pool armed, and until this ack existed
+// they were indistinguishable on the wire from a correctly-isolated test.
+func (a *Agent) BeginScope(ctx context.Context, name string, pid int) (models.ScopeAck, error) {
 	if name == "" {
-		return nil
+		return models.ScopeAck{Reason: models.ScopeReasonEmptyName}, nil
 	}
 	if a.config != nil && a.config.Agent.Mode == models.MODE_TEST {
 		a.scopeMu.Lock()
 		names, ok := a.scopeTable[name]
+		tableSize := len(a.scopeTable)
 		a.scopeMu.Unlock()
-		if !ok || len(names) == 0 {
-			// No per-test mapping for this test — leave the whole pool armed.
-			return nil
+		// No per-test mapping for this test — leave the whole pool armed. All
+		// three shapes below served the whole set silently before; they are
+		// distinguished here because a runner needs to know WHICH it hit: an
+		// absent mappings.yaml is a setup error, an absent NAME is a renamed
+		// or never-recorded test.
+		switch {
+		case tableSize == 0:
+			a.logger.Debug("scope begin: NOT scoped, no per-test mapping table installed", zap.String("test", name))
+			return models.ScopeAck{Reason: models.ScopeReasonNoMappingTable}, nil
+		case !ok:
+			a.logger.Debug("scope begin: NOT scoped, this name is absent from the mapping table", zap.String("test", name), zap.Int("mapped_tests", tableSize))
+			return models.ScopeAck{Reason: models.ScopeReasonUnmappedScope}, nil
+		case len(names) == 0:
+			a.logger.Debug("scope begin: NOT scoped, this name is mapped to zero mocks", zap.String("test", name))
+			return models.ScopeAck{Reason: models.ScopeReasonEmptyMapping}, nil
 		}
 		if pid > 0 {
 			// Parallel-safe: narrow ONLY this worker's served view, keyed by its
 			// PID, so concurrent workers never overwrite one shared filter.
 			a.logger.Debug("scope begin: worker-scoped pool", zap.String("test", name), zap.Int("worker", pid), zap.Int("mocks", len(names)))
 			a.SetWorkerScope(uint32(pid), names)
-			return nil
+			return models.ScopeAck{Scoped: true, Mocks: len(names), Reason: models.ScopeReasonWorkerScoped}, nil
 		}
 		// No worker PID reported — restrict the single global pool (correct for
 		// a sequential single-worker suite, the pre-Design-A behavior).
 		a.logger.Debug("scope begin: restricting served pool to test", zap.String("test", name), zap.Int("mocks", len(names)))
-		return a.UpdateMockParams(ctx, models.MockFilterParams{
+		if err := a.UpdateMockParams(ctx, models.MockFilterParams{
 			MockMapping:     names,
 			UseMappingBased: true,
 			AfterTime:       models.BaseTime,
 			BeforeTime:      time.Now(),
-		})
+		}); err != nil {
+			return models.ScopeAck{}, err
+		}
+		return models.ScopeAck{Scoped: true, Mocks: len(names), Reason: models.ScopeReasonPoolRestricted}, nil
 	}
 
 	// Record mode: mark the window start (agent clock), keyed by worker PID so
@@ -77,10 +97,19 @@ func (a *Agent) BeginScope(ctx context.Context, name string, pid int) error {
 	if a.workerOpen == nil {
 		a.workerOpen = make(map[scopeKey]time.Time)
 	}
-	a.workerOpen[scopeKey{pid: uint32(pid), name: name}] = time.Now()
+	k := scopeKey{pid: uint32(pid), name: name}
+	// A second begin for a scope that was never ended silently discards the
+	// earlier window start, so every mock captured before this call is
+	// attributed to no test and vanishes from mappings.yaml. The overwrite is
+	// kept (changing it is a separate fix) but it is no longer silent.
+	_, alreadyOpen := a.workerOpen[k]
+	a.workerOpen[k] = time.Now()
 	a.scopeMu.Unlock()
-	a.logger.Debug("scope begin (record)", zap.String("test", name), zap.Int("worker", pid))
-	return nil
+	a.logger.Debug("scope begin (record)", zap.String("test", name), zap.Int("worker", pid), zap.Bool("already_open", alreadyOpen))
+	if alreadyOpen {
+		return models.ScopeAck{Reason: models.ScopeReasonRecordAlreadyOpen}, nil
+	}
+	return models.ScopeAck{Reason: models.ScopeReasonRecordWindowOpened}, nil
 }
 
 // EndScope closes a per-test scope. In record mode it records the [begin, now]

--- a/pkg/service/agent/scope_ack_test.go
+++ b/pkg/service/agent/scope_ack_test.go
@@ -1,0 +1,179 @@
+package agent
+
+// /agent/scope/begin has several paths that leave the WHOLE suite's mock pool
+// armed instead of narrowing to the calling test. Before ScopeAck they were
+// indistinguishable on the wire from a correctly-isolated test, so a renamed or
+// moved test silently degraded to whole-suite replay. These tests pin one
+// distinct, stable reason token per path.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.keploy.io/server/v3/config"
+	coreAgent "go.keploy.io/server/v3/pkg/agent"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// testModeAgent is a MODE_TEST agent with no proxy and no resident mocks: every
+// case here returns before UpdateMockParams, which is exactly what makes them
+// the silent-fallback paths.
+func testModeAgent(t *testing.T, table map[string][]string) *Agent {
+	t.Helper()
+	a := &Agent{logger: zap.NewNop()}
+	a.config = &config.Config{}
+	a.config.Agent.Mode = models.MODE_TEST
+	a.scopeTable = table
+	return a
+}
+
+func TestBeginScopeAckReplayNotScoped(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name   string
+		table  map[string][]string
+		scope  string
+		reason string
+		why    string
+	}{
+		{
+			name: "no mapping table", table: nil, scope: "alpha",
+			reason: models.ScopeReasonNoMappingTable,
+			why:    "replay ran without a mappings.yaml, so no scope table was ever installed",
+		},
+		{
+			name: "name absent from table", table: map[string][]string{"beta": {"m1"}}, scope: "alpha",
+			reason: models.ScopeReasonUnmappedScope,
+			why:    "the test was renamed or moved since the recording",
+		},
+		{
+			name: "name mapped to zero mocks", table: map[string][]string{"alpha": {}}, scope: "alpha",
+			reason: models.ScopeReasonEmptyMapping,
+			why:    "record captured no calls for this test",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := testModeAgent(t, tc.table)
+			ack, err := a.BeginScope(ctx, tc.scope, 0)
+			require.NoError(t, err)
+			require.False(t, ack.Scoped, "the whole pool is still armed — %s", tc.why)
+			require.Equal(t, tc.reason, ack.Reason)
+			require.Zero(t, ack.Mocks)
+		})
+	}
+}
+
+// The two scoped paths must be distinguishable from each other, because they
+// isolate differently: pid==0 re-stages one global pool, pid>0 narrows only
+// this worker's view.
+func TestBeginScopeAckReplayScoped(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("worker scoped", func(t *testing.T) {
+		a, _ := replayAgent(t, []string{"m1", "m2"}, map[string][]string{"alpha": {"m1", "m2"}})
+		ack, err := a.BeginScope(ctx, "alpha", 7)
+		require.NoError(t, err)
+		require.True(t, ack.Scoped)
+		require.Equal(t, models.ScopeReasonWorkerScoped, ack.Reason)
+		require.Equal(t, 2, ack.Mocks)
+	})
+
+	t.Run("global pool restricted", func(t *testing.T) {
+		a, _ := replayAgent(t, []string{"m1", "m2"}, map[string][]string{"alpha": {"m1"}})
+		ack, err := a.BeginScope(ctx, "alpha", 0)
+		require.NoError(t, err)
+		require.True(t, ack.Scoped)
+		require.Equal(t, models.ScopeReasonPoolRestricted, ack.Reason)
+		require.Equal(t, 1, ack.Mocks, "the count a runner asserts its call volume against")
+	})
+}
+
+// Record mode serves nothing, so Scoped is always false; the reason still has
+// to separate a clean window from a double begin, which silently discards the
+// earlier window start and orphans everything captured before it.
+func TestBeginScopeAckRecord(t *testing.T) {
+	ctx := context.Background()
+	a := newRecordAgent()
+
+	ack, err := a.BeginScope(ctx, "alpha", 0)
+	require.NoError(t, err)
+	require.False(t, ack.Scoped)
+	require.Equal(t, models.ScopeReasonRecordWindowOpened, ack.Reason)
+
+	ack, err = a.BeginScope(ctx, "alpha", 0) // no EndScope in between
+	require.NoError(t, err)
+	require.Equal(t, models.ScopeReasonRecordAlreadyOpen, ack.Reason)
+}
+
+func TestBeginScopeAckEmptyName(t *testing.T) {
+	a := newRecordAgent()
+	ack, err := a.BeginScope(context.Background(), "", 0)
+	require.NoError(t, err)
+	require.False(t, ack.Scoped)
+	require.Equal(t, models.ScopeReasonEmptyName, ack.Reason)
+	require.Empty(t, windowNames(a), "an empty name must not open a record window")
+}
+
+// fakeScopeProxy is a coreAgent.Proxy stand-in that records what the agent
+// stages. The embedded nil interface supplies the rest of the method set; only
+// the methods BeginScope's replay path actually calls are implemented, so any
+// unexpected call panics loudly instead of passing silently.
+//
+// It deliberately DOES implement coreAgent.ConsumedStateReader
+// (GetPersistentConsumed) — that is the upstream read side, and the point of
+// TestBeginScopeIgnoresPersistentConsumed is that the mock-replay path never
+// asks for it.
+type fakeScopeProxy struct {
+	coreAgent.Proxy
+	staged    [][]string
+	workers   map[uint32][]string
+	consumed  map[string]models.MockState
+	universes [][]string
+}
+
+func newFakeScopeProxy() *fakeScopeProxy {
+	return &fakeScopeProxy{workers: map[uint32][]string{}, consumed: map[string]models.MockState{}}
+}
+
+func (f *fakeScopeProxy) SetMocks(_ context.Context, filtered, _ []*models.Mock) error {
+	names := make([]string, 0, len(filtered))
+	for _, m := range filtered {
+		names = append(names, m.Name)
+	}
+	f.staged = append(f.staged, names)
+	return nil
+}
+
+func (f *fakeScopeProxy) SetWorkerScope(pid uint32, names []string) { f.workers[pid] = names }
+func (f *fakeScopeProxy) ClearWorkerScope(pid uint32)               { delete(f.workers, pid) }
+func (f *fakeScopeProxy) SetMappedUniverse(names []string)          { f.universes = append(f.universes, names) }
+
+func (f *fakeScopeProxy) GetPersistentConsumed() map[string]models.MockState {
+	out := make(map[string]models.MockState, len(f.consumed))
+	for k, v := range f.consumed {
+		out[k] = v
+	}
+	return out
+}
+
+// replayAgent builds an agent in the shape `keploy mock replay` leaves it in:
+// MODE_TEST, the whole set resident under client 0, and a scope table installed
+// from mappings.yaml.
+func replayAgent(t *testing.T, mockNames []string, table map[string][]string) (*Agent, *fakeScopeProxy) {
+	t.Helper()
+	p := newFakeScopeProxy()
+	a := &Agent{logger: zap.NewNop(), Proxy: p}
+	a.config = &config.Config{}
+	a.config.Agent.Mode = models.MODE_TEST
+
+	resident := make([]*models.Mock, 0, len(mockNames))
+	for _, n := range mockNames {
+		resident = append(resident, &models.Mock{Name: n, Kind: models.HTTP})
+	}
+	a.clientMocks.Store(uint64(0), &ClientMockStorage{filtered: resident})
+
+	require.NoError(t, a.SetScopeTable(context.Background(), table))
+	return a, p
+}

--- a/pkg/service/agent/scope_test.go
+++ b/pkg/service/agent/scope_test.go
@@ -26,8 +26,10 @@ func windowNames(a *Agent) []string {
 func TestRecordScopesNestedPidZero(t *testing.T) {
 	a := newRecordAgent()
 	ctx := context.Background()
-	require.NoError(t, a.BeginScope(ctx, "suite", 0))
-	require.NoError(t, a.BeginScope(ctx, "test1", 0))
+	_, err := a.BeginScope(ctx, "suite", 0)
+	require.NoError(t, err)
+	_, err = a.BeginScope(ctx, "test1", 0)
+	require.NoError(t, err)
 	require.NoError(t, a.EndScope(ctx, "test1", 0))
 	require.NoError(t, a.EndScope(ctx, "suite", 0))
 	require.ElementsMatch(t, []string{"suite", "test1"}, windowNames(a),
@@ -39,8 +41,10 @@ func TestRecordScopesNestedPidZero(t *testing.T) {
 func TestRecordScopesParallelWorkers(t *testing.T) {
 	a := newRecordAgent()
 	ctx := context.Background()
-	require.NoError(t, a.BeginScope(ctx, "t", 100))
-	require.NoError(t, a.BeginScope(ctx, "t", 200)) // overlaps worker 100's scope
+	_, err := a.BeginScope(ctx, "t", 100)
+	require.NoError(t, err)
+	_, err = a.BeginScope(ctx, "t", 200) // overlaps worker 100's scope
+	require.NoError(t, err)
 	require.NoError(t, a.EndScope(ctx, "t", 100))
 	require.NoError(t, a.EndScope(ctx, "t", 200))
 

--- a/pkg/service/mock/record.go
+++ b/pkg/service/mock/record.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg/models"
 	rec "go.keploy.io/server/v3/pkg/service/record"
 	"go.keploy.io/server/v3/utils"
@@ -62,14 +63,24 @@ func (m *mockService) Record(ctx context.Context) error {
 
 	// 1. Instrument: start the agent, hooks and proxy in mock mode (no ingress
 	//    port relocation — the runner is not a server).
+	// --pass-through-ports lands in BypassRules (config.SetByPassPorts, driven by
+	// cli/provider/cmd.go). The proxy-level rules were already forwarded via
+	// OutgoingOptions.Rules below, but the KERNEL-level bypass is a separate
+	// channel and mock mode never populated it -- so a bypassed port was still
+	// pulled through the proxy and recorded. Integration record/test have always
+	// set this (service/record/record.go, service/replay/replay.go); mock mode
+	// was the only path that did not.
+	passPortsUint := config.GetByPassPorts(m.config)
+
 	if err := m.instrumentation.Setup(ctx, m.config.Command, models.SetupOptions{
-		Container:   m.config.ContainerName,
-		CommandType: m.config.CommandType,
-		DockerDelay: m.config.BuildDelay,
-		BuildDelay:  m.config.BuildDelay,
-		Mode:        models.MODE_RECORD,
-		MockMode:    true,
-		ConfigPath:  m.config.ConfigPath,
+		Container:        m.config.ContainerName,
+		CommandType:      m.config.CommandType,
+		DockerDelay:      m.config.BuildDelay,
+		BuildDelay:       m.config.BuildDelay,
+		Mode:             models.MODE_RECORD,
+		MockMode:         true,
+		ConfigPath:       m.config.ConfigPath,
+		PassThroughPorts: passPortsUint,
 	}); err != nil {
 		if ctx.Err() != nil {
 			return nil

--- a/pkg/service/mock/replay.go
+++ b/pkg/service/mock/replay.go
@@ -9,6 +9,7 @@ import (
 
 	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg/models"
+	"go.keploy.io/server/v3/pkg/service/replay"
 	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -80,12 +81,34 @@ func (m *mockService) Replay(ctx context.Context) error {
 	}
 
 	// 2. Put the proxy in mock-serving mode with the miss policy.
+	//
+	// Opting into strict enforcement is what makes a changed request VALUE
+	// miss: the default request-body check is PerformBodyMatch -> bodyMatch,
+	// which compares top-level key presence only, so a payload that keeps its
+	// shape and changes a value is served the stale recorded response.
+	//
+	// NoiseConfig is forwarded only alongside it. It also feeds header noise,
+	// so passing it unconditionally would loosen matching for anyone with an
+	// existing test.globalNoise block; gating it keeps the default literal
+	// byte-for-byte the zero-valued one this call has always used.
+	//
+	// SchemaNoiseDetection is deliberately NOT forwarded. Its rule is
+	// "changed && !alreadyKnownNoise -> noise" on a single observation, and
+	// MergeLearned is monotonic, so running the learner on the very PR that
+	// broke something amnesties that field permanently. A learner pointed at a
+	// gate defeats the gate.
+	var mockNoiseConfig map[string]map[string][]string
+	if m.config.Test.SchemaNoiseStrict {
+		mockNoiseConfig = replay.PrepareMockNoiseConfig(m.config.Test.GlobalNoise.Global, m.config.Test.GlobalNoise.Testsets, name)
+	}
 	if err := m.instrumentation.MockOutgoing(ctx, models.OutgoingOptions{
 		Rules:                     m.config.BypassRules,
 		MongoPassword:             m.config.Test.MongoPassword,
 		SQLDelay:                  time.Duration(m.config.Test.Delay) * time.Second,
 		Mocking:                   true,
 		OnMiss:                    policy,
+		NoiseConfig:               mockNoiseConfig,
+		SchemaNoiseStrict:         m.config.Test.SchemaNoiseStrict,
 		MysqlPorts:                m.config.MysqlPorts,
 		DisableMysqlAutoDetect:    m.config.DisableMysqlAutoDetect,
 		DisableMysqlEndpointDrift: m.config.DisableMysqlEndpointDrift,

--- a/pkg/service/mock/replay.go
+++ b/pkg/service/mock/replay.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"go.keploy.io/server/v3/config"
 	"go.keploy.io/server/v3/pkg/models"
 	"go.keploy.io/server/v3/utils"
 	"go.uber.org/zap"
@@ -52,14 +53,24 @@ func (m *mockService) Replay(ctx context.Context) error {
 	}()
 
 	// 1. Instrument in mock (test) mode — no ingress port relocation.
+	// --pass-through-ports lands in BypassRules (config.SetByPassPorts, driven by
+	// cli/provider/cmd.go). The proxy-level rules were already forwarded via
+	// OutgoingOptions.Rules below, but the KERNEL-level bypass is a separate
+	// channel and mock mode never populated it -- so a bypassed port was still
+	// pulled through the proxy and recorded. Integration record/test have always
+	// set this (service/record/record.go, service/replay/replay.go); mock mode
+	// was the only path that did not.
+	passPortsUint := config.GetByPassPorts(m.config)
+
 	if err := m.instrumentation.Setup(ctx, m.config.Command, models.SetupOptions{
-		Container:   m.config.ContainerName,
-		CommandType: m.config.CommandType,
-		DockerDelay: m.config.BuildDelay,
-		BuildDelay:  m.config.BuildDelay,
-		Mode:        models.MODE_TEST,
-		MockMode:    true,
-		ConfigPath:  m.config.ConfigPath,
+		Container:        m.config.ContainerName,
+		CommandType:      m.config.CommandType,
+		DockerDelay:      m.config.BuildDelay,
+		BuildDelay:       m.config.BuildDelay,
+		Mode:             models.MODE_TEST,
+		MockMode:         true,
+		ConfigPath:       m.config.ConfigPath,
+		PassThroughPorts: passPortsUint,
 	}); err != nil {
 		if ctx.Err() != nil {
 			return nil

--- a/pkg/service/mock/strict_body_wiring_test.go
+++ b/pkg/service/mock/strict_body_wiring_test.go
@@ -1,0 +1,138 @@
+package mock
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// errStopReplay short-circuits Replay right after the proxy has been switched
+// into mock-serving mode. Everything the flow does afterwards (StoreMocks, the
+// wrapped runner, the consumed-mock summary) is irrelevant to this wiring pin
+// and would need a far larger fake.
+var errStopReplay = errors.New("stop after MockOutgoing")
+
+// capturingInstrumentation records the OutgoingOptions literal that
+// mockService.Replay hands to the proxy. That literal is the ONLY channel
+// through which `keploy mock replay` can turn on strict request-body matching:
+// the proxy builds its schemanoise.Engine from opts.SchemaNoiseStrict
+// (pkg/agent/proxy/integrations/http/decode.go, match.go's
+// filterStrictNoiseMatches), so a field left off the literal is a feature that
+// cannot be reached from this command at all.
+type capturingInstrumentation struct {
+	Instrumentation // embedded nil: any unexpected call panics loudly
+
+	got models.OutgoingOptions
+}
+
+func (c *capturingInstrumentation) Setup(context.Context, string, models.SetupOptions) error {
+	return nil
+}
+
+func (c *capturingInstrumentation) MockOutgoing(_ context.Context, opts models.OutgoingOptions) error {
+	c.got = opts
+	return errStopReplay
+}
+
+func (c *capturingInstrumentation) NotifyGracefulShutdown(context.Context) error { return nil }
+
+// TestReplay_ForwardsSchemaNoiseStrictToTheProxy is the regression guard for
+// `keploy mock replay` silently ignoring strict request-body matching.
+//
+// Without strict, the outgoing HTTP match cascade ends at PerformBodyMatch ->
+// bodyMatch, whose whole comparison is "does the request body contain every
+// top-level key the mock's body had". It never reads a VALUE, so a request that
+// keeps its shape and changes a value is served the STALE recorded response
+// with missed: 0 and exit 0.
+//
+// The enforcement (filterStrictNoiseMatches -> schemanoise.Engine.StrictReject)
+// already exists and is reached only when opts.SchemaNoiseStrict is true. This
+// call site built OutgoingOptions without the field, so setting
+// test.schemaNoiseStrict: true in keploy.yml was a silent no-op for this
+// command.
+func TestReplay_ForwardsSchemaNoiseStrictToTheProxy(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		strict bool
+	}{
+		{"strict off stays off", false},
+		{"strict on reaches the proxy", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := &capturingInstrumentation{}
+			cfg := &config.Config{Command: "echo hi"}
+			cfg.Mock.Name = "my-set"
+			cfg.Mock.OnMiss = string(models.MissFail)
+			cfg.Test.SchemaNoiseStrict = tc.strict
+
+			svc := New(zap.NewNop(), inst, nil, nil, nil, nil, cfg)
+			if err := svc.Replay(context.Background()); !errors.Is(err, errStopReplay) {
+				t.Fatalf("Replay returned %v, want the post-MockOutgoing sentinel", err)
+			}
+
+			if inst.got.SchemaNoiseStrict != tc.strict {
+				t.Fatalf("OutgoingOptions.SchemaNoiseStrict = %v, want %v — "+
+					"`mock replay` is not forwarding it, so the strict request-body "+
+					"matcher can never engage and a drifted request value is served "+
+					"the stale recorded response",
+					inst.got.SchemaNoiseStrict, tc.strict)
+			}
+		})
+	}
+}
+
+// TestReplay_ForwardsRequestBodyNoiseOnlyWithStrict pins the escape hatch and
+// the compatibility guarantee in one place.
+//
+// Escape hatch: with strict ON, test.globalNoise.requestbody must reach the
+// proxy, because StrictReject subtracts the known-noise paths before rejecting
+// — it is the only way to keep a legitimately-varying field (nonce, timestamp,
+// request id) from failing every match.
+//
+// Compatibility: with strict OFF, NoiseConfig must stay nil. It also feeds
+// header noise (decode.go's headerNoise), so forwarding it unconditionally
+// would loosen header matching for every existing user who has a globalNoise
+// block — a behaviour change on the default path.
+func TestReplay_ForwardsRequestBodyNoiseOnlyWithStrict(t *testing.T) {
+	newCfg := func(strict bool) *config.Config {
+		cfg := &config.Config{Command: "echo hi"}
+		cfg.Mock.Name = "my-set"
+		cfg.Mock.OnMiss = string(models.MissFail)
+		cfg.Test.SchemaNoiseStrict = strict
+		cfg.Test.GlobalNoise.Global = config.GlobalNoise{
+			"requestbody": {"nonce": {}},
+			"header":      {"authorization": {}},
+		}
+		return cfg
+	}
+
+	t.Run("strict on forwards the noise buckets", func(t *testing.T) {
+		inst := &capturingInstrumentation{}
+		if err := New(zap.NewNop(), inst, nil, nil, nil, nil, newCfg(true)).
+			Replay(context.Background()); !errors.Is(err, errStopReplay) {
+			t.Fatalf("Replay returned %v, want the post-MockOutgoing sentinel", err)
+		}
+		if _, ok := inst.got.NoiseConfig["requestbody"]["nonce"]; !ok {
+			t.Fatalf("requestbody noise did not reach the proxy: %#v — without it "+
+				"strict mode rejects every mock whose nonce field drifted",
+				inst.got.NoiseConfig)
+		}
+	})
+
+	t.Run("strict off leaves NoiseConfig nil", func(t *testing.T) {
+		inst := &capturingInstrumentation{}
+		if err := New(zap.NewNop(), inst, nil, nil, nil, nil, newCfg(false)).
+			Replay(context.Background()); !errors.Is(err, errStopReplay) {
+			t.Fatalf("Replay returned %v, want the post-MockOutgoing sentinel", err)
+		}
+		if inst.got.NoiseConfig != nil {
+			t.Fatalf("NoiseConfig = %#v with strict off, want nil — forwarding it "+
+				"unconditionally also loosens header matching on the default path",
+				inst.got.NoiseConfig)
+		}
+	})
+}

--- a/utils/passthrough_rules_test.go
+++ b/utils/passthrough_rules_test.go
@@ -1,0 +1,114 @@
+package utils
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// A bypass rule that specifies only a port -- what `--pass-through-ports N` and
+// `bypassRules: [{port: N}]` both produce via config.SetByPassPorts, which
+// builds models.BypassRule{Host: "", Path: "", Port: N} -- was a no-op at the
+// proxy layer. IsPassThrough seeded a `passThrough` flag to false, only the Host
+// and Path arms ever assigned it, and the port comparison sat inside
+// `if passThrough`. A rule with neither host nor path skipped both arms, so the
+// port comparison was unreachable and the function returned false.
+//
+// The port-only cases below fail on unpatched code.
+func TestIsPassThrough_PortOnlyRules(t *testing.T) {
+	req := &http.Request{Host: "api.example.com", URL: &url.URL{Scheme: "https", Host: "api.example.com", Path: "/v1/users"}}
+
+	cases := []struct {
+		name     string
+		rules    []models.BypassRule
+		destPort uint
+		want     bool
+	}{
+		{"port-only rule, port matches", []models.BypassRule{{Port: 3000}}, 3000, true},
+		{"port-only rule, port differs", []models.BypassRule{{Port: 3000}}, 8080, false},
+		{"two port-only rules, the second matches", []models.BypassRule{{Port: 43900}, {Port: 3000}}, 3000, true},
+		{"host-only rule that matches", []models.BypassRule{{Host: "api\\.example\\.com"}}, 443, true},
+		{"host-only rule that does not match", []models.BypassRule{{Host: "other\\.host"}}, 443, false},
+		{"host and port, both match", []models.BypassRule{{Host: "api\\.example\\.com", Port: 443}}, 443, true},
+		{"host matches but port does not", []models.BypassRule{{Host: "api\\.example\\.com", Port: 8080}}, 443, false},
+		{"path-only rule that matches", []models.BypassRule{{Path: "/v1/.*"}}, 443, true},
+		{"path and port, both match", []models.BypassRule{{Path: "/v1/.*", Port: 443}}, 443, true},
+		{"path matches but port does not", []models.BypassRule{{Path: "/v1/.*", Port: 8080}}, 443, false},
+		{"port-only rule against destPort 0", []models.BypassRule{{Port: 3000}}, 0, false},
+		// A rule constraining nothing must be inert, not "bypass everything" --
+		// a stray empty list entry must never silently disable recording.
+		{"rule constraining nothing is inert", []models.BypassRule{{}}, 443, false},
+		{"no rules at all", nil, 443, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsPassThrough(zap.NewNop(), req, tc.destPort, models.OutgoingOptions{Rules: tc.rules})
+			if got != tc.want {
+				t.Errorf("IsPassThrough(destPort=%d, rules=%+v) = %v, want %v", tc.destPort, tc.rules, got, tc.want)
+			}
+		})
+	}
+}
+
+// A rule whose path regex does not compile is skipped. Historically the skip
+// left a `passThrough` flag set by a PREVIOUS, matching arm still true, so the
+// function could return true on the strength of a rule it had just rejected --
+// and the leak also carried into later iterations, letting a subsequent rule
+// reach a port comparison it was never meant to reach.
+//
+// That fail-OPEN behaviour is deliberately changed to fail-CLOSED here: a rule
+// keploy cannot evaluate must not bypass recording. Recording something the
+// user wanted skipped is recoverable; silently skipping something they wanted
+// recorded is not. These cases pin that decision -- restoring the old flag
+// would make them fail.
+func TestIsPassThrough_MalformedRegexFailsClosed(t *testing.T) {
+	req := &http.Request{Host: "api.example.com", URL: &url.URL{Scheme: "https", Host: "api.example.com", Path: "/v1/users"}}
+
+	cases := []struct {
+		name     string
+		rules    []models.BypassRule
+		destPort uint
+		want     bool
+	}{
+		{
+			name:     "matching host then an uncompilable path must not bypass",
+			rules:    []models.BypassRule{{Host: "api\\.example\\.com", Path: "["}},
+			destPort: 443,
+			want:     false,
+		},
+		{
+			name:     "an uncompilable host must not bypass",
+			rules:    []models.BypassRule{{Host: "[", Port: 443}},
+			destPort: 443,
+			want:     false,
+		},
+		{
+			// The rejected rule must not leak permission into the next one.
+			// Here the second rule legitimately matches on port, so the answer
+			// is true either way -- but for the right reason only after the fix.
+			name:     "a rejected rule does not grant the next one permission",
+			rules:    []models.BypassRule{{Host: "api\\.example\\.com", Path: "["}, {Port: 3000}},
+			destPort: 3000,
+			want:     true,
+		},
+		{
+			name:     "...and the following rule is still evaluated on its own merits",
+			rules:    []models.BypassRule{{Host: "api\\.example\\.com", Path: "["}, {Port: 3000}},
+			destPort: 9999,
+			want:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsPassThrough(zap.NewNop(), req, tc.destPort, models.OutgoingOptions{Rules: tc.rules})
+			if got != tc.want {
+				t.Errorf("IsPassThrough(destPort=%d, rules=%+v) = %v, want %v", tc.destPort, tc.rules, got, tc.want)
+			}
+		})
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -183,8 +183,6 @@ func GetReqMeta(req *http.Request) map[string]string {
 }
 
 func IsPassThrough(logger *zap.Logger, req *http.Request, destPort uint, opts models.OutgoingOptions) bool {
-	passThrough := false
-
 	for _, bypass := range opts.Rules {
 		if bypass.Host != "" {
 			regex, err := regexp.Compile(bypass.Host)
@@ -192,8 +190,7 @@ func IsPassThrough(logger *zap.Logger, req *http.Request, destPort uint, opts mo
 				LogError(logger, err, "failed to compile the host regex", zap.Any("metadata", GetReqMeta(req)))
 				continue
 			}
-			passThrough = regex.MatchString(req.Host)
-			if !passThrough {
+			if !regex.MatchString(req.Host) {
 				continue
 			}
 		}
@@ -203,21 +200,29 @@ func IsPassThrough(logger *zap.Logger, req *http.Request, destPort uint, opts mo
 				LogError(logger, err, "failed to compile the path regex", zap.Any("metadata", GetReqMeta(req)))
 				continue
 			}
-			passThrough = regex.MatchString(req.URL.String())
-			if !passThrough {
+			if !regex.MatchString(req.URL.String()) {
 				continue
 			}
 		}
-
-		if passThrough {
-			if bypass.Port == 0 || bypass.Port == destPort {
-				return true
-			}
-			passThrough = false
+		// A rule that constrains nothing is inert, not "bypass everything":
+		// `bypassRules: [{}]`, or a stray empty list entry, must never
+		// silently disable recording for the whole run. Mirrors the
+		// bypassEligible gate in pkg/agent/hooks/conn/util.go.
+		if bypass.Host == "" && bypass.Path == "" && bypass.Port == 0 {
+			continue
+		}
+		// Reached only once every field the rule DID set has matched, so a
+		// port-only rule -- what --pass-through-ports and `bypassRules:
+		// [{port: N}]` produce via config.SetByPassPorts -- is decided here on
+		// port alone. This branch used to be guarded by a `passThrough` flag
+		// that only the Host/Path arms ever assigned, so a port-only rule
+		// could never reach it and was a no-op at the proxy layer.
+		if bypass.Port == 0 || bypass.Port == destPort {
+			return true
 		}
 	}
 
-	return passThrough
+	return false
 }
 
 func kebabToCamel(s string) string {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -228,9 +228,43 @@ func kebabToCamel(s string) string {
 	return strings.Join(parts, "")
 }
 
+// NoViperBindAnnotation marks a flag whose value is consumed directly via
+// cmd.Flags().Get*, never through viper.Unmarshal into the config struct.
+// BindFlagsToViper skips such a flag entirely.
+//
+// Why this exists: BindFlagsToViper derives a command-scoped key
+// <cmd.Name()>.<camelCase(flag)>, which ASSUMES the flag's destination lives
+// under the command's own config section. When it does not, that derived key
+// can land on an unrelated field of an incompatible type and abort
+// viper.Unmarshal for the WHOLE config, taking the command down with it.
+//
+// --pass-through-ports is the case that exposed this. It is consumed directly
+// at cli/provider/cmd.go:1293 and :2077 (into Config.BypassRules, via
+// config.SetByPassPorts) and at :1790 (into Agent.PassThroughPorts, for
+// `keploy agent` only) -- never through viper.Unmarshal. But on any command
+// whose Name() is "record" -- both `keploy record` and `keploy mock record` --
+// the derived key is record.passThroughPorts, which maps onto
+// Record.PassThroughPorts ([]models.PassThroughRule, telemetry-egress rules: an
+// unrelated feature that merely shares the name). Decoding []uint into a struct
+// slice fails with 'record.passThroughPorts[0]' expected a map or struct, got
+// "uint", aborting the whole config unmarshal and with it the command. This
+// fires only when the flag is explicitly passed: its default is empty, and an
+// empty list decodes into []PassThroughRule cleanly. `keploy test` and
+// `keploy mock replay` are unaffected because their Name() differs.
+//
+// Note this skips the binds BindFlagsToViper itself makes; the separate
+// viper.BindPFlags(cmd.Flags()) at cli/provider/cmd.go:628 still binds the
+// literal kebab key, which is harmless because it matches no mapstructure name.
+const NoViperBindAnnotation = "keploy_no_viper_bind"
+
 func BindFlagsToViper(logger *zap.Logger, cmd *cobra.Command, viperKeyPrefix string) error {
 	var bindErr error
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if _, skip := flag.Annotations[NoViperBindAnnotation]; skip {
+			logger.Debug("flag is read directly, not via viper; skipping bind",
+				zap.String("flag", flag.Name))
+			return
+		}
 		camelCaseName := kebabToCamel(flag.Name)
 		err := viper.BindPFlag(camelCaseName, flag)
 		if err != nil {

--- a/utils/viper_bind_annotation_test.go
+++ b/utils/viper_bind_annotation_test.go
@@ -1,0 +1,100 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+// TestBindFlagsToViper_AnnotatedFlagIsNotBound reproduces the --pass-through-ports
+// defect and proves the fix.
+//
+// BindFlagsToViper derives a command-scoped key <cmd.Name()>.<camelCase(flag)>,
+// which assumes the flag's destination lives under the command's own config
+// section. --pass-through-ports feeds Agent.PassThroughPorts ([]uint), but on
+// any command whose Name() is "record" -- both `keploy record` and
+// `keploy mock record` -- the derived key is record.passThroughPorts, which maps
+// onto Record.PassThroughPorts ([]models.PassThroughRule): an unrelated
+// telemetry-egress feature that merely shares the name. viper.Unmarshal then
+// aborts the WHOLE config with
+//
+//	'record.passThroughPorts[0]' expected a map or struct, got "uint"
+//
+// taking down both commands that accept the flag. On unpatched code this test
+// fails at the first assertion.
+func TestBindFlagsToViper_AnnotatedFlagIsNotBound(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	cmd := &cobra.Command{Use: "record"}
+	cmd.Flags().UintSlice("pass-through-ports", nil, "")
+	if err := cmd.Flags().SetAnnotation("pass-through-ports", NoViperBindAnnotation, []string{"true"}); err != nil {
+		t.Fatalf("SetAnnotation: %v", err)
+	}
+	if err := cmd.Flags().Set("pass-through-ports", "3000"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if err := BindFlagsToViper(zap.NewNop(), cmd, ""); err != nil {
+		t.Fatalf("BindFlagsToViper: %v", err)
+	}
+
+	if viper.IsSet("record.passThroughPorts") {
+		t.Errorf("record.passThroughPorts is bound in viper (value=%v); it collides with "+
+			"Record.PassThroughPorts []models.PassThroughRule and aborts viper.Unmarshal",
+			viper.Get("record.passThroughPorts"))
+	}
+	if viper.IsSet("passThroughPorts") {
+		t.Errorf("bare passThroughPorts is bound in viper; the annotation did not skip the bind")
+	}
+
+	// POSITIVE CASE -- the dangerous regression would be a fix that stops the
+	// flag working. Every consumer reads it directly, so it must still be readable.
+	got, err := cmd.Flags().GetUintSlice("pass-through-ports")
+	if err != nil {
+		t.Fatalf("GetUintSlice: %v", err)
+	}
+	if len(got) != 1 || got[0] != 3000 {
+		t.Errorf("flag value lost: got %v, want [3000]", got)
+	}
+}
+
+// NEGATIVE CONTROL: an un-annotated flag must still bind exactly as before, so
+// the fix cannot silently disable viper binding for every other flag.
+func TestBindFlagsToViper_UnannotatedFlagStillBound(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	cmd := &cobra.Command{Use: "record"}
+	cmd.Flags().String("build-delay", "", "")
+	if err := cmd.Flags().Set("build-delay", "30"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := BindFlagsToViper(zap.NewNop(), cmd, ""); err != nil {
+		t.Fatalf("BindFlagsToViper: %v", err)
+	}
+	if !viper.IsSet("record.buildDelay") {
+		t.Fatal("record.buildDelay is NOT bound; the fix broke normal flag binding")
+	}
+	if got := viper.GetString("record.buildDelay"); got != "30" {
+		t.Errorf("record.buildDelay = %q, want \"30\"", got)
+	}
+}
+
+// The commands that never had the defect must be unchanged: their Name() differs,
+// so their derived key never collided.
+func TestBindFlagsToViper_NonCollidingCommandUnaffected(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().UintSlice("pass-through-ports", nil, "")
+	if err := cmd.Flags().Set("pass-through-ports", "3000"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := BindFlagsToViper(zap.NewNop(), cmd, ""); err != nil {
+		t.Fatalf("BindFlagsToViper: %v", err)
+	}
+	if !viper.IsSet("test.passThroughPorts") {
+		t.Error("test.passThroughPorts not bound; unrelated commands were affected")
+	}
+}


### PR DESCRIPTION
15 commits · 35 files · +3600 / −130

---

## Eleven fixes for `keploy mock record` / `keploy mock replay`

`keploy mock` lets keploy act purely as a mocking layer for a project's **own**
test runner — pytest, jest, go test, Playwright — rather than owning the test
cases itself. It shipped in #4469 and has had four commits since.

I drove a real browser end-to-end suite through it with the backend switched off.
These are the defects that surfaced. Every one of them is generic: none needs a
browser or any knowledge of my project to reproduce, and several affect
`keploy record` and `keploy test` too.

**The common thread is worth stating plainly: most of these produce a *clean
run*.** `missed: 0`, exit 0, nothing in the log — while the application under
test received the wrong bytes or none at all. That is the failure mode that
makes a mocking layer untrustworthy, so it is what most of these fix.

Each commit message carries its own measured before/after. Unless noted, the
measurement is a real binary in a privileged Linux container, dependency stopped
for replay.

---

## The fixes

### 1. A repeated request replays the first recording, forever

An app that calls the same endpoint several times and gets different answers each
time is served the **first** answer every time.

```
record   SEEN_SEQUENCE=[1, 2, 3]
replay   SEEN_SEQUENCE=[1, 1, 1]
         mock replay summary {"loaded": 5, "consumed": 1, "missed": 0}
```

Cause: `TestModeInfo.Lifetime` is `json:"-"`, so it is re-derived from
`Spec.Metadata["type"]` on every load. The HTTP recorder stamps every capture
`HTTP_CLIENT` — a real, deliberate tag — but the lax-mode rule promotes any
non-canonical tag on a listed protocol to session lifetime, and HTTP is listed.
Session mocks are never consumed, so the tape never advances.

The fix splits that one protocol list in two. The untagged rule keeps the
original list, so pre-tagging recordings replay byte-for-byte; only the lax
tagged rule loses HTTP. **Measured blast radius: 9 of 308 rows in a full
protocol × tag × connection-id × preflight matrix, all HTTP.**

This is what `docs/explanation/mock-lifetimes.md` already documents — *"Any other
tag — including `mocks`, `HTTP_CLIENT`, or none at all — routes to per-test"* —
and the lax rule is documented nowhere. It is also what the comment on that list
already argues: it declines to add Redis/Kafka precisely because doing so *"would
wrongly route those to the session pool — which breaks the per-test consumption
the matcher depends on"*. That is this bug, for a protocol already on the list.

`KEPLOY_STRICT_MOCK_WINDOW=1` also disables the rule, but measured it moves **112
of 308 rows across 7 protocols** — it would strip the promotion from MySQL and
Postgres, which is the depletion case the rule exists to prevent.

### 2. A bodyless response swallows the rest of its keep-alive connection

Per RFC 9112 §6.3 a `204`, `304`, `1xx`, or any response to `HEAD` has no body
regardless of headers. The v2 recorder had no status-code awareness, so those fell
into read-until-close and consumed every later exchange on the connection as body
— returning success.

```
four exchanges on one keep-alive connection → 1 mock recorded
after the fix                                → 4
```

This is the shared v2 recorder, so it affects `keploy record` as well as mock mode.
Chunked framing is deliberately **unchanged**; a test pins that.

### 3. `--pass-through-ports` aborts the command *(three commits)*

```
$ keploy record --pass-through-ports 3000 -c "..."
ERROR failed to unmarshal the config
  'record.passThroughPorts[0]' expected a map or struct, got "uint"
```

`BindFlagsToViper` derives `<cmd.Name()>.<camelCase(flag)>`. Both `keploy record`
and `keploy mock`'s `record` subcommand are named `record`, so the key becomes
`record.passThroughPorts` — which is `Record.PassThroughPorts
[]models.PassThroughRule`, an unrelated telemetry feature that shares the name.
Decoding `[]uint` into a struct slice kills the whole config unmarshal.

Two further parts: mock mode never populated the kernel-level bypass, so the flag
did nothing even once it parsed; and a bypass rule specifying **only** a port was
ignored at the proxy layer, because the port comparison sat behind a flag only
the host and path arms ever set.

```
keploy record       port 7001: 0 mocks    (bypass works)
keploy mock record  port 7001: 2 mocks    (bypass inert)  → 0 after the fix
```

A fourth commit reserves the agent's own control port in the fixed-size kernel
array, which the second commit makes reachable, and warns on truncation instead
of silently dropping ports. In mock mode the wrapped runner reaches the agent's
own API at `localhost:<AgentPort>`; that bypass was appended **last** to a
`[10]int32` that truncates, so ten `--pass-through-ports` push it off the end.
The symptom is not a hard failure, which is what makes it worth fixing:

```
record   before  exit 0, 9 mocks — 3 dependency calls plus 6 recordings of
                 keploy's OWN /agent/scope/* traffic, and no warning
         after   exit 0, 3 mocks, 0 agent-API mocks, WARN names the dropped port

replay   before  exit 0, "3 passed", {"loaded":9,"consumed":9,"missed":0}
                 every scope/begin → {"scoped":false,"reason":"record_window_opened"}
         after   exit 0, "3 passed", {"loaded":3,"consumed":3,"missed":0}
                 every scope/begin → {"scoped":true,"reason":"pool_restricted"}
```

Read the `scoped` field, not the exit code: before the fix the runner's
`scope/begin` never reached the live agent at all — it was answered off the tape
with the *record-time* response, so per-test isolation was silently off for the
whole run while every signal keploy emits said success.

### 4. A recording made without `Origin` is served to a browser request

Header matching is a subset test, so a recording with *fewer* headers is *more*
permissive. Harmless except for `Origin`: its presence on the request is what
makes a server attach the CORS header to the response. An app that calls its own
API from both a browser and a server-side renderer records both shapes; the
CORS-less one matches browser requests, the browser discards the response, and
keploy reports a successful match.

```
before   REPLAY SERVED  · summary {"consumed": 1, "missed": 0}
after    REPLAY MISSED  · summary {"consumed": 0, "missed": 1}
```

Presence only — the value is not compared. Skipped when `origin` is in header
noise, so it can be turned off deliberately.

### 5. A response of 8 KiB or more is never served

Large responses are spilled to a side file, leaving a nil response and a lazy
loader. The serializer checked for nil **before** calling the loader.

```
before   http: mock "mock-2" has no response to serialize → connection torn down
         summary {"loaded": 3, "consumed": 1, "missed": 0}
after    GOT 9010 bytes
```

Note `missed: 0` in the failing case. Reachable today with
`KEPLOY_STRICT_MOCK_WINDOW=1`; reachable on the **default** path once fix 1 lands,
since only per-test mocks are eligible for the disk store. That is why the two
are in the same series.

**A second commit comes with it, and it is the reason this pair is not one
commit.** Serving a spilled mock means running its lazy loader, and that loader
*wrote* — `Spec.HTTPResp = …` and `responseHydrator = nil`. Those writes were
dead before: the nil guard rejected every spilled mock first, so every surviving
caller had a nil hydrator and the call was a pure read. Moving the load above
the guard made them live, and a pooled `*Mock` is not owned by the goroutine
serving it — `handleConnection` runs one goroutine per accepted connection and
the pool's getters hand out the stored pointer, not a copy. A second connection
that matched the same mock reads the whole struct by value on the consume path
(`deleteMock := *matchedMock`, `http/match.go:1269`).

So fixes 1 and 5 together introduce a data race that does not exist on `main`.
Measured with a race-enabled binary, eight concurrent connections onto one 9 KiB
spilled mock, dependency stopped:

```
before   rep.log: 8 × WARNING: DATA RACE      (replay still exits 0, "8 consumed, 0 missed")
after    rep.log: 0
```

A mutex cannot close it: the readers are by-value dereferences, and they cannot
take a lock without changing `MockMemDb`'s signatures — `DeleteFilteredMock`
takes `models.Mock`, not a pointer — which is an interface break for
out-of-tree parsers. `mockmanager_race_test.go:36` already documents this same
hole for `HitCount`. So the fix is to stop writing: `HydratedHTTPResp` resolves
the response and returns it without touching the mock, and the serve path holds
it locally. A repeat serve re-reads the blob instead of caching it, which is
the intended trade — a per-test mock is consumed on first match, so a repeat
serve is off the normal path anyway. `HydrateResponse` is retained and
documented as unsafe on a pooled mock rather than deleted, because out-of-tree
parsers depend on the signature.

### 6. A failed upstream TLS dial panics the connection

`tls.Dial` returns a concrete `*tls.Conn`, so a failed dial leaves a non-nil
`net.Conn` interface holding a nil pointer. The `dstConn != nil` guard passes and
the deferred close dereferences it. Reproduced against a DNS-sinkholed host: 48
panics in one run, each losing that connection's recording while the run reports
success.

**#4569 landed the same repair while this branch was open**, as a side effect of
adding the loopback address-family fallback: both call sites now go through
`util.DialDestinationTLS`, which builds on `tls.Dialer` — and the stdlib refuses
to put a typed nil in that interface. The production change here is dropped on
rebase. What is kept is the regression test, repointed at the new helper,
because nothing else pins the nil shape: the eleven tests in
`util/dialdest_test.go` all cover the fallback. Revert either helper to
`tls.Dial` and the panic returns silently, since it surfaces as a recovered
panic rather than a test failure.

### 7. A changed request value gets the stale response

Once byte-exact matching fails, `bodyMatch` only checks that the request carries
every top-level key the recording had. No value is read. Every GraphQL payload is
`{operationName, query, variables}`, so any GraphQL request matches any recorded
GraphQL mock on the same URL.

The strict enforcement already exists but `mock replay` never enabled it: the
options struct did not forward it, and the flag was not registered on the command
at all. Both fixed; **off by default**.

### 8. `scope/begin` cannot report that it did not isolate the test

The scope API is the documented integration point for a user's own runner. Several
paths inside `BeginScope` leave the whole suite's pool armed — no mapping table,
the test's name absent from it (a renamed test), or a name mapped to zero mocks —
and all answered `{"status":"ok"}`, identical to a correctly isolated test.

```
{"status":"ok","scoped":true, "mocks":3,"reason":"pool_restricted"}
{"status":"ok","scoped":false,"mocks":0,"reason":"unmapped_scope"}
```

`status` is retained verbatim, so an existing runner is unaffected.

---

### 9. A large recording is skipped on the egress-passthrough path

The same defect as fix 5, one function over. `serveOnePassThroughMock` answers a
`--pass-through-ports` request from a recorded mock without consuming it, and
rejected any candidate whose response was nil — but its candidates include the
**per-test** pool, which is exactly the tier that spills. So every spilled
recording was skipped and the caller wrote a **synthetic 200 with an empty body**,
logged only at `Debug`.

Reachable because of this series: before fix 1, tagged HTTP was promoted to
session lifetime and session mocks are never disk-eligible, so a passthrough
candidate could not have spilled.

### 10. A chunked body is framed by a byte marker instead of its framing

The recorder ended a chunked body when the buffer *ended with* `0\r\n\r\n`. That is
wrong in both directions. It misses a real end — a last-chunk extension
(`0;pad=x`) or a trailer section (`0\r\nGrpc-Status: 5`) — and swallows every later
exchange on the connection. And it finds an end that is not there: a data chunk
whose payload ends in `0\r\n` is followed by the framing CRLF, so on a *streamed*
response a tee boundary lands there routinely and the body is cut short, which
then fails to parse and records **nothing** for that connection.

```
trailer after the last chunk        recorded [/grpc]  want [/grpc /after]
chunk extension on the last chunk   recorded [/ext]   want [/ext /after]
boundary after a payload "0\r\n"     recorded []       want [/split /after]
chunked REQUEST with a trailer      recorded []       want [/obj /after]
```

The request-side case is what the AWS SDKs send for a streaming `PutObject` with
checksums (`x-amz-trailer`), and it costs the whole connection. The response-side
case comes from an Envoy/Istio gRPC↔HTTP/1.1 bridge — and note `Grpc-Status: 0`
happens to end in the marker, so it only fires when a call **fails**.

The fix walks the framing instead of scanning for bytes. The pre-existing test
that claimed to guard the false-positive delivers the payload as one chunk, so it
never ends at the false marker — it passed for a reason unrelated to what it
guards. It is kept, joined by the packing that actually bites, and by an
exhaustive every-split-point case.

### 11. Parallel workers starve a shared CORS preflight

Fix 4's companion. Promoting a preflight to session lifetime fixes the path where
the runner reports no worker PID. When it reports one, `scope/begin` installs the
per-worker filter instead, and that filter matches on mock **names**: a preflight
is attributed to whichever test's window it happened to fire in, so every other
worker loses it and the browser fails CORS with `net::ERR_FAILED`. The gate is the
PID, not a worker count — a single-worker runner that reports its pid hits it too.

Exempting `Lifetime == LifetimeSession` would undo what per-worker scoping is for:
rules 4 and 5 make most of the pool session-lifetime for reasons unrelated to
reusability. So the exemption keys off the **derivation reason** —
`(*Mock).IsSharedAcrossTests`, now the single definition of "a rule-1 protocol
override fired", called by both `DeriveLifetime` and the scoping filter. It grants
read visibility only; session mocks are never consumed, so a worker still cannot
take another worker's mock.

Pre-existing rather than introduced here — the MySQL arm of rule 1 has always been
droppable the same way — but fix 4 is what makes it routinely reachable.

## Behaviour changes users will notice

1. **Repeated identical requests now advance the tape.** An app that issues *more*
   calls at replay than were recorded gets a 502 and a reported miss where it
   previously re-served the first recording silently. Under `--strict` that turns
   such a run red. Intended: a loud over-read beats quiet wrong data.
2. **Mixed browser/server-side recordings will start missing.** The match was
   wrong and the browser was discarding the response; a miss is fixable, a
   wrongly-served response is not.
3. **`test.schemaNoiseStrict: true` already in a config now takes effect** for
   `mock replay`, where it was previously inert. Those users also get `NoiseConfig`
   forwarded, which loosens header and url matching at the same time as it tightens
   body matching.
4. **Chunked recordings that previously ended early now frame to their true end.**
   A set recorded before this change may hold a truncated body or a missing
   exchange; re-record to pick them up. Nothing that framed correctly changes.

## One known limitation, tracked separately

Not a defect, and nothing here depends on it — stating it so it is not a
surprise later.

`MockMemDb`'s consume methods take `models.Mock` **by value**
(`DeleteFilteredMock(mock models.Mock)`), while its read methods hand out
`*models.Mock`. A parser holding a pool pointer must therefore copy the whole
496-byte struct to consume it — `deleteMock := *matchedMock` — and a copy is a
read of every field. Any concurrent write to that mock tears it.

This is what fix 5's race was an instance of, and the repo already documents a
second instance for `HitCount` (`mockmanager_race_test.go:36`). **Both are
symptom-free today** — fix 5's companion removes the write, and a copy with
nobody writing is harmless.

It is not fixed here because it cannot be: the interface is consumed by nine
protocols in the enterprise repo (zookeeper, sqs, redis, kafka, pulsar,
aerospike, couchbase, hbase, memcached) plus three test doubles that implement
it. Changing the signature stops that repo compiling, so the two must release
together. Filed separately with that evidence.

Two other items that were in an earlier draft of this section have been removed
rather than deferred, because neither is a bug: spilled **Mongo** responses are
never hydrated, but no Mongo parser exists in either repo, so the code is inert;
and behaviour after a **`101`** upgrade is a deliberate design decision
(`recordv2.go:287`), not an omission.

## Testing

Every commit adds tests that fail against its parent on the case they protect,
with controls that pass either way. Most were additionally reproduced end-to-end
with real binaries under privileged Docker, dependency stopped for replay; the
measurements are in the commit messages. Fixes 9, 10 and 11 are pinned by
red-before/green-after unit tests driving the real recorder and the real scoping
filter, not by an e2e.

`go build ./...`, `go vet ./...` and `gofmt -l` are clean, and **`go test ./...`
is green natively on Linux** — Debian 13, kernel 6.12, amd64, Go 1.27.0: 65
packages ok, 0 failures, 64s. That includes `pkg/agent/hooks/linux`, which is
`//go:build linux` and so never ran on the macOS box this series was written on;
its 19 tests — 15 pre-existing plus the 4 added here — all pass.

Three Java tests in `pkg/agent/proxy/tls` *fail* on macOS and **skip** on Linux.
Neither box has a JDK; the difference is an Apple artifact, not a Java gap.
macOS ships a `/usr/bin/java` stub that exists and then reports "Unable to
locate a Java Runtime", so the guard sees a java binary and proceeds where on
Linux it finds none and skips. Pre-existing, identical on unpatched
`origin/main` (e8aa6b1b), and untouched by this series.

Two fixes were additionally reproduced end-to-end with **race-enabled**
binaries. The spilled-response race above is one: eight concurrent connections
onto a single 9 KiB mock, dependency stopped, `WARNING: DATA RACE` counted in
the replay log — 8 before, 0 after, same workload and build flags with only
`decode.go` differing. `go-test.yaml`'s race lane also gains
`./pkg/agent/proxy/integrations/http/`; it ran only `./pkg/agent/proxy/`, so
the new regression test would have passed on a racing build.

The agent-control-port commit was additionally reproduced on that VM end-to-end,
real binaries and real eBPF under privileged Docker. Its four new tests build a
real BPF map and call `RegisterClient` unmodified; the two that assert port
order fail against the parent commit, and the two controls pass either way. The
e2e used the three-test pytest suite from
`.github/workflows/test_workflow_scripts/mock/mock-linux.sh`, so it demonstrates
the lost scoping rather than a wider suite's mis-served mocks.

**One workflow change comes with it.** That real BPF map needs `CAP_BPF`, and
`Running Unit Tests` is unprivileged — so those four tests would skip there and
leave the package reporting `ok`, which is the same silent-green defect the
commit is about. `go-test.yaml` now runs that one package a second time under
`sudo` with `KEPLOY_TEST_BPF_REQUIRED=1`, which makes an unavailable map a
failure rather than a skip. Verified in all three states: no capability and the
variable unset skips, no capability with it set fails loudly, capability with
it set passes for real.

One caveat I would rather state than have found:

- **Commit 8 is the only public API addition** (a response struct and eight reason
  constants a runner would depend on) and has no coupling to the other ten. Happy
  to split it into its own PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
