### PR TITLE
fix(dns): decide a redundant search expansion from the name, not from upstream

### DIFF
--- a/pkg/agent/proxy/dns.go
+++ b/pkg/agent/proxy/dns.go
@@ -260,6 +260,47 @@ func (p *Proxy) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	}
 }
 
+// isRedundantSearchExpansion reports whether name is a search-list expansion
+// applied to a name that already carried that same suffix — the shape a
+// resolver produces while walking its search list past an already-qualified
+// name (ndots:5 is the Kubernetes default).
+//
+// Such a name cannot resolve, so capture never recorded it: both capture
+// paths skip non-Success rcodes deliberately — recordDNSMock below, and
+// enterprise pkg/agent/proxy/dns_capture.go. Its absence at replay is
+// therefore expected, and the miss report's own advice — "re-record to
+// capture DNS queries" — can never succeed for it.
+//
+// Decided from the name alone on purpose. #4565 suppresses the same class of
+// report but only on a definitive NXDOMAIN from upstream, which makes the
+// verdict depend on the resolver being reachable within the forward deadline;
+// a timeout or a SERVFAIL then reports a miss for a name that never could have
+// had a mock. A name carrying only ONE search suffix is NOT redundant: it is
+// a real name, and its miss is still worth reporting.
+func (p *Proxy) isRedundantSearchExpansion(name string) bool {
+	if len(p.dnsSearch) == 0 || name == "" {
+		return false
+	}
+	q := strings.ToLower(dns.Fqdn(name))
+	for _, s := range p.dnsSearch {
+		s = strings.ToLower(strings.TrimSuffix(dns.Fqdn(s), "."))
+		if s == "" {
+			continue
+		}
+		suffix := "." + s + "."
+		if !strings.HasSuffix(q, suffix) {
+			continue
+		}
+		// Strip the trailing ".s", keeping the final dot, and ask whether
+		// what remains still ends in the same suffix.
+		base := q[:len(q)-len(s)-1]
+		if strings.HasSuffix(base, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mode, mockingEnabled bool, reqTime time.Time, session *agent.Session) dnsCacheEntry {
 	switch mode {
 	case models.MODE_TEST:
@@ -429,7 +470,20 @@ func (p *Proxy) resolveUncachedDNSResponse(question dns.Question, mode models.Mo
 		//
 		// The app is unaffected either way -- it still receives the synthetic
 		// NOERROR steer below (issue #2006). Only the spurious verdict goes.
-		if mockingEnabled && !upstreamSaysNameDoesNotExist {
+		// A redundant search expansion is unrecordable by construction, so it
+		// is filtered here rather than on upstream's verdict — that keeps the
+		// report from depending on whether the resolver answered at all.
+		redundantExpansion := mockingEnabled && p.isRedundantSearchExpansion(question.Name)
+		if redundantExpansion {
+			// The only field-visible trace that the name-shape gate fired.
+			// Without it a suppressed report and a report that never reached
+			// the gate look identical in the agent log.
+			p.logger.Debug("DNS mock miss suppressed: redundant search-list expansion, unrecordable by construction",
+				zap.String("query", question.Name),
+				zap.String("qtype", dns.TypeToString[question.Qtype]),
+				zap.Strings("search", p.dnsSearch))
+		}
+		if mockingEnabled && !upstreamSaysNameDoesNotExist && !redundantExpansion {
 			// Send mock not found error if we couldn't match any DNS
 			// mock and upstream forwarding also failed.
 			p.logger.Debug("mock miss",

--- a/pkg/agent/proxy/dns_forward.go
+++ b/pkg/agent/proxy/dns_forward.go
@@ -78,6 +78,11 @@ func (p *Proxy) captureDNSUpstream() {
 		return
 	}
 
+	// Keep the search list: it is what makes a redundant expansion
+	// recognisable without a round trip. Captured even when every
+	// nameserver is filtered out below, since the two are independent.
+	p.dnsSearch = append([]string(nil), config.Search...)
+
 	// resolv.conf has no port syntax per RFC — config.Port is populated
 	// from an "options" line or defaults to "53". We compare by string
 	// to avoid parsing surprises (leading zeros, etc.).
@@ -109,7 +114,8 @@ func (p *Proxy) captureDNSUpstream() {
 	p.dnsUpstreamPort = nsPort
 	p.logger.Debug("captured upstream DNS resolvers for forward-on-miss",
 		zap.Strings("servers", p.dnsUpstreamServers),
-		zap.String("port", p.dnsUpstreamPort))
+		zap.String("port", p.dnsUpstreamPort),
+		zap.Strings("search", p.dnsSearch))
 }
 
 // hasDNSUpstream reports whether the forwarder has any real upstream

--- a/pkg/agent/proxy/dns_search_expansion_test.go
+++ b/pkg/agent/proxy/dns_search_expansion_test.go
@@ -1,0 +1,161 @@
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"go.keploy.io/server/v3/pkg/models"
+	"go.uber.org/zap"
+)
+
+// A Kubernetes resolver with ndots:5 walks its search list before trying a name
+// absolutely, so `appdb.ns.svc.cluster.local` is first probed as
+// `appdb.ns.svc.cluster.local.ns.svc.cluster.local.` — the search domain glued
+// onto a name that already carried it. Such a name cannot resolve and cannot
+// have been recorded: capture skips non-Success rcodes by design.
+//
+// #4565 already suppresses the mock-miss report for these, but only when
+// upstream actually answers NXDOMAIN. Every other way the forward can end —
+// fwdErr != nil (no upstream configured, unreachable, or the 2s loop-wide
+// deadline expiring) and SERVFAIL/REFUSED — still reports. Which of those
+// fires in the enterprise selfhosted-cloud-replay-e2e lane is UNKNOWN: the
+// mismatch was seen on pipelines 8804, 8802 and 8796 (all on
+// appdb.java-mysql.svc.cluster.local.java-mysql.svc.cluster.local.), but the
+// agent's in-cluster DNS debug logs were never obtained, so no claim is made
+// here about resolver timing being the cause.
+//
+// This fix does not need to know: it closes all of those paths at once.
+//
+// A doubled search suffix is decidable from the name alone, so the report does
+// not need to ask upstream at all.
+func TestDNSMockMiss_RedundantSearchExpansion_IsNotReported(t *testing.T) {
+	// No upstream configured: forwardDNSUpstream fails immediately, which is
+	// the path #4565 deliberately keeps reportable. That isolates this fix —
+	// the suppression must come from the name's shape, not from an rcode.
+	p := &Proxy{
+		logger:     zap.NewNop(),
+		errChannel: make(chan error, 4),
+		dnsSearch:  []string{"java-mysql.svc.cluster.local", "svc.cluster.local", "cluster.local"},
+		IP4:        "127.0.0.1",
+	}
+
+	for _, qtype := range []uint16{dns.TypeA, dns.TypeAAAA} {
+		q := dns.Question{
+			Name:   "appdb.java-mysql.svc.cluster.local.java-mysql.svc.cluster.local.",
+			Qtype:  qtype,
+			Qclass: dns.ClassINET,
+		}
+		_ = p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+		select {
+		case err := <-p.errChannel:
+			t.Fatalf("%s: a doubled search suffix can never have a mock, so it must not be "+
+				"reported as one; got %v", dns.TypeToString[qtype], err)
+		default:
+		}
+	}
+}
+
+// CONTROL: a name the resolver expanded ONCE is a real name that is expected to
+// resolve. If it misses and upstream cannot confirm it is absent, that is still
+// a candidate defect and must stay reported — otherwise this fix would silence
+// every in-cluster miss.
+func TestDNSMockMiss_SingleSearchExpansion_IsStillReported(t *testing.T) {
+	p := &Proxy{
+		logger:     zap.NewNop(),
+		errChannel: make(chan error, 4),
+		dnsSearch:  []string{"java-mysql.svc.cluster.local", "svc.cluster.local", "cluster.local"},
+		IP4:        "127.0.0.1",
+	}
+
+	q := dns.Question{
+		Name:   "appdb.java-mysql.svc.cluster.local.",
+		Qtype:  dns.TypeA,
+		Qclass: dns.ClassINET,
+	}
+	_ = p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+	select {
+	case <-p.errChannel:
+		// expected: a legitimately-expanded name that missed is still a miss.
+	default:
+		t.Fatal("a singly-expanded name is a real name; its miss must still be reported")
+	}
+}
+
+func TestIsRedundantSearchExpansion(t *testing.T) {
+	p := &Proxy{dnsSearch: []string{"java-mysql.svc.cluster.local", "svc.cluster.local", "cluster.local"}}
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		{"appdb.java-mysql.svc.cluster.local.java-mysql.svc.cluster.local.", true},
+		{"appdb.svc.cluster.local.svc.cluster.local.", true},
+		{"appdb.cluster.local.cluster.local.", true},
+		{"appdb.java-mysql.svc.cluster.local.", false}, // expanded once — a real name
+		{"appdb.", false},
+		{"java-mysql.svc.cluster.local.", false}, // the search domain itself
+		{"appdb.example.com.", false},            // unrelated
+		// Label boundary: "mysvc.cluster.local" is a DIFFERENT name that
+		// merely ends in the same characters. Appending svc.cluster.local
+		// to it is a normal single expansion, so it stays reportable.
+		{"mysvc.cluster.local.svc.cluster.local.", false},
+		{"APPDB.JAVA-MYSQL.SVC.CLUSTER.LOCAL.JAVA-MYSQL.SVC.CLUSTER.LOCAL.", true}, // case-insensitive
+	} {
+		if got := p.isRedundantSearchExpansion(tc.name); got != tc.want {
+			t.Errorf("isRedundantSearchExpansion(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+	// The search list is normalised, not trusted verbatim: resolv.conf may
+	// spell an entry in any case, and with or without a trailing dot. DNS
+	// names are case-insensitive, so both must classify identically.
+	for _, entry := range []string{"SVC.CLUSTER.LOCAL", "svc.cluster.local."} {
+		q := &Proxy{dnsSearch: []string{entry}}
+		if !q.isRedundantSearchExpansion("appdb.svc.cluster.local.svc.cluster.local.") {
+			t.Errorf("search entry %q must still classify the doubled name", entry)
+		}
+	}
+
+	// With no search list nothing can be classified.
+	empty := &Proxy{}
+	if empty.isRedundantSearchExpansion("appdb.java-mysql.svc.cluster.local.java-mysql.svc.cluster.local.") {
+		t.Error("with no search list, no name should be classified as a redundant expansion")
+	}
+}
+
+// The predicate is only useful if the search list actually arrives from
+// resolv.conf. Every other test here sets dnsSearch directly, which would keep
+// passing even if the capture never populated it — and an empty list makes
+// isRedundantSearchExpansion return false for everything, silently restoring
+// the old behaviour in production.
+func TestCaptureDNSUpstream_CapturesSearchList(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resolv.conf")
+	content := "nameserver 10.96.0.10\n" +
+		"search java-mysql.svc.cluster.local svc.cluster.local cluster.local\n" +
+		"options ndots:5\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write temp resolv.conf: %v", err)
+	}
+	orig := resolvConfPath
+	resolvConfPath = path
+	defer func() { resolvConfPath = orig }()
+
+	p := &Proxy{logger: zap.NewNop(), DNSPort: 53}
+	p.captureDNSUpstream()
+
+	want := []string{"java-mysql.svc.cluster.local", "svc.cluster.local", "cluster.local"}
+	if len(p.dnsSearch) != len(want) {
+		t.Fatalf("dnsSearch = %v; want %v", p.dnsSearch, want)
+	}
+	for i := range want {
+		if p.dnsSearch[i] != want[i] {
+			t.Fatalf("dnsSearch = %v; want %v", p.dnsSearch, want)
+		}
+	}
+	// End to end: the captured list must classify the name from the pipelines.
+	if !p.isRedundantSearchExpansion("appdb.java-mysql.svc.cluster.local.java-mysql.svc.cluster.local.") {
+		t.Error("the captured search list should classify the doubled name as a redundant expansion")
+	}
+}

--- a/pkg/agent/proxy/proxy.go
+++ b/pkg/agent/proxy/proxy.go
@@ -274,6 +274,14 @@ type Proxy struct {
 	// dnsUpstreamPort is the port read alongside dnsUpstreamServers.
 	// Defaults to "53" when resolv.conf does not specify one.
 	dnsUpstreamPort string
+	// dnsSearch is the resolv.conf search list, kept so a query can be
+	// recognised as a redundant search expansion without asking upstream.
+	// A resolver probes name.S for each search domain S — before the name
+	// absolutely when it carries fewer than ndots dots (5 in Kubernetes),
+	// after otherwise — so a name that already ends in S is probed as
+	// name.S.S. That shape is decidable from the name alone, whatever
+	// upstream says, and nothing answers it, so capture never recorded it.
+	dnsSearch []string
 	// dnsForwardTimeout caps how long a single upstream Exchange is
 	// allowed to block. Short by design — a flaky resolver must never
 	// stall the app's DNS lookup. On timeout we fall through to the


### PR DESCRIPTION
## The bug

`selfhosted-cloud-replay-e2e > run-e2e` fails intermittently on enterprise CI with a mock mismatch for a name no one ever recorded:

```
Mock mismatch: [DNS] A    appdb.java-mysql.svc.cluster.local.java-mysql.svc.cluster.local.
Mock mismatch: [DNS] AAAA appdb.java-mysql.svc.cluster.local.java-mysql.svc.cluster.local.
Hint: DNS mocks may be missing. Re-record to capture DNS queries.
```

Note the doubled suffix. A Kubernetes resolver walks its search list, so a name already ending in a search domain `S` is probed as `name.S.S`. Nothing answers that, and capture never records it — both capture paths skip non-Success rcodes deliberately. So the hint is unfollowable: re-recording cannot produce a mock for a name that never resolves.

Seen on pipelines **8804, 8802 and 8796**, the latter two on unrelated branches.

## Why #4565 does not already cover it

#4565 suppresses exactly this report, but only when upstream returns a definitive `NXDOMAIN`. The report still fires on:

- `SERVFAIL` / `REFUSED` — deliberate, and unchanged here
- `fwdErr != nil` — no upstream configured, resolver unreachable, or the **2 s loop-wide forward deadline** expiring

So the verdict depends on the resolver being reachable and prompt. The lane passed on pipeline **8793** and failed on **8804** with the *same branch and the same OSS pin*.

**Which of those paths actually fires in that lane is unknown** — the agent's in-cluster DNS debug logs were never obtained, and this PR makes no claim about it. It does not need to: the fix closes all of them at once.

## The change

The shape is decidable from the name alone, so decide it there. `resolv.conf`'s search list was already parsed and thrown away; keep it, and gate the mock-miss report on whether the queried name is a search domain appended to a name that already carried it.

Deliberately narrow:

- only a **doubled** suffix qualifies — one search suffix is a real name, still reported
- anchored at a **label boundary**, so `mysvc.cluster.local.svc.cluster.local.` stays reportable
- `SERVFAIL`/`REFUSED` stay reportable for every other name, preserving #4565's distinction that *"the resolver failed" is not "the name is absent"*. Its six tests pass unmodified.

Only the report is suppressed. The app still receives the synthetic steer to the proxy IP that #2006 requires.

Two Debug lines are added because a silent no-op would otherwise be indistinguishable from a working fix: the captured search list is logged with the upstream servers, and one line fires when the gate suppresses a report.

## Tests

Four, each failing before and passing after, and mutation-checked:

| mutant | killed by |
|---|---|
| revert the report gate | `..._RedundantSearchExpansion_IsNotReported` |
| drop the search-list capture | `TestCaptureDNSUpstream_CapturesSearchList` |
| `suffix` loses the label boundary | `TestIsRedundantSearchExpansion` |
| drop case-folding / FQDN normalisation of a search entry | `TestIsRedundantSearchExpansion` |

`TestCaptureDNSUpstream_CapturesSearchList` exists because the other tests set `dnsSearch` directly and would keep passing even if capture never populated it — an empty list makes the predicate return `false` for everything, silently restoring today's behaviour.

Build, `go vet`, the full `pkg/agent/proxy` package and `-race` on the DNS subset are all clean.

## Relationship to #4474 / #4475

- **#4474** — its concrete evidence is 16 mismatches, all doubled search expansions. #4565 plus this change silence all of it regardless of rcode or reachability. Its broader framing is not fully addressed: a *non-doubled* name that SERVFAILs is still reported, on purpose.
- **#4475** — not obsoleted by this. Its distinguishing content is broadening suppression to all non-Success rcodes, which main rejected with a test. This removes its practical motivation, so it strengthens the case for closing it as superseded. Credit to @Aditya-eddy, whose analysis of the underlying cause was correct and arrived first.

## Scope this does not cover

An agent on `hostNetwork` reads the node's `resolv.conf`, which carries no `cluster.local` search entries, so the predicate finds nothing and the report behaves exactly as today. That fails safe.

**Do not assume this greens the enterprise lane until observed.** The replay container was measured at `options ndots:0`, under which the absolute name is tried first — so the doubled probe may originate in the in-cluster `--trigger` stage rather than the docker replay. If the absolute lookup is itself failing first, the doubled miss is a symptom of something earlier. The new Debug line is what will tell you which.
