### PR TITLE
test(replay): assert the shape of a DNS mock-miss report, not just its presence

### DIFF
--- a/pkg/agent/proxy/dns_negative_answer_test.go
+++ b/pkg/agent/proxy/dns_negative_answer_test.go
@@ -1,7 +1,9 @@
 package proxy
 
 import (
+	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,26 +12,104 @@ import (
 	"go.uber.org/zap"
 )
 
-// nxdomainUpstream starts a local DNS server that answers NXDOMAIN for every
-// query, standing in for a cluster resolver being asked about a name that does
-// not exist. Returns its address parts and a stop func.
+// rcodeUpstream starts a local DNS server that answers every query with the
+// given rcode and no records, standing in for a cluster resolver's verdict on a
+// name. It returns the address in the two parts the Proxy fields want, plus a
+// stop func.
+//
+// It delegates to startFakeUpstream rather than binding its own server so the
+// two helpers cannot drift, and so this one inherits the readiness poll:
+// dns.Server.Shutdown returns "server not started" if it beats ActivateAndServe,
+// leaving the shutdown channel unclosed and the join inside startFakeUpstream
+// blocking until the test binary panics.
 func rcodeUpstream(t *testing.T, rcode int) (host, port string, stop func()) {
 	t.Helper()
-	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	srv := &dns.Server{PacketConn: pc, Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+	addr, stop := startFakeUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
 		m := new(dns.Msg)
 		m.SetRcode(r, rcode)
 		_ = w.WriteMsg(m)
-	})}
-	go func() { _ = srv.ActivateAndServe() }()
-	h, p, err := net.SplitHostPort(pc.LocalAddr().String())
+	})
+	h, p, err := net.SplitHostPort(addr)
 	if err != nil {
-		t.Fatalf("split: %v", err)
+		stop()
+		t.Fatalf("split %q: %v", addr, err)
 	}
-	return h, p, func() { _ = srv.Shutdown() }
+	return h, p, stop
+}
+
+// collectMockMissReports drains p.errChannel and returns the DNS mock-miss
+// reports it held, checking the SHAPE of each one on the way through.
+//
+// The gate under test decides WHETHER a report is emitted, but a report emitted
+// with an empty or malformed payload is just as broken as a missing one, and a
+// bare `case <-p.errChannel` cannot tell those apart -- it passes on any value
+// of any type. Asserting ErrMockNotFound + a non-nil MismatchReport here means
+// the negative assertions below stay honest if the reporting path is reshaped.
+//
+// The non-blocking drain cannot race the producer: SendError delivers on the
+// caller's goroutine, and resolveUncachedDNSResponse calls it synchronously
+// before returning, so every report is already buffered by the time these
+// helpers run. StartErrorDrain is never started against these hand-built Proxy
+// values, so this is the only reader.
+func collectMockMissReports(t *testing.T, p *Proxy) []models.MockMismatchReport {
+	t.Helper()
+	var reports []models.MockMismatchReport
+	for {
+		select {
+		case err := <-p.errChannel:
+			parserErr, ok := err.(models.ParserError)
+			if !ok {
+				t.Fatalf("unexpected error type on errChannel: %T (%v)", err, err)
+			}
+			if parserErr.ParserErrorType != models.ErrMockNotFound {
+				t.Fatalf("unexpected parser error type on errChannel: %q", parserErr.ParserErrorType)
+			}
+			if parserErr.MismatchReport == nil {
+				t.Fatalf("ErrMockNotFound carried no MismatchReport: %v", parserErr.Err)
+			}
+			reports = append(reports, *parserErr.MismatchReport)
+		default:
+			return reports
+		}
+	}
+}
+
+// assertReportedOnce pins that the miss was reported EXACTLY once and that the
+// report identifies the query. "Exactly" matters: a duplicate double-counts one
+// miss in the replay summary. `why` carries the caller's reason into the failure
+// output -- without it a regression prints only "got 0 reports", which says what
+// happened but not why it is wrong.
+//
+// The qtype is asserted alongside the name because a name alone is not
+// actionable: glibc fires A and AAAA for every hostname, so "which record type
+// was missing" is precisely what the user needs to know.
+func assertReportedOnce(t *testing.T, p *Proxy, q dns.Question, why string) {
+	t.Helper()
+	reports := collectMockMissReports(t, p)
+	if len(reports) != 1 {
+		t.Fatalf("%s; expected exactly 1 DNS mock-miss report, got %d: %+v", why, len(reports), reports)
+	}
+	if reports[0].Protocol != "DNS" {
+		t.Errorf("report protocol = %q, want \"DNS\"", reports[0].Protocol)
+	}
+	if !strings.Contains(reports[0].ActualSummary, q.Name) {
+		t.Errorf("report ActualSummary = %q; want it to name the query %q", reports[0].ActualSummary, q.Name)
+	}
+	// Anchored, not Contains: "A" is a substring of "AAAA", so a Contains check
+	// passes when the report names the wrong record type -- exactly the A/AAAA
+	// confusion this assertion exists to catch.
+	if qt := dns.TypeToString[q.Qtype]; !strings.HasPrefix(reports[0].ActualSummary, qt+" ") {
+		t.Errorf("report ActualSummary = %q; want it to start with the qtype %q", reports[0].ActualSummary, qt)
+	}
+}
+
+// assertNotReported pins that nothing was reported, and prints what WAS
+// reported when the gate regresses.
+func assertNotReported(t *testing.T, p *Proxy, why string) {
+	t.Helper()
+	if reports := collectMockMissReports(t, p); len(reports) != 0 {
+		t.Fatalf("%s; got %d report(s): %+v", why, len(reports), reports)
+	}
 }
 
 // A Kubernetes resolver walks its search list (ndots:5 by default), so a name
