### PR TITLE
fix(install): point Windows users at the Community build, not WSL2 only

### DIFF
--- a/keploy.sh
+++ b/keploy.sh
@@ -456,10 +456,23 @@ installKeploy (){
                 echo "Unsupported architecture: $ARCH"
                 return
             fi
-        elif [[ "$OS_NAME" == MINGW32_NT* ]]; then
-            echo "\e]8;; https://pureinfotech.com/install-windows-subsystem-linux-2-windows-10\aWindows not supported please run on WSL2\e]8;;\a"
-        elif [[ "$OS_NAME" == MINGW64_NT* ]]; then
-            echo "\e]8;; https://pureinfotech.com/install-windows-subsystem-linux-2-windows-10\aWindows not supported please run on WSL2\e]8;;\a"
+        elif [[ "$OS_NAME" == MINGW32_NT* ]] || [[ "$OS_NAME" == MINGW64_NT* ]] || [[ "$OS_NAME" == MSYS_NT* ]] || [[ "$OS_NAME" == CYGWIN_NT* ]]; then
+            # This is the OSS build, which intercepts with eBPF and therefore has
+            # no native Windows backend -- DefaultNativeCommandSupported in
+            # cli/provider/hooks.go accepts linux only, so `keploy record -c ...`
+            # is refused here. Native Windows (userspace, no Administrator) ships
+            # in the Community build, so point there rather than only at WSL2.
+            echo "The OSS build has no native Windows support (it intercepts with eBPF, which is Linux only)."
+            echo ""
+            echo "For native Windows -- no WSL, no Docker, no Administrator -- install the Community build:"
+            echo "  https://keploy.io/docs/installation/windows-installation/"
+            echo ""
+            echo "To stay on the OSS build, run Keploy under WSL2:"
+            echo "  https://pureinfotech.com/install-windows-subsystem-linux-2-windows-10"
+            echo ""
+            echo "The OSS build also supports running your application in Docker on every"
+            echo "platform. Download keploy_windows_amd64 from the releases page first:"
+            echo "  https://github.com/keploy/keploy/releases"
         else
             echo "Unknown OS, install Linux to run Keploy"
         fi


### PR DESCRIPTION
## Problem

`keploy.sh` tells Windows users:

```
Windows not supported please run on WSL2
```

That is wrong about the product. Native Windows support exists, is userspace, loads no driver and needs no Administrator — it just ships in the Community build rather than this one. `AgentNeedsElevation` (`pkg/platform/http/utils/elevate.go:29`) returns true for Linux only, and the Windows backend is registered via `RegisterNativeCommandSupport`.

The message is right that *this* build can't do it — `DefaultNativeCommandSupported` (`cli/provider/hooks.go:38`) is `goos == "linux"` — but it sends people to WSL2 when a native option exists one install away.

## Changes

- Say plainly that the OSS build has no native Windows support **because it intercepts with eBPF**, and link the Community install docs.
- Keep WSL2 and Docker as the ways to stay on this build. The releases-page asset is now named *before* Docker is suggested — this branch installs nothing, so a bare `keploy record -c "docker compose up"` would have been a dead end.
- Match `MSYS_NT*` and `CYGWIN_NT*` alongside `MINGW*`, and collapse the two duplicated MINGW arms into one.

## Note on reachability

This branch is only reached via `source install.sh --oss`. The default path at `keploy.sh:493` re-execs `keploy.io/ent/install.sh`, so the default Windows behaviour is fixed by keploy/enterprise#2560, not by this PR. This one stops the OSS path from being actively misleading.

## Testing

`bash -n` clean; `shellcheck -S error` 0 before and after.

```
The OSS build has no native Windows support (it intercepts with eBPF, which is Linux only).

For native Windows -- no WSL, no Docker, no Administrator -- install the Community build:
  https://keploy.io/docs/installation/windows-installation/

To stay on the OSS build, run Keploy under WSL2:
  https://pureinfotech.com/install-windows-subsystem-linux-2-windows-10

The OSS build also supports running your application in Docker on every
platform. Download keploy_windows_amd64 from the releases page first:
  https://github.com/keploy/keploy/releases
```