@@ -80,12 +160,8 @@ func TestDNSMockMiss_UpstreamNXDOMAIN_IsNotReportedAsAMockMiss(t *testing.T) {
 		t.Fatalf("expected the proxy steer 127.0.0.1 in the A record, got %v", got.Msg.Answer[0])
 	}
 
-	select {
-	case err := <-p.errChannel:
-		t.Fatalf("upstream authoritatively said this name does not exist, so there is no "+
-			"mock to be missing; it must not be reported as a mock miss. got: %v", err)
-	default:
-	}
+	assertNotReported(t, p, "upstream authoritatively said this name does not exist, "+
+		"so there is no mock to be missing and it must not be reported as a mock miss")
 }
 
 // The narrowing above must not swallow REAL gaps. When upstream cannot be
@@ -106,12 +182,8 @@ func TestDNSMockMiss_UpstreamUnreachable_IsStillReported(t *testing.T) {
 	q := dns.Question{Name: "some-service.default.svc.cluster.local.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	_ = p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
 
-	select {
-	case <-p.errChannel:
-		// expected: we could not confirm the name is absent, so report it.
-	default:
-		t.Fatal("upstream was unreachable, so the miss is unexplained and MUST still be reported")
-	}
+	assertReportedOnce(t, p, q, "upstream was unreachable, so the miss is unexplained "+
+		"and MUST still be reported")
 }
 
 // With no upstream configured at all there is likewise no evidence, so a miss
@@ -126,12 +198,8 @@ func TestDNSMockMiss_NoUpstreamConfigured_IsStillReported(t *testing.T) {
 	q := dns.Question{Name: "some-service.default.svc.cluster.local.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	_ = p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
 
-	select {
-	case <-p.errChannel:
-		// expected
-	default:
-		t.Fatal("no upstream to consult, so the miss is unexplained and MUST still be reported")
-	}
+	assertReportedOnce(t, p, q, "no upstream to consult, so the miss is unexplained "+
+		"and MUST still be reported")
 }
 
 // SERVFAIL/REFUSED are NOT "this name does not exist" — they are "the resolver
@@ -161,13 +229,51 @@ func TestDNSMockMiss_UpstreamSERVFAILOrREFUSED_IsStillReported(t *testing.T) {
 			q := dns.Question{Name: "some-service.default.svc.cluster.local.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 			_ = p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
 
-			select {
-			case <-p.errChannel:
-				// expected: the resolver failed, so we learned nothing about the name.
-			default:
-				t.Fatalf("%s means the resolver failed, not that the name is absent; "+
-					"the miss MUST still be reported", tc.name)
-			}
+			assertReportedOnce(t, p, q, fmt.Sprintf("%s means the resolver failed, "+
+				"not that the name is absent; the miss MUST still be reported", tc.name))
 		})
 	}
+}
+
+// NODATA -- NOERROR with zero answer records -- is a VALID negative answer
+// ("the name exists, but has no record of this type"), not a failure and not an
+// absence. It is relayed to the app verbatim rather than steered, so it leaves
+// resolveUncachedDNSResponse well before the reporting block.
+//
+// That early return is exactly why this needs pinning: the no-report behaviour
+// here is a consequence of statement ORDER, not of the rcode gate, so it is
+// invisible to the gate's own tests and would be silently lost by anything that
+// moved reporting earlier. A dual-stack app resolving a v4-only service emits
+// an AAAA query per lookup, so a regression would report a mock miss on every
+// one of them.
+func TestDNSMockMiss_UpstreamNODATA_IsRelayedAndNotReported(t *testing.T) {
+	host, port, stop := rcodeUpstream(t, dns.RcodeSuccess) // NOERROR, no answers
+	defer stop()
+
+	p := &Proxy{
+		logger:             zap.NewNop(),
+		errChannel:         make(chan error, 4),
+		dnsUpstreamServers: []string{host},
+		dnsUpstreamPort:    port,
+		dnsForwardTimeout:  2 * time.Second,
+	}
+
+	q := dns.Question{Name: "postgres.checkr.svc.cluster.local.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}
+	got := p.resolveUncachedDNSResponse(q, models.MODE_TEST, true, time.Now(), nil)
+
+	// FromUpstream is the assertion that actually separates a relay from a
+	// synthetic answer, so it goes first. Rcode and answer count cannot: for an
+	// AAAA query defaultDNSResponse ALSO returns NOERROR with zero answers,
+	// because EnableIPv6Redirect is unset here and the AAAA arm returns an empty
+	// answer rather than synthesising one (dns.go, case dns.TypeAAAA). Checking
+	// rcode and answer count alone would therefore pass on the steer.
+	if !got.FromUpstream {
+		t.Fatalf("expected the upstream NODATA relayed as-is; got a synthetic answer instead: %+v", got.Msg)
+	}
+	if got.Msg == nil || got.Msg.Rcode != dns.RcodeSuccess || len(got.Msg.Answer) != 0 {
+		t.Fatalf("expected an empty NOERROR, got %+v", got.Msg)
+	}
+
+	assertNotReported(t, p, "NODATA is a valid answer that the app receives verbatim, "+
+		"so there is no mock miss to report")
 }


### PR DESCRIPTION
## What

`#4565` gated DNS mock-miss reporting on NXDOMAIN and covered the gate in `dns_negative_answer_test.go`. This strengthens what those tests assert about the report itself.

The three positive cases each ended in:

```go
select {
case <-p.errChannel:  // expected
default: t.Fatal(...)
}
```

which accepts **any value of any type** on the channel. A report carrying a nil `MismatchReport`, a blank `Protocol`, an `ActualSummary` naming neither the query nor the record type, or an entirely different `ParserErrorType` all satisfy it — as does the same miss reported **twice**, which double-counts one miss in the replay summary. The gate decided *whether* to report; nothing checked that what came out was usable.

## Changes

- A shared collector drains the channel and asserts `ErrMockNotFound` + a non-nil `MismatchReport`, then pins `Protocol`, **exactly one** report, and that `ActualSummary` names both the query and its qtype.
- The qtype check is **anchored** (`HasPrefix(summary, qtype+" ")`), not `Contains` — `"A"` is a substring of `"AAAA"`, so a `Contains` check passes on a report naming the wrong record type, which is the exact A/AAAA confusion the assertion exists to catch.
- Adds the one uncovered behaviour: **NODATA produces no report**. The relay itself is already covered by `dns_forward_test.go:442`; what nothing asserted was that the error channel stays empty. That outcome comes from a `return` sitting *above* the reporting block, so it is a property of statement order rather than of the rcode gate.
- `rcodeUpstream` was a second copy of `startFakeUpstream` minus its readiness poll. `dns.Server.Shutdown` returns `"server not started"` if it beats `ActivateAndServe`, leaving the shutdown channel unclosed and a join blocked until the test binary panics. It now delegates to the existing helper so the two cannot drift.

## Verification

Every assertion was mutation-tested against `pkg/agent/proxy/dns.go`, restoring the file after each. All caught:

| Mutation | Result |
|---|---|
| `MismatchReport` set to nil | caught |
| `Protocol` blanked | caught |
| `ActualSummary` loses the query name | caught |
| `ActualSummary` loses the qtype | caught |
| `ActualSummary` hardcodes the **wrong** qtype (`AAAA` for an `A` query) | caught (survived before the anchor) |
| wrong `ParserErrorType` | caught |
| `SendError` called twice | caught |
| NXDOMAIN gate reverted | caught |
| gate widened to all negative rcodes | caught |
| NODATA early return removed | caught |

`go vet` and `gofmt` clean; `TestDNSMockMiss -race -count=5` clean; full `pkg/agent/proxy` package green under `-race`.

**Production code is untouched** — `dns.go` and `dns_forward_test.go` are byte-identical to `main`. The diff is one test file.

## Relationship to #4475

Supersedes #4475, which proposed widening the gate to SERVFAIL/REFUSED. #4565 settled that the other way and its reasoning holds: those rcodes report a failure of the *resolver*, not a property of the *name* — the same no-evidence state as an unreachable upstream, which is already reported. A sick resolver answering SERVFAIL to everything would otherwise turn every replay silently green, and in a verification tool a false PASS is categorically worse than a false FAIL.

#4475's tests are dropped as duplicates of #4565's; only the assertions above, which were genuinely absent, are kept.
