### PR TITLE
fix(docker): keep the top-level keys compose files put their anchors in

### DIFF
--- a/pkg/platform/docker/compose_anchor_test.go
+++ b/pkg/platform/docker/compose_anchor_test.go
@@ -1,0 +1,416 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+// composeWithAnchor is the shape the Compose spec endorses for reuse: a shared
+// fragment under an `x-*` extension key, pulled into services with a merge
+// alias. Docker accepts it; keploy has to round-trip it without breaking it.
+const composeWithAnchor = `x-mysql-common: &mysql-common
+  command: --skip-log-bin
+  healthcheck:
+    test: [ "CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "--protocol=tcp" ]
+    start_period: 60s
+services:
+  mysql-users:
+    image: mysql:8.0
+    <<: *mysql-common
+  mysql-orders:
+    image: mysql:8.0
+    <<: *mysql-common
+`
+
+// TestComposeRoundTrip_PreservesAnchorDefinition is the regression test for the
+// generated compose failing to load with:
+//
+//	go-yaml load error in composer at L15.C21: unknown anchor 'mysql-common' referenced
+//
+// Compose names only six top-level keys, so `x-mysql-common` was dropped on
+// read. Services is a yaml.Node and kept `<<: *mysql-common` verbatim, so the
+// file keploy wrote referenced an anchor that was no longer defined and the
+// user's app never started.
+//
+// Asserting the round trip RELOADS is the point: checking only that the anchor
+// text survives would still pass if it were emitted after the alias that uses
+// it, which YAML rejects.
+func TestComposeRoundTrip_PreservesAnchorDefinition(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "docker-compose.yaml")
+	if err := os.WriteFile(src, []byte(composeWithAnchor), 0644); err != nil {
+		t.Fatalf("write source compose: %v", err)
+	}
+
+	compose, err := idc.ReadComposeFile(src)
+	if err != nil {
+		t.Fatalf("ReadComposeFile: %v", err)
+	}
+
+	out := filepath.Join(dir, "docker-compose-tmp.yaml")
+	if err := idc.WriteComposeFile(compose, out); err != nil {
+		t.Fatalf("WriteComposeFile: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read generated compose: %v", err)
+	}
+
+	// The generated file is what `docker compose -f ... up` parses next.
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("generated compose does not load: %v\n--- generated ---\n%s", err, data)
+	}
+
+	services, ok := reloaded["services"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("generated compose has no services mapping:\n%s", data)
+	}
+	for _, name := range []string{"mysql-users", "mysql-orders"} {
+		svc, ok := services[name].(map[string]interface{})
+		if !ok {
+			t.Fatalf("service %q missing from generated compose:\n%s", name, data)
+		}
+		// The merge must still resolve, or the service silently loses the
+		// healthcheck that gates everything depending on it.
+		if got := svc["command"]; got != "--skip-log-bin" {
+			t.Errorf("service %q command = %v, want %q — merge alias did not resolve",
+				name, got, "--skip-log-bin")
+		}
+		if _, ok := svc["healthcheck"].(map[string]interface{}); !ok {
+			t.Errorf("service %q lost its healthcheck through the round trip", name)
+		}
+	}
+
+	// The anchor has to be DEFINED, not merely referenced.
+	if !strings.Contains(string(data), "&mysql-common") {
+		t.Errorf("anchor definition missing from generated compose:\n%s", data)
+	}
+}
+
+// TestComposeRoundTrip_KeepsUnknownTopLevelKeys pins the general case behind the
+// anchor bug: keys the Compose struct does not name must survive, not just the
+// one that happened to carry an anchor.
+func TestComposeRoundTrip_KeepsUnknownTopLevelKeys(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = `name: my-project
+x-shared-config:
+  retries: 3
+services:
+  app:
+    image: alpine:3.21
+`
+	dir := t.TempDir()
+	src := filepath.Join(dir, "docker-compose.yaml")
+	if err := os.WriteFile(src, []byte(in), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	compose, err := idc.ReadComposeFile(src)
+	if err != nil {
+		t.Fatalf("ReadComposeFile: %v", err)
+	}
+	data, err := idc.MarshalCompose(compose)
+	if err != nil {
+		t.Fatalf("MarshalCompose: %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded["name"] != "my-project" {
+		t.Errorf("top-level `name` lost: %v\n%s", reloaded["name"], data)
+	}
+	if _, ok := reloaded["x-shared-config"]; !ok {
+		t.Errorf("top-level `x-shared-config` lost:\n%s", data)
+	}
+}
+
+// TestComposeMarshal_ProgrammaticComposeStillWorks pins the fallback: a Compose
+// built in code has no original document, and must still serialise.
+func TestComposeMarshal_ProgrammaticComposeStillWorks(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	compose := &Compose{Version: "3.8"}
+	compose.Services = yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		{Kind: yaml.ScalarNode, Value: "app"},
+		{Kind: yaml.MappingNode, Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "image"},
+			{Kind: yaml.ScalarNode, Value: "alpine:3.21"},
+		}},
+	}}
+	data, err := idc.MarshalCompose(compose)
+	if err != nil {
+		t.Fatalf("MarshalCompose: %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("reload: %v\n%s", err, data)
+	}
+	services, ok := reloaded["services"].(map[string]interface{})
+	if !ok || services["app"] == nil {
+		t.Fatalf("programmatic compose lost its service:\n%s", data)
+	}
+}
+
+// TestComposeRoundTrip_ModifiedServicesAreWritten pins that preserving the
+// original document does not come at the cost of DISCARDING the modifications.
+//
+// keploy's whole reason for rewriting the compose file is to inject its agent
+// service and adjust the app service (ModifyComposeForAgent). Those edits land
+// on compose.Services, which is decoded separately from the original mapping,
+// so they only reach the generated file if that section is spliced back in.
+// Without the splice every test above still passes while keploy silently runs
+// the user's UNMODIFIED stack -- no agent, nothing recorded.
+func TestComposeRoundTrip_ModifiedServicesAreWritten(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "docker-compose.yaml")
+	if err := os.WriteFile(src, []byte(composeWithAnchor), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	compose, err := idc.ReadComposeFile(src)
+	if err != nil {
+		t.Fatalf("ReadComposeFile: %v", err)
+	}
+
+	// Stand in for ModifyComposeForAgent: add a service, and edit an existing one.
+	compose.Services.Content = append(compose.Services.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "keploy-agent"},
+		&yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "image"},
+			{Kind: yaml.ScalarNode, Value: "keploy/agent:v3"},
+		}})
+	for i := 0; i+1 < len(compose.Services.Content); i += 2 {
+		if compose.Services.Content[i].Value == "mysql-users" {
+			svc := compose.Services.Content[i+1]
+			svc.Content = append(svc.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Value: "container_name"},
+				&yaml.Node{Kind: yaml.ScalarNode, Value: "patched-by-keploy"})
+		}
+	}
+
+	data, err := idc.MarshalCompose(compose)
+	if err != nil {
+		t.Fatalf("MarshalCompose: %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	services, _ := reloaded["services"].(map[string]interface{})
+	if services == nil {
+		t.Fatalf("no services in generated compose:\n%s", data)
+	}
+	agent, ok := services["keploy-agent"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("injected keploy-agent service missing — the modified services "+
+			"section was not written:\n%s", data)
+	}
+	if agent["image"] != "keploy/agent:v3" {
+		t.Errorf("keploy-agent image = %v, want keploy/agent:v3", agent["image"])
+	}
+	appSvc, _ := services["mysql-users"].(map[string]interface{})
+	if appSvc == nil || appSvc["container_name"] != "patched-by-keploy" {
+		t.Errorf("edit to an existing service was not written: %v\n%s", appSvc, data)
+	}
+	// ...and the anchor must still resolve for the untouched service.
+	if other, _ := services["mysql-orders"].(map[string]interface{}); other == nil ||
+		other["command"] != "--skip-log-bin" {
+		t.Errorf("merge alias stopped resolving after modification: %v", other)
+	}
+}
+
+// TestComposeRoundTrip_AbsentSectionsStayAbsent pins the zero-node skip in
+// composeDocument, which runs on EVERY compose file keploy rewrites.
+//
+// Compose names six top-level sections; most files declare two or three. The
+// undeclared ones decode to zero yaml.Nodes, and splicing those in unconditionally
+// writes `configs: null` / `secrets: null` into the generated file. Real
+// `docker compose` rejects that outright ("configs must be a mapping"), so
+// dropping the guard breaks every user whose compose omits a section -- which is
+// nearly all of them.
+func TestComposeRoundTrip_AbsentSectionsStayAbsent(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = `services:
+  app:
+    image: alpine:3.21
+networks:
+  default:
+    driver: bridge
+`
+	dir := t.TempDir()
+	src := filepath.Join(dir, "docker-compose.yaml")
+	if err := os.WriteFile(src, []byte(in), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	compose, err := idc.ReadComposeFile(src)
+	if err != nil {
+		t.Fatalf("ReadComposeFile: %v", err)
+	}
+	data, err := idc.MarshalCompose(compose)
+	if err != nil {
+		t.Fatalf("MarshalCompose: %v", err)
+	}
+
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("reload: %v\n%s", err, data)
+	}
+	for _, absent := range []string{"configs", "secrets", "volumes", "version"} {
+		if v, present := reloaded[absent]; present {
+			t.Errorf("section %q was absent from the source but appears as %v in the "+
+				"generated file — docker compose rejects a null section:\n%s",
+				absent, v, data)
+		}
+	}
+	// The sections that WERE declared must survive.
+	if _, ok := reloaded["services"].(map[string]interface{}); !ok {
+		t.Errorf("services missing:\n%s", data)
+	}
+	if _, ok := reloaded["networks"].(map[string]interface{}); !ok {
+		t.Errorf("networks missing:\n%s", data)
+	}
+}
+
+// TestComposeRoundTrip_VersionIsWriteThrough pins that Version behaves like the
+// five yaml.Node fields. It is a string, so it needs its own splice; without one
+// it is the single named field that silently ignores writes.
+func TestComposeRoundTrip_VersionIsWriteThrough(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = `version: "3.8"
+services:
+  app:
+    image: alpine:3.21
+`
+	dir := t.TempDir()
+	src := filepath.Join(dir, "docker-compose.yaml")
+	if err := os.WriteFile(src, []byte(in), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	compose, err := idc.ReadComposeFile(src)
+	if err != nil {
+		t.Fatalf("ReadComposeFile: %v", err)
+	}
+	compose.Version = "3.9"
+	data, err := idc.MarshalCompose(compose)
+	if err != nil {
+		t.Fatalf("MarshalCompose: %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("reload: %v\n%s", err, data)
+	}
+	if got := reloaded["version"]; got != "3.9" {
+		t.Errorf("version = %v, want 3.9 — Version is not write-through:\n%s", got, data)
+	}
+}
+
+// TestComposeMarshal_DirectYamlMarshalIsAlsoCorrect pins that the fix lives on
+// the TYPE, not on WriteComposeFile/MarshalCompose. Callers outside this package
+// marshal a *Compose directly (enterprise's --dump-compose does), and if only the
+// two wrappers were fixed, the file keploy RUNS and the file it dumps for
+// debugging would disagree precisely when this bug bites.
+func TestComposeMarshal_DirectYamlMarshalIsAlsoCorrect(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "docker-compose.yaml")
+	if err := os.WriteFile(src, []byte(composeWithAnchor), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	compose, err := idc.ReadComposeFile(src)
+	if err != nil {
+		t.Fatalf("ReadComposeFile: %v", err)
+	}
+
+	direct, err := yaml.Marshal(compose)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(direct, &reloaded); err != nil {
+		t.Fatalf("a direct yaml.Marshal produced an unloadable document: %v\n%s", err, direct)
+	}
+	viaHelper, err := idc.MarshalCompose(compose)
+	if err != nil {
+		t.Fatalf("MarshalCompose: %v", err)
+	}
+	if string(direct) != string(viaHelper) {
+		t.Errorf("yaml.Marshal and MarshalCompose disagree:\n--- direct ---\n%s\n--- helper ---\n%s",
+			direct, viaHelper)
+	}
+}
+
+// TestComposeRoundTrip_UntouchedVersionKeepsItsNode pins that making Version
+// write-through did not cost fidelity on the far more common path where nobody
+// writes it.
+//
+// Splicing unconditionally replaces `version:`'s node with a fresh scalar, which
+// drops its line comment and re-quotes the value — so `version` would become the
+// single key in the document that loses exactly what preserving the original
+// mapping exists to keep, on every compose file that declares one.
+func TestComposeRoundTrip_UntouchedVersionKeepsItsNode(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = `version: '3.8' # pinned deliberately
+services:
+  app:
+    image: alpine:3.21
+`
+	dir := t.TempDir()
+	src := filepath.Join(dir, "docker-compose.yaml")
+	if err := os.WriteFile(src, []byte(in), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	compose, err := idc.ReadComposeFile(src)
+	if err != nil {
+		t.Fatalf("ReadComposeFile: %v", err)
+	}
+	// Deliberately do NOT touch compose.Version.
+	data, err := idc.MarshalCompose(compose)
+	if err != nil {
+		t.Fatalf("MarshalCompose: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "pinned deliberately") {
+		t.Errorf("the comment on `version:` was destroyed by an unnecessary splice:\n%s", out)
+	}
+	if !strings.Contains(out, "'3.8'") {
+		t.Errorf("the original scalar style of `version:` was rewritten:\n%s", out)
+	}
+}
+
+// TestComposeMarshal_ValueReceiverAlsoCorrect pins that the fix is reachable
+// through a VALUE, not only a pointer. A pointer-receiver MarshalYAML is absent
+// from Compose's method set, so `yaml.Marshal(*compose)` would quietly fall back
+// to encoding the struct and emit the unloadable document this exists to fix.
+func TestComposeMarshal_ValueReceiverAlsoCorrect(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "docker-compose.yaml")
+	if err := os.WriteFile(src, []byte(composeWithAnchor), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	compose, err := idc.ReadComposeFile(src)
+	if err != nil {
+		t.Fatalf("ReadComposeFile: %v", err)
+	}
+	data, err := yaml.Marshal(*compose) // value, not pointer
+	if err != nil {
+		t.Fatalf("yaml.Marshal(value): %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("marshalling a Compose VALUE produced an unloadable document: %v\n%s", err, data)
+	}
+	services, _ := reloaded["services"].(map[string]interface{})
+	svc, _ := services["mysql-users"].(map[string]interface{})
+	if svc == nil || svc["command"] != "--skip-log-bin" {
+		t.Errorf("merge did not resolve via the value path: %v", svc)
+	}
+}

--- a/pkg/platform/docker/compose_services_alias_test.go
+++ b/pkg/platform/docker/compose_services_alias_test.go
@@ -479,3 +479,141 @@ services: *thing
 		t.Errorf("the error should name the section: %v", err)
 	}
 }
+
+// TestSubKeyAlias_EnvAndVolumesResolve covers an alias one level BELOW the
+// service — `environment: *appenv`, `volumes: *appvols` — which is at least as
+// common an `x-*` idiom as aliasing a whole service.
+//
+// Unresolved, the two writers fail in opposite directions and neither says
+// anything. addServiceEnvVar's type switch matches neither SequenceNode nor
+// MappingNode for an AliasNode, so it falls straight through and keploy's CA and
+// JAVA_TOOL_OPTIONS never appear — the app runs uninstrumented.
+// addServiceListProperty appends into the alias, so the TLS-cert mount is
+// dropped. Both leave a file docker compose accepts.
+func TestSubKeyAlias_EnvAndVolumesResolve(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	const in = `x-env: &appenv
+  SSL_CERT_FILE: /etc/mine/ca.pem
+x-vols: &appvols
+  - ./data:/data
+services:
+  app:
+    image: alpine:3.21
+    environment: *appenv
+    volumes: *appvols
+  sidecar:
+    image: busybox
+    environment: *appenv
+    volumes: *appvols
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	node, _, err := idc.findServiceNodeAndName(&compose, "app")
+	if err != nil {
+		t.Fatalf("findServiceNodeAndName: %v", err)
+	}
+	idc.addServiceEnvVar(node, "SSL_CERT_FILE", "/tmp/keploy-tls/ca.crt")
+	idc.addServiceListProperty(node, "volumes", "keploy-tls-certs:/tmp/keploy-tls")
+
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	svcs, _ := out["services"].(map[string]interface{})
+
+	app, _ := svcs["app"].(map[string]interface{})
+	appEnv, _ := app["environment"].(map[string]interface{})
+	if appEnv == nil || appEnv["SSL_CERT_FILE"] != "/tmp/keploy-tls/ca.crt" {
+		t.Errorf("keploy's env var was dropped into an alias node and never emitted; "+
+			"the app would run without keploy's CA: %v\n%s", app["environment"], data)
+	}
+	appVols, _ := app["volumes"].([]interface{})
+	var mounted bool
+	for _, v := range appVols {
+		if s, _ := v.(string); strings.Contains(s, "keploy-tls-certs") {
+			mounted = true
+		}
+	}
+	if !mounted {
+		t.Errorf("keploy's TLS mount was dropped: %v\n%s", appVols, data)
+	}
+
+	// The sibling shares both fragments and must be untouched — it is not in the
+	// agent's network namespace, so keploy's CA would break its outbound TLS.
+	sidecar, _ := svcs["sidecar"].(map[string]interface{})
+	sideEnv, _ := sidecar["environment"].(map[string]interface{})
+	if sideEnv == nil || sideEnv["SSL_CERT_FILE"] != "/etc/mine/ca.pem" {
+		t.Errorf("the sibling's own SSL_CERT_FILE was replaced with keploy's: %v", sideEnv)
+	}
+	sideVols, _ := sidecar["volumes"].([]interface{})
+	for _, v := range sideVols {
+		if s, _ := v.(string); strings.Contains(s, "keploy-tls-certs") {
+			t.Errorf("the sibling inherited keploy's TLS mount: %v", sideVols)
+		}
+	}
+	// And the user's fragments themselves.
+	frag, _ := out["x-env"].(map[string]interface{})
+	if frag == nil || frag["SSL_CERT_FILE"] != "/etc/mine/ca.pem" {
+		t.Errorf("the user's own env fragment was rewritten: %v", frag)
+	}
+	if vf, _ := out["x-vols"].([]interface{}); len(vf) != 1 {
+		t.Errorf("the user's own volumes fragment gained entries: %v", vf)
+	}
+}
+
+// TestSubKeyAlias_SequenceStyleEnvResolves pins the other legal env shape: a
+// sequence of KEY=VALUE strings behind an alias.
+func TestSubKeyAlias_SequenceStyleEnvResolves(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	const in = `x-env: &appenv
+  - APP_ENV=prod
+services:
+  app:
+    image: alpine:3.21
+    environment: *appenv
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	node, _, err := idc.findServiceNodeAndName(&compose, "app")
+	if err != nil {
+		t.Fatalf("findServiceNodeAndName: %v", err)
+	}
+	idc.addServiceEnvVar(node, "SSL_CERT_FILE", "/tmp/keploy-tls/ca.crt")
+
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("reload: %v\n%s", err, data)
+	}
+	svcs, _ := out["services"].(map[string]interface{})
+	app, _ := svcs["app"].(map[string]interface{})
+	env, _ := app["environment"].([]interface{})
+	var got, kept bool
+	for _, e := range env {
+		s, _ := e.(string)
+		if strings.HasPrefix(s, "SSL_CERT_FILE=") {
+			got = true
+		}
+		if s == "APP_ENV=prod" {
+			kept = true
+		}
+	}
+	if !got {
+		t.Errorf("keploy's env var was dropped from a sequence-style aliased "+
+			"environment: %v\n%s", env, data)
+	}
+	if !kept {
+		t.Errorf("the user's own env var was lost: %v", env)
+	}
+}

--- a/pkg/platform/docker/compose_services_alias_test.go
+++ b/pkg/platform/docker/compose_services_alias_test.go
@@ -1,0 +1,481 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+
+	"go.keploy.io/server/v3/config"
+	"go.keploy.io/server/v3/pkg/models"
+)
+
+// buildAgentOpts is the minimum GenerateKeployAgentService needs to succeed.
+func buildAgentOpts() models.SetupOptions {
+	return models.SetupOptions{
+		KeployContainer: "keploy-agent",
+		AgentPort:       16789,
+		ProxyPort:       16790,
+		DnsPort:         16791,
+		Mode:            models.MODE_TEST,
+	}
+}
+
+// baseFragment carries the two keys any real base fragment carries — and the two
+// keploy actually writes into. A fixture without them cannot detect a shallow
+// copy, which is how an earlier version of this test passed while siblings were
+// being corrupted.
+const baseFragment = `x-base: &base
+  image: alpine:3.21
+  environment:
+    SSL_CERT_FILE: /etc/mine/ca.pem
+  volumes:
+    - ./data:/data
+services:
+  app: *base
+  sidecar: *base
+`
+
+// TestServiceAlias_EditsLandAndSiblingsAreUntouched is the regression test for
+// the silent half of the services-alias bug.
+//
+// `services: {app: *appdef}` is legal compose. The node findServiceNodeAndName
+// returns is exactly what modifyAppServiceForKeploy writes into, and an alias
+// holds no entries — so the agent wiring, TLS mounts and entrypoint rewrite all
+// went into a node the encoder never emits. No error, no warning: the app ran
+// uninstrumented and nothing was recorded.
+//
+// Resolving is only half of it. The copy must be DEEP, because keploy does not
+// merely append to a service — it deletes keys and overwrites values in place.
+// With children shared, `sidecar` inherits keploy's TLS environment while living
+// outside the agent's network namespace, so its outbound TLS fails verification
+// silently; and the user's own SSL_CERT_FILE is overwritten inside their
+// fragment.
+func TestServiceAlias_EditsLandAndSiblingsAreUntouched(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(baseFragment), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	node, name, err := idc.findServiceNodeAndName(&compose, "app")
+	if err != nil {
+		t.Fatalf("findServiceNodeAndName: %v", err)
+	}
+	if name != "app" || node.Kind != yaml.MappingNode {
+		t.Fatalf("resolved to name=%q kind=%d, want app as a mapping", name, node.Kind)
+	}
+
+	// Exactly what keploy does to the app service: append, and overwrite an
+	// existing value in place.
+	node.Content = append(node.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "container_name"},
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "patched-by-keploy"})
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == "environment" {
+			env := node.Content[i+1]
+			for j := 0; j+1 < len(env.Content); j += 2 {
+				if env.Content[j].Value == "SSL_CERT_FILE" {
+					env.Content[j+1].Value = "/tmp/keploy-tls/ca.crt"
+				}
+			}
+		}
+	}
+
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	svcs, _ := out["services"].(map[string]interface{})
+
+	app, _ := svcs["app"].(map[string]interface{})
+	if app == nil || app["container_name"] != "patched-by-keploy" {
+		t.Errorf("keploy's edit was silently lost; the app would run uninstrumented "+
+			"with nothing recorded:\n%s", data)
+	}
+	if env, _ := app["environment"].(map[string]interface{}); env == nil ||
+		env["SSL_CERT_FILE"] != "/tmp/keploy-tls/ca.crt" {
+		t.Errorf("keploy's in-place env rewrite did not land on app: %v", app["environment"])
+	}
+
+	// The sibling must be exactly as the user wrote it.
+	sidecar, _ := svcs["sidecar"].(map[string]interface{})
+	if sidecar == nil {
+		t.Fatalf("sidecar disappeared:\n%s", data)
+	}
+	if _, leaked := sidecar["container_name"]; leaked {
+		t.Errorf("sidecar inherited keploy's container_name — the copy was shallow:\n%s", data)
+	}
+	if env, _ := sidecar["environment"].(map[string]interface{}); env == nil ||
+		env["SSL_CERT_FILE"] != "/etc/mine/ca.pem" {
+		t.Errorf("sidecar's own SSL_CERT_FILE was overwritten with keploy's CA (%v); "+
+			"it is not in the agent's netns, so its outbound TLS would fail "+
+			"verification silently:\n%s", env, data)
+	}
+	// And the user's fragment itself.
+	frag, _ := out["x-base"].(map[string]interface{})
+	if env, _ := frag["environment"].(map[string]interface{}); env == nil ||
+		env["SSL_CERT_FILE"] != "/etc/mine/ca.pem" {
+		t.Errorf("the user's own fragment was rewritten: %v", env)
+	}
+}
+
+// TestServiceAlias_ContainerNameMatchAlsoResolves pins the lookup path that
+// matches on container_name rather than on the service key. It scans the service
+// node's contents, so against an alias it scanned nil and could never match —
+// leaving the shape reported as "service not found" on a file that has it.
+func TestServiceAlias_ContainerNameMatchAlsoResolves(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = `x-app: &app
+  image: alpine:3.21
+  container_name: myapp
+services:
+  web: *app
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	node, name, err := idc.findServiceNodeAndName(&compose, "myapp")
+	if err != nil {
+		t.Fatalf("lookup by container_name failed: %v — the service is there, "+
+			"behind an alias", err)
+	}
+	if name != "web" || node.Kind != yaml.MappingNode {
+		t.Errorf("resolved to name=%q kind=%d, want web as a mapping", name, node.Kind)
+	}
+}
+
+// TestServiceAlias_PortsAndNetworksAreRead pins the gate that feeds
+// opts.AppPorts / opts.AppNetworks.
+//
+// It runs BEFORE ModifyComposeForAgent. Read off an unresolved alias they come
+// back empty, so the app's published port never reaches keploy-agent — which
+// publishes on the app's behalf under network_mode: service:keploy-agent — and
+// the app is unreachable from the host even when everything else works.
+func TestServiceAlias_PortsAndNetworksAreRead(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = `x-app: &app
+  image: alpine:3.21
+  ports:
+    - "8080:8080"
+  networks:
+    - appnet
+services:
+  app: *app
+networks:
+  appnet: {}
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	nets, ports, name, found := idc.findContainerInServices(&compose, "app")
+	if !found {
+		t.Fatalf("the app service was not found behind its alias")
+	}
+	if name != "app" {
+		t.Errorf("name = %q, want app", name)
+	}
+	if len(ports) == 0 {
+		t.Errorf("no ports read from the aliased service; keploy-agent would publish "+
+			"none on its behalf and the app would be unreachable from the host (got %v)", ports)
+	}
+	if len(nets) == 0 {
+		t.Errorf("no networks read from the aliased service (got %v)", nets)
+	}
+}
+
+// TestServiceAlias_WholeSectionAliased covers `services: *svcs`, and pins that
+// resolving it does not drag unrelated services into keploy's changes.
+func TestServiceAlias_WholeSectionAliased(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = `x-svcs: &svcs
+  app:
+    image: alpine:3.21
+  db:
+    image: postgres:16
+services: *svcs
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	node, name, err := idc.findServiceNodeAndName(&compose, "app")
+	if err != nil {
+		t.Fatalf("findServiceNodeAndName: %v — the section is aliased, not absent", err)
+	}
+	if name != "app" {
+		t.Fatalf("name = %q, want app", name)
+	}
+	node.Content = append(node.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "container_name"},
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "patched-by-keploy"})
+
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	svcs, _ := out["services"].(map[string]interface{})
+	db, _ := svcs["db"].(map[string]interface{})
+	if _, leaked := db["container_name"]; leaked {
+		t.Errorf("the unrelated db service inherited keploy's edit:\n%s", data)
+	}
+	if db["image"] != "postgres:16" {
+		t.Errorf("db was altered: %v", db)
+	}
+}
+
+// TestAddKeployAgent_RefusesADuplicate pins the guard for a user compose that
+// already defines a service named keploy-agent. Appending beside it produced a
+// generated file that does not parse at all — `mapping key "keploy-agent"
+// already defined` — which reads as a keploy bug rather than a name collision.
+func TestAddKeployAgent_RefusesADuplicate(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	const in = `services:
+  keploy-agent:
+    image: mine/agent
+  app:
+    image: alpine:3.21
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	err := idc.AddKeployAgentToCompose(&compose, buildAgentOpts())
+	if err == nil {
+		data, _ := idc.MarshalCompose(&compose)
+		var probe map[string]interface{}
+		if e := yaml.Unmarshal(data, &probe); e != nil {
+			t.Fatalf("a second keploy-agent was appended and the generated file no "+
+				"longer parses (%v):\n%s", e, data)
+		}
+		t.Fatalf("expected a clear error for the name collision, got none")
+	}
+	if !strings.Contains(err.Error(), "keploy-agent") {
+		t.Errorf("error does not name the colliding service: %v", err)
+	}
+}
+
+// TestServiceAlias_PortsReadThroughAnAliasedSection pins the section-level
+// resolution in findContainerInServices specifically.
+//
+// The per-service resolution inside the loop covers `services: {app: *app}`,
+// where the section itself is a real mapping. It cannot help when the whole
+// section is an alias: the loop never runs, the gate reports not-found, and the
+// caller fails with "container 'X' not found in any of the compose files" on a
+// file that plainly declares it.
+func TestServiceAlias_PortsReadThroughAnAliasedSection(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = `x-svcs: &svcs
+  app:
+    image: alpine:3.21
+    ports:
+      - "8080:8080"
+services: *svcs
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	_, ports, name, found := idc.findContainerInServices(&compose, "app")
+	if !found {
+		t.Fatalf("the app was not found behind a wholly-aliased `services:` section; " +
+			"the caller reports \"container not found\" on a file that declares it")
+	}
+	if name != "app" {
+		t.Errorf("name = %q, want app", name)
+	}
+	if len(ports) == 0 {
+		t.Errorf("no ports read, so keploy-agent would publish none on the app's "+
+			"behalf and the app would be unreachable from the host (got %v)", ports)
+	}
+}
+
+// TestServiceAlias_RealModifyComposeForAgent drives the ACTUAL pipeline rather
+// than hand-simulating keploy's edits.
+//
+// The other tests append to the service node themselves, which cannot notice the
+// simulation drifting from what the code does — and a mutation removing the
+// loop-top resolve in modifyAppServiceForKeploy survived precisely because
+// nothing here exercised that function. This runs ModifyComposeForAgent end to
+// end on the shape that matters: two services aliasing one fragment.
+func TestServiceAlias_RealModifyComposeForAgent(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	const in = `x-base: &base
+  image: alpine:3.21
+  environment:
+    SSL_CERT_FILE: /etc/mine/ca.pem
+  ports:
+    - "8080:8080"
+services:
+  app: *base
+  sidecar: *base
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// The gate the caller runs first; its ports feed opts.AppPorts.
+	_, ports, _, found := idc.findContainerInServices(&compose, "app")
+	if !found || len(ports) == 0 {
+		t.Fatalf("gate did not resolve the aliased service: found=%v ports=%v", found, ports)
+	}
+
+	opts := buildAgentOpts()
+	opts.AppPorts = ports
+	if err := idc.ModifyComposeForAgent(&compose, opts, "app"); err != nil {
+		t.Fatalf("ModifyComposeForAgent: %v", err)
+	}
+
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	svcs, _ := out["services"].(map[string]interface{})
+
+	// The app must actually be wired to the agent.
+	app, _ := svcs["app"].(map[string]interface{})
+	if app == nil {
+		t.Fatalf("app service missing:\n%s", data)
+	}
+	if app["network_mode"] == nil && app["depends_on"] == nil {
+		t.Errorf("the app was not wired to keploy-agent — every edit went into a "+
+			"node the encoder never emits, so it would run uninstrumented:\n%s", data)
+	}
+	if _, ok := svcs["keploy-agent"]; !ok {
+		t.Errorf("keploy-agent was not added:\n%s", data)
+	}
+
+	// The sibling must be exactly as the user wrote it.
+	sidecar, _ := svcs["sidecar"].(map[string]interface{})
+	if sidecar == nil {
+		t.Fatalf("sidecar disappeared:\n%s", data)
+	}
+	if sidecar["network_mode"] != nil || sidecar["depends_on"] != nil {
+		t.Errorf("the sibling was dragged into keploy's wiring:\n%s", data)
+	}
+	if env, _ := sidecar["environment"].(map[string]interface{}); env != nil {
+		if env["SSL_CERT_FILE"] != "/etc/mine/ca.pem" {
+			t.Errorf("the sibling's own SSL_CERT_FILE was replaced with keploy's CA "+
+				"(%v); it is not in the agent's netns, so its outbound TLS would fail "+
+				"verification silently", env["SSL_CERT_FILE"])
+		}
+	}
+}
+
+// TestServiceAlias_ModifyResolvesWhenAgentComesFirst pins the loop-top resolve
+// inside modifyAppServiceForKeploy specifically.
+//
+// Through ModifyComposeForAgent that line looks redundant: the keploy-agent
+// lookup runs first and, because the agent is appended LAST, walks the whole
+// list and resolves every alias on the way. Delete the line and the output is
+// byte-identical — which is exactly why a mutation removing it survived.
+//
+// It stops being redundant the moment the agent is NOT last: the lookup returns
+// early, leaving later services unresolved, and the app's wiring goes into an
+// alias node that is never emitted.
+func TestServiceAlias_ModifyResolvesWhenAgentComesFirst(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	const in = `x-base: &base
+  image: alpine:3.21
+services:
+  keploy-agent:
+    image: keploy/agent
+  app: *base
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := idc.modifyAppServiceForKeploy(&compose, "app"); err != nil {
+		t.Fatalf("modifyAppServiceForKeploy: %v", err)
+	}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	svcs, _ := out["services"].(map[string]interface{})
+	app, _ := svcs["app"].(map[string]interface{})
+	if app == nil {
+		t.Fatalf("app missing:\n%s", data)
+	}
+	if app["network_mode"] == nil && app["depends_on"] == nil && app["pid"] == nil {
+		t.Errorf("the app got no keploy wiring — the service was still an alias when "+
+			"it was modified, so every edit went into a node that is never "+
+			"emitted:\n%s", data)
+	}
+}
+
+// TestAddKeployAgent_RefusesAContainerNameCollision covers the collision the key
+// check cannot see.
+//
+// findServiceNodeAndName matches on container_name as well as on the service
+// key, so a user service carrying `container_name: keploy-agent` is handed back
+// as keploy's OWN agent — keploy then moves the app's dns onto the user's
+// service, and compose rejects the file with `container name "keploy-agent" is
+// already in use`. Worse than a duplicate key, and invisible to a key-only guard.
+func TestAddKeployAgent_RefusesAContainerNameCollision(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	const in = `services:
+  myagent:
+    image: mine/agent
+    container_name: keploy-agent
+  app:
+    image: alpine:3.21
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	err := idc.AddKeployAgentToCompose(&compose, buildAgentOpts())
+	if err == nil {
+		t.Fatalf("expected a refusal: the user's service already uses container_name " +
+			"keploy-agent, so keploy would adopt it as its own agent")
+	}
+	if !strings.Contains(err.Error(), "container_name") || !strings.Contains(err.Error(), "myagent") {
+		t.Errorf("the error should name the colliding service and why: %v", err)
+	}
+}
+
+// TestAddKeployAgent_RefusesAnUnusableServicesSection pins the refusal for a
+// `services:` that still cannot hold entries after resolution — an alias to a
+// scalar or sequence. Appending there returns nil while the agent service is
+// simply absent from the generated file, which is the silent-failure shape this
+// whole change exists to remove.
+func TestAddKeployAgent_RefusesAnUnusableServicesSection(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	const in = `x-thing: &thing just-a-string
+services: *thing
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	err := idc.AddKeployAgentToCompose(&compose, buildAgentOpts())
+	if err == nil {
+		data, _ := idc.MarshalCompose(&compose)
+		t.Fatalf("expected a refusal; instead the agent service was silently "+
+			"dropped:\n%s", data)
+	}
+	if !strings.Contains(err.Error(), "services") {
+		t.Errorf("the error should name the section: %v", err)
+	}
+}

--- a/pkg/platform/docker/compose_volumes_test.go
+++ b/pkg/platform/docker/compose_volumes_test.go
@@ -1,0 +1,247 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"gopkg.in/yaml.v3"
+)
+
+// TestAddTopLevelVolume_ExplicitNullVolumes is the regression test for a compose
+// file that declares `volumes:` with nothing under it.
+//
+// The guard used to test only for a ZERO node, which is what an ABSENT key
+// decodes to. An explicit empty key decodes to a null SCALAR (Kind
+// yaml.ScalarNode, Tag "!!null") instead, so the normalisation was skipped and
+// the volume was appended to a scalar's Content -- where the encoder ignores it.
+// The generated compose then declared no volume at all while keploy's agent
+// service referenced one, and docker compose refused the file. The user saw
+// their app fail to start on a compose file docker accepts.
+func TestAddTopLevelVolume_ExplicitNullVolumes(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = `services:
+  app:
+    image: alpine:3.21
+volumes:
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Guard the premise: if this ever decodes to a zero node, the bug this
+	// pins cannot happen and the test is no longer testing anything.
+	if compose.Volumes.Kind != yaml.ScalarNode || compose.Volumes.Tag != "!!null" {
+		t.Fatalf("expected an explicit `volumes:` to decode as a null scalar, got Kind=%d Tag=%q",
+			compose.Volumes.Kind, compose.Volumes.Tag)
+	}
+
+	idc.addTopLevelVolume(&compose, "keploy-tls-certs")
+
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), "keploy-tls-certs") {
+		t.Fatalf("the appended volume was never emitted; the agent service would "+
+			"reference an undefined volume:\n%s", data)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("reload: %v\n%s", err, data)
+	}
+	vols, ok := reloaded["volumes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("volumes is %T, not a mapping — docker compose rejects this:\n%s",
+			reloaded["volumes"], data)
+	}
+	if _, ok := vols["keploy-tls-certs"]; !ok {
+		t.Errorf("volumes mapping does not contain the appended volume: %v", vols)
+	}
+	// Cosmetic, but pinned so the tag-clearing is not unjustified dead code:
+	// docker compose accepts `volumes: !!null` with entries under it, yet
+	// emitting it puts a stray null tag in a file operators read while
+	// debugging. Scoped to the volumes line rather than the whole document, so
+	// a fixture that legitimately contains "!!null" elsewhere cannot trip it.
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "volumes:") && strings.Contains(line, "!!null") {
+			t.Errorf("volumes section carries a stray null tag: %q", line)
+		}
+	}
+}
+
+// TestAddTopLevelVolume_AbsentAndPopulated pins the two shapes that already
+// worked, so normalising the null case did not break them.
+func TestAddTopLevelVolume_AbsentAndPopulated(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	for _, tc := range []struct {
+		name string
+		in   string
+		also string // an existing volume that must survive
+	}{
+		{"absent", "services:\n  app:\n    image: alpine:3.21\n", ""},
+		{"populated", "services:\n  app:\n    image: alpine:3.21\nvolumes:\n  appdata: {}\n", "appdata"},
+		{"empty mapping", "services:\n  app:\n    image: alpine:3.21\nvolumes: {}\n", ""},
+		// The shapes that survived a fix which enumerated null spellings: each
+		// produces the identical "volumes must be a mapping" rejection.
+		{"empty sequence", "services:\n  app:\n    image: alpine:3.21\nvolumes: []\n", ""},
+		{"empty string", "services:\n  app:\n    image: alpine:3.21\nvolumes: \"\"\n", ""},
+		{"tilde null", "services:\n  app:\n    image: alpine:3.21\nvolumes: ~\n", ""},
+		{"word null", "services:\n  app:\n    image: alpine:3.21\nvolumes: null\n", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var compose Compose
+			if err := yaml.Unmarshal([]byte(tc.in), &compose); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			idc.addTopLevelVolume(&compose, "keploy-tls-certs")
+			data, err := idc.MarshalCompose(&compose)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var reloaded map[string]interface{}
+			if err := yaml.Unmarshal(data, &reloaded); err != nil {
+				t.Fatalf("reload: %v\n%s", err, data)
+			}
+			vols, ok := reloaded["volumes"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("volumes is %T, not a mapping:\n%s", reloaded["volumes"], data)
+			}
+			if _, ok := vols["keploy-tls-certs"]; !ok {
+				t.Errorf("appended volume missing: %v", vols)
+			}
+			if tc.also != "" {
+				if _, ok := vols[tc.also]; !ok {
+					t.Errorf("pre-existing volume %q was lost: %v", tc.also, vols)
+				}
+			}
+		})
+	}
+}
+
+// TestAddTopLevelVolume_Idempotent pins that appending the same volume twice
+// does not duplicate the key, which would make the file unloadable.
+func TestAddTopLevelVolume_Idempotent(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte("services:\n  app:\n    image: alpine:3.21\nvolumes:\n"), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	idc.addTopLevelVolume(&compose, "keploy-tls-certs")
+	idc.addTopLevelVolume(&compose, "keploy-tls-certs")
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("duplicate key made the document unloadable: %v\n%s", err, data)
+	}
+	// Count KEYS in the volumes mapping, not occurrences in the document: the
+	// real pipeline also emits the name once per service that mounts it, so a
+	// document-wide count would fire spuriously the moment this fixture grew a
+	// mount.
+	vols, ok := reloaded["volumes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("volumes is %T, not a mapping:\n%s", reloaded["volumes"], data)
+	}
+	if len(vols) != 1 {
+		t.Errorf("volumes has %d entries, want 1: %v", len(vols), vols)
+	}
+}
+
+// TestEnsureMapping_LeavesPopulatedNonMappingAlone pins the guard that stops the
+// normalisation becoming data loss.
+//
+// Reshaping an EMPTY node is safe — there is nothing to lose. Reshaping a
+// populated one is not: the content would be dropped on the floor and the user
+// would get a compose file silently missing what they wrote. docker compose's
+// own "must be a mapping" error is a far better outcome than losing it, so a
+// populated non-mapping must survive untouched.
+func TestEnsureMapping_LeavesPopulatedNonMappingAlone(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+	}{
+		{"populated sequence", "volumes:\n  - appdata\n  - logs\n"},
+		{"non-empty scalar", "volumes: appdata\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var doc yaml.Node
+			if err := yaml.Unmarshal([]byte(tc.in), &doc); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			node := doc.Content[0].Content[1] // the value of `volumes:`
+			before := *node
+			beforeKids := len(node.Content)
+
+			ensureMapping(node)
+
+			if node.Kind != before.Kind {
+				t.Errorf("Kind changed %d -> %d: a populated node was reshaped, "+
+					"which discards what the user wrote", before.Kind, node.Kind)
+			}
+			if len(node.Content) != beforeKids {
+				t.Errorf("Content changed %d -> %d entries", beforeKids, len(node.Content))
+			}
+			if node.Value != before.Value {
+				t.Errorf("Value changed %q -> %q", before.Value, node.Value)
+			}
+		})
+	}
+}
+
+// TestAddTopLevelVolume_WarnsWhenVolumesCannotHoldTheEntry covers the shapes
+// ensureMapping deliberately refuses to reshape.
+//
+// `volumes: *alias` is the one that matters: it is LEGAL compose and it is the
+// same `x-*` + anchor idiom this file preserves elsewhere, yet keploy cannot
+// append its volume to an alias node. Without a warning the user gets only
+// docker compose's downstream complaint, which names the agent service and says
+// nothing about their `volumes:` line.
+func TestAddTopLevelVolume_WarnsWhenVolumesCannotHoldTheEntry(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		in       string
+		wantWarn bool
+	}{
+		{"alias to a populated mapping", "x-vols: &vols\n  appdata: {}\nvolumes: *vols\n", true},
+		{"populated sequence", "volumes:\n  - appdata\n", true},
+		{"populated scalar", "volumes: appdata\n", true},
+		{"explicit null (normalises fine)", "volumes:\n", false},
+		{"empty sequence (normalises fine)", "volumes: []\n", false},
+		{"already a mapping", "volumes:\n  appdata: {}\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			core, logs := observer.New(zap.WarnLevel)
+			idc := &Impl{logger: zap.New(core)}
+
+			var compose Compose
+			if err := yaml.Unmarshal([]byte(tc.in), &compose); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			idc.addTopLevelVolume(&compose, "keploy-tls-certs")
+
+			warns := logs.FilterMessageSnippet("is not a mapping").Len()
+			if tc.wantWarn && warns == 0 {
+				t.Errorf("no warning for a `volumes:` shape that cannot hold the entry; " +
+					"the user would only see docker compose's undefined-volume error")
+			}
+			if !tc.wantWarn && warns != 0 {
+				t.Errorf("warned about a shape that normalised fine: %v",
+					logs.All()[0].Message)
+			}
+			// Whatever happens, the user's own content must survive.
+			if tc.wantWarn {
+				data, err := idc.MarshalCompose(&compose)
+				if err != nil {
+					t.Fatalf("marshal: %v", err)
+				}
+				if !strings.Contains(string(data), "appdata") {
+					t.Errorf("the user's volumes content was discarded:\n%s", data)
+				}
+			}
+		})
+	}
+}

--- a/pkg/platform/docker/compose_volumes_test.go
+++ b/pkg/platform/docker/compose_volumes_test.go
@@ -206,7 +206,6 @@ func TestAddTopLevelVolume_WarnsWhenVolumesCannotHoldTheEntry(t *testing.T) {
 		in       string
 		wantWarn bool
 	}{
-		{"alias to a populated mapping", "x-vols: &vols\n  appdata: {}\nvolumes: *vols\n", true},
 		{"populated sequence", "volumes:\n  - appdata\n", true},
 		{"populated scalar", "volumes: appdata\n", true},
 		{"explicit null (normalises fine)", "volumes:\n", false},
@@ -223,7 +222,7 @@ func TestAddTopLevelVolume_WarnsWhenVolumesCannotHoldTheEntry(t *testing.T) {
 			}
 			idc.addTopLevelVolume(&compose, "keploy-tls-certs")
 
-			warns := logs.FilterMessageSnippet("is not a mapping").Len()
+			warns := logs.FilterMessageSnippet("cannot hold a volume entry").Len()
 			if tc.wantWarn && warns == 0 {
 				t.Errorf("no warning for a `volumes:` shape that cannot hold the entry; " +
 					"the user would only see docker compose's undefined-volume error")
@@ -243,5 +242,316 @@ func TestAddTopLevelVolume_WarnsWhenVolumesCannotHoldTheEntry(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestAddTopLevelVolume_ResolvesAnAliasByCopy covers `volumes: *vols`,
+// which is legal compose and the same `x-*` + anchor idiom the rest of this
+// change works to preserve.
+//
+// An alias node is a REFERENCE: it holds no entries, so appending to it writes
+// into a node the encoder never emits. The generated file then declared no
+// volume while the agent service mounted one, and docker compose rejected it
+// with "refers to undefined volume" — an error naming a service the user never
+// wrote.
+//
+// The alias is resolved BY COPY: `volumes:` receives a clone of the fragment and
+// keploy's entry is appended to that. Appending into the anchored node instead
+// would hand the entry to every other alias of it, which is what the sibling
+// test below pins.
+func TestAddTopLevelVolume_ResolvesAnAliasByCopy(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = `x-vols: &vols
+  appdata: {}
+volumes: *vols
+services:
+  app:
+    image: alpine:3.21
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	idc.addTopLevelVolume(&compose, "keploy-tls-certs")
+
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	vols, ok := reloaded["volumes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("volumes is %T, not a mapping:\n%s", reloaded["volumes"], data)
+	}
+	if _, ok := vols["keploy-tls-certs"]; !ok {
+		t.Errorf("the volume was not declared; the agent service would reference an "+
+			"undefined volume:\n%s", data)
+	}
+	// The user's own volume must survive...
+	if _, ok := vols["appdata"]; !ok {
+		t.Errorf("the user's own volume was lost: %v", vols)
+	}
+	// ...and the anchored fragment must be UNCHANGED. Appending into it instead
+	// of copying would hand keploy's volume to every other alias of it.
+	frag, ok := reloaded["x-vols"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("x-vols is %T, not the mapping the user wrote:\n%s", reloaded["x-vols"], data)
+	}
+	if _, leaked := frag["keploy-tls-certs"]; leaked {
+		t.Errorf("keploy's volume was written into the user's shared `x-vols` "+
+			"fragment; every other alias of it inherits the entry:\n%s", data)
+	}
+	if len(frag) != 1 {
+		t.Errorf("the user's fragment gained entries: %v", frag)
+	}
+}
+
+// TestAddTopLevelVolume_AliasIsIdempotent pins that following the alias does not
+// break the duplicate check — appending twice through a reference must still
+// produce one entry, or the generated file carries a duplicate mapping key and
+// will not load at all.
+func TestAddTopLevelVolume_AliasIsIdempotent(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = "x-vols: &vols\n  appdata: {}\nvolumes: *vols\n"
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	idc.addTopLevelVolume(&compose, "keploy-tls-certs")
+	idc.addTopLevelVolume(&compose, "keploy-tls-certs")
+
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("duplicate key made the document unloadable: %v\n%s", err, data)
+	}
+	vols, _ := reloaded["volumes"].(map[string]interface{})
+	if len(vols) != 2 {
+		t.Errorf("volumes has %d entries, want 2 (appdata + keploy-tls-certs): %v", len(vols), vols)
+	}
+}
+
+// TestAddTopLevelVolume_AliasToNonMappingIsLeftAlone pins the guard on following
+// an alias.
+//
+// Following it blindly would append into whatever the anchor happens to be. If
+// that is a scalar the entries vanish exactly as they did before this change —
+// but now silently and without the warning, because the code believes it found a
+// container. Worse, it would be writing into the user's own fragment. An alias is
+// followed only when it resolves to something that can actually hold entries.
+func TestAddTopLevelVolume_AliasToNonMappingIsLeftAlone(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	idc := &Impl{logger: zap.New(core)}
+
+	// A populated sequence. Under copy-resolution either shape discriminates —
+	// dropping the guard leaves `volumes:` an empty mapping and never touches
+	// the fragment — so what this pins is the WARNING, plus the fragment being
+	// left exactly as written rather than reshaped to suit us.
+	const in = `x-thing: &thing
+  - just-a-string
+volumes: *thing
+services:
+  app:
+    image: alpine:3.21
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	idc.addTopLevelVolume(&compose, "keploy-tls-certs")
+
+	if logs.FilterMessageSnippet("cannot hold a volume entry").Len() == 0 {
+		t.Error("no warning for an alias resolving to a scalar — the volume cannot " +
+			"be declared there, and silence is what made this class of failure hard " +
+			"to diagnose in the first place")
+	}
+
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	// The user's fragment must be untouched: appending into it corrupts a value
+	// they wrote, and unlike a scalar a sequence's contents really are emitted.
+	frag, ok := reloaded["x-thing"].([]interface{})
+	if !ok {
+		t.Fatalf("x-thing is %T, not the sequence the user wrote:\n%s", reloaded["x-thing"], data)
+	}
+	if len(frag) != 1 || frag[0] != "just-a-string" {
+		t.Errorf("keploy appended into the user's anchored sequence: %v\n%s", frag, data)
+	}
+}
+
+// TestAddTopLevelVolume_DoesNotCorruptAFragmentSharedElsewhere is the reason the
+// alias is resolved by COPY rather than by appending into the anchored node.
+//
+// An `x-*` fragment is shared: appending into it hands keploy's volume to every
+// other reference. The shape below is the sharp case — the same fragment names
+// the volume set AND a service's labels — so mutating it in place gives the app
+// a `keploy-tls-certs` LABEL. Corrupting an unrelated part of the user's file to
+// fix our own is a worse outcome than the bug, and it leaves no trace.
+func TestAddTopLevelVolume_DoesNotCorruptAFragmentSharedElsewhere(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = `x-common: &common
+  foo: bar
+volumes: *common
+services:
+  app:
+    image: alpine:3.21
+    labels: *common
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	idc.addTopLevelVolume(&compose, "keploy-tls-certs")
+
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+
+	// keploy's volume is declared...
+	vols, _ := reloaded["volumes"].(map[string]interface{})
+	if _, ok := vols["keploy-tls-certs"]; !ok {
+		t.Errorf("the volume was not declared:\n%s", data)
+	}
+	// ...and has NOT leaked into the shared fragment or the service's labels.
+	frag, _ := reloaded["x-common"].(map[string]interface{})
+	if _, leaked := frag["keploy-tls-certs"]; leaked {
+		t.Errorf("keploy's volume leaked into the shared `x-common` fragment:\n%s", data)
+	}
+	svcs, _ := reloaded["services"].(map[string]interface{})
+	app, _ := svcs["app"].(map[string]interface{})
+	labels, _ := app["labels"].(map[string]interface{})
+	if _, leaked := labels["keploy-tls-certs"]; leaked {
+		t.Errorf("keploy's volume became a LABEL on the user's service — the shared "+
+			"fragment was mutated in place:\n%s", data)
+	}
+	if len(labels) != 1 {
+		t.Errorf("the service's labels changed: %v", labels)
+	}
+}
+
+// TestAddTopLevelVolume_ResolvedCopiesAreIndependent pins that the clone in
+// sectionForAppend is load-bearing rather than defensive.
+//
+// A mapping node's Content holds two entries per key, so a THREE-key fragment
+// sits at len 6 / cap 8 — exactly the two spare slots one append consumes. Share
+// the slice instead of cloning it and the append writes into the fragment's
+// backing array without reallocating; a second section resolved through the same
+// fragment then OVERWRITES the first's entry instead of appending after it.
+//
+// Three keys is not incidental: one- and two-key fragments have zero spare
+// capacity, so Go reallocates and the bug cannot be observed.
+func TestAddTopLevelVolume_ResolvedCopiesAreIndependent(t *testing.T) {
+	const in = `x-shared: &shared
+  a: {}
+  b: {}
+  c: {}
+volumes: *shared
+networks: *shared
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Resolve BOTH sections through the same fragment and append to each, which
+	// is what extending this to networks would do.
+	vols := sectionForAppend(&compose.Volumes)
+	nets := sectionForAppend(&compose.Networks)
+	vols.Content = append(vols.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "keploy-tls-certs"},
+		&yaml.Node{Kind: yaml.MappingNode})
+	nets.Content = append(nets.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "keploy-net"},
+		&yaml.Node{Kind: yaml.MappingNode})
+
+	idc := &Impl{logger: zap.NewNop()}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("reload: %v\n%s", err, data)
+	}
+
+	gotVols, _ := reloaded["volumes"].(map[string]interface{})
+	if _, ok := gotVols["keploy-tls-certs"]; !ok {
+		t.Errorf("volumes lost its own entry — a second section resolved through the "+
+			"same fragment overwrote it through a shared backing array: %v\n%s",
+			gotVols, data)
+	}
+	if _, wrong := gotVols["keploy-net"]; wrong {
+		t.Errorf("volumes gained the networks entry: %v", gotVols)
+	}
+	gotNets, _ := reloaded["networks"].(map[string]interface{})
+	if _, ok := gotNets["keploy-net"]; !ok {
+		t.Errorf("networks lost its own entry: %v", gotNets)
+	}
+	// And the user's fragment is untouched by either.
+	frag, _ := reloaded["x-shared"].(map[string]interface{})
+	if len(frag) != 3 {
+		t.Errorf("the shared fragment gained entries: %v", frag)
+	}
+}
+
+// TestAddTopLevelVolume_AliasToAnEmptyFragment pins the isEmptySection arm of
+// sectionForAppend, which nothing else reaches.
+//
+// `x-vols: &vols` with nothing under it is a null scalar, so an alias to it is
+// not a mapping — declining there would regress this shape straight back to the
+// bug. The fragment itself must NOT be reshaped: rewriting a user's `&vols` into
+// a mapping is how the earlier, abandoned approach broke a service whose own
+// volumes list aliased the same fragment.
+func TestAddTopLevelVolume_AliasToAnEmptyFragment(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop()}
+	const in = `x-vols: &vols
+volumes: *vols
+services:
+  app:
+    image: alpine:3.21
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	idc.addTopLevelVolume(&compose, "keploy-tls-certs")
+
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	vols, ok := reloaded["volumes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("volumes is %T, not a mapping — an alias to an empty fragment was "+
+			"declined, leaving the volume undeclared:\n%s", reloaded["volumes"], data)
+	}
+	if _, ok := vols["keploy-tls-certs"]; !ok {
+		t.Errorf("the volume was not declared: %v\n%s", vols, data)
+	}
+	// The user's fragment stays exactly as written.
+	if v, present := reloaded["x-vols"]; !present || v != nil {
+		t.Errorf("the empty anchored fragment was reshaped to %#v; it must be left "+
+			"as the user wrote it:\n%s", v, data)
 	}
 }

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -1379,9 +1379,12 @@ func (idc *Impl) addServiceListProperty(serviceNode *yaml.Node, key, value strin
 	var valueNode *yaml.Node
 
 	// Check if key exists
-	for i := 0; i < len(serviceNode.Content); i += 2 {
+	for i := 0; i+1 < len(serviceNode.Content); i += 2 {
 		if serviceNode.Content[i].Value == key {
-			valueNode = serviceNode.Content[i+1]
+			// An aliased list (`volumes: *appvols`) holds no entries, so the
+			// append below would land in a node the encoder never emits and the
+			// TLS-cert mount would simply not appear.
+			valueNode = resolveAliasByCopy(serviceNode.Content[i+1])
 			break
 		}
 	}
@@ -1403,9 +1406,14 @@ func (idc *Impl) addServiceListProperty(serviceNode *yaml.Node, key, value strin
 // a SequenceNode if none exists. It centralizes the lookup/create logic for
 // environment mutations performed by helper methods.
 func (idc *Impl) getOrCreateEnvNode(serviceNode *yaml.Node) *yaml.Node {
-	for i := 0; i < len(serviceNode.Content); i += 2 {
+	for i := 0; i+1 < len(serviceNode.Content); i += 2 {
 		if serviceNode.Content[i].Value == "environment" {
-			return serviceNode.Content[i+1]
+			// `environment: *appenv` is an alias: it holds no entries, so the
+			// callers' type switch matches nothing and keploy's variables are
+			// silently dropped. Resolving by copy also keeps a sibling service
+			// sharing that fragment from inheriting keploy's CA paths while
+			// living outside the agent's network namespace.
+			return resolveAliasByCopy(serviceNode.Content[i+1])
 		}
 	}
 
@@ -1613,10 +1621,33 @@ func resolvedKind(n *yaml.Node) yaml.Kind {
 // fragment is only ever appended to, so a duplicate definition cannot diverge
 // from the original. A copied service is edited, so it can.
 func resolveServiceAlias(n *yaml.Node) *yaml.Node {
+	if n != nil && n.Kind == yaml.AliasNode && n.Alias != nil &&
+		n.Alias.Kind != yaml.MappingNode {
+		// A service must be a mapping. Leave anything else exactly as written
+		// and let the caller report it.
+		return n
+	}
+	return resolveAliasByCopy(n)
+}
+
+// resolveAliasByCopy is resolveServiceAlias without the mapping-only
+// restriction, for the nodes INSIDE a service.
+//
+// `environment:` and `volumes:` are aliased at least as often as a whole
+// service, and keploy writes into both. Unresolved, the two helpers below fail
+// in opposite directions and neither says anything: addServiceEnvVar's type
+// switch matches neither SequenceNode nor MappingNode for an AliasNode and falls
+// straight through, so keploy's CA and JAVA_TOOL_OPTIONS are dropped and the app
+// runs uninstrumented; addServiceListProperty appends into the alias, so the
+// TLS-cert mount never appears. Both leave a file docker compose happily accepts.
+//
+// A sequence target is allowed here because `environment: - K=V` and
+// `volumes: - a:b` are the ordinary shapes.
+func resolveAliasByCopy(n *yaml.Node) *yaml.Node {
 	if n == nil || n.Kind != yaml.AliasNode || n.Alias == nil {
 		return n
 	}
-	if n.Alias.Kind != yaml.MappingNode {
+	if n.Alias.Kind != yaml.MappingNode && n.Alias.Kind != yaml.SequenceNode {
 		// Cannot hold entries. Left exactly as the user wrote it rather than
 		// reshaping a fragment they authored; the caller reports it.
 		return n

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -1154,10 +1154,7 @@ func (idc *Impl) AddKeployAgentToCompose(compose *Compose, opts models.SetupOpti
 	}
 
 	// Ensure services section exists
-	if compose.Services.Content == nil {
-		compose.Services.Kind = yaml.MappingNode
-		compose.Services.Content = make([]*yaml.Node, 0)
-	}
+	ensureMapping(&compose.Services)
 
 	// Add the keploy-agent service to the compose file
 	compose.Services.Content = append(compose.Services.Content,
@@ -1466,9 +1463,22 @@ func (idc *Impl) appendServiceEnvVar(serviceNode *yaml.Node, envKey, appendValue
 
 // Helper to ensure top-level volumes exists
 func (idc *Impl) addTopLevelVolume(compose *Compose, volumeName string) {
-	if compose.Volumes.Kind == 0 {
-		compose.Volumes.Kind = yaml.MappingNode
-		compose.Volumes.Content = []*yaml.Node{}
+	ensureMapping(&compose.Volumes)
+	if compose.Volumes.Kind != yaml.MappingNode {
+		// Left deliberately un-reshaped by ensureMapping because it holds
+		// something. The append below cannot land, so the generated compose
+		// will declare no volume while the agent service mounts one, and
+		// docker compose will reject it with "refers to undefined volume".
+		// That error names the agent, not the user's `volumes:` line, so say
+		// here what actually has to change.
+		//
+		// `volumes: *alias` is the shape worth calling out: it is legal
+		// compose, and it is the same x-* + anchor idiom this file works hard
+		// to preserve elsewhere.
+		idc.logger.Warn("top-level `volumes:` is not a mapping, so keploy cannot declare "+
+			"its volume there; docker compose will reject the generated file",
+			zap.String("volume", volumeName),
+			zap.Int("yamlKind", int(compose.Volumes.Kind)))
 	}
 
 	// Check if volume exists
@@ -1483,6 +1493,64 @@ func (idc *Impl) addTopLevelVolume(compose *Compose, volumeName string) {
 		&yaml.Node{Kind: yaml.ScalarNode, Value: volumeName},
 		&yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{}}, // {}
 	)
+}
+
+// ensureMapping turns an EMPTY section node into an empty mapping so callers can
+// append key/value pairs to it.
+//
+// A section reaches us in several empty shapes and only two used to be handled,
+// each at a different call site with a different predicate. An absent key
+// decodes to a zero node; an explicit `volumes:` with nothing under it decodes
+// to a null SCALAR; `volumes: []` decodes to an empty sequence; `volumes: ""` to
+// an empty string. Appending to any of the latter three writes into a node the
+// encoder will not emit as a mapping, so the generated compose declared nothing
+// while keploy's agent service referenced it, and docker compose refused the
+// file with "volumes must be a mapping" -- on a compose file it otherwise
+// accepts. Normalising on the target shape closes all of them at once instead of
+// enumerating spellings.
+//
+// A POPULATED non-mapping is deliberately left alone. Reshaping it would
+// silently discard what the user wrote, and docker compose's own error is a far
+// better outcome than losing their data.
+//
+// The tag is cleared because a MappingNode still carrying `!!null` emits
+// `volumes: !!null` above the entries. Both docker compose and go-yaml accept
+// that, so it is cosmetic -- but it is a stray null tag in a file operators are
+// handed to debug. Value is deliberately NOT cleared: the encoder never reads it
+// for a mapping, so clearing it would be an unobservable no-op.
+func ensureMapping(n *yaml.Node) {
+	if n == nil || n.Kind == yaml.MappingNode || !isEmptySection(n) {
+		return
+	}
+	n.Kind = yaml.MappingNode
+	n.Tag = ""
+	// Style carries the flow/quote bits of the shape being replaced, so an
+	// empty `volumes: []` would otherwise normalise into a flow-style mapping
+	// sitting in an otherwise block-style file. Valid either way; consistent
+	// reads better.
+	n.Style = 0
+	n.Content = []*yaml.Node{}
+}
+
+// isEmptySection reports whether a section node holds nothing, in any of the
+// shapes YAML can express that: an absent key (zero node), a null in any
+// spelling, an empty string, or an empty sequence.
+//
+// A node carrying content is NOT empty, and that includes shapes whose payload
+// does not live in Content: a scalar keeps its text in Value, and an alias
+// resolves elsewhere entirely. Treating those as empty would silently discard
+// what the user wrote.
+func isEmptySection(n *yaml.Node) bool {
+	switch n.Kind {
+	case 0:
+		return true
+	case yaml.ScalarNode:
+		return n.Tag == "!!null" || n.Value == ""
+	case yaml.SequenceNode:
+		return len(n.Content) == 0
+	default:
+		return false
+	}
 }
 
 func cloneYAMLNode(node *yaml.Node) *yaml.Node {

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -493,6 +493,12 @@ func (idc *Impl) FindContainerInComposeFiles(composePaths []string, containerNam
 // findContainerInServices searches for a container within the services of a compose file
 // This reuses the same iteration pattern as existing functions like SetPidContainer
 func (idc *Impl) findContainerInServices(compose *Compose, containerName string) ([]string, []string, string, bool) {
+	// This gate runs BEFORE ModifyComposeForAgent and its ports/networks become
+	// opts.AppPorts/AppNetworks. Read off an unresolved alias they come back
+	// empty, so the app's published port never reaches keploy-agent -- which
+	// publishes on the app's behalf under network_mode: service:keploy-agent --
+	// and the app is unreachable from the host.
+	resolveServiceAlias(&compose.Services)
 	if compose.Services.Content == nil {
 		return nil, nil, "", false
 	}
@@ -504,7 +510,7 @@ func (idc *Impl) findContainerInServices(compose *Compose, containerName string)
 		}
 
 		serviceNameNode := compose.Services.Content[i]
-		serviceContentNode := compose.Services.Content[i+1]
+		serviceContentNode := resolveServiceAlias(compose.Services.Content[i+1])
 		serviceName := serviceNameNode.Value
 
 		// Check for explicit container_name using the same pattern as existing functions
@@ -1147,14 +1153,54 @@ func (idc *Impl) GenerateKeployAgentService(opts models.SetupOptions) (*yaml.Nod
 // AddKeployAgentToCompose adds the keploy-agent service to an existing Docker Compose file
 // This is a convenience function that shows how to use GenerateKeployAgentService
 func (idc *Impl) AddKeployAgentToCompose(compose *Compose, opts models.SetupOptions) error {
+	// Ensure services section exists. Resolve as well as normalise: an aliased
+	// `services:` would otherwise take the append into a node that is never
+	// emitted, and this must not depend on findServiceNodeAndName happening to
+	// run first.
+	ensureMapping(&compose.Services)
+	resolveServiceAlias(&compose.Services)
+
+	// A section that STILL cannot hold entries -- an alias to a scalar or a
+	// sequence -- would swallow the append and leave this returning nil with the
+	// agent service simply absent from the generated file.
+	if compose.Services.Kind != yaml.MappingNode {
+		return fmt.Errorf("`services:` is not a mapping (%s), so keploy cannot add "+
+			"its agent service to it", yamlKindName(compose.Services.Kind))
+	}
+
+	// Refuse to add a second keploy-agent, by service KEY or by container_name.
+	// A user service by that name is unusual but legal, and appending beside it
+	// produced a generated file that does not parse at all -- `mapping key
+	// "keploy-agent" already defined` -- reading as a keploy bug rather than the
+	// name collision it is. The container_name variant is worse than a duplicate
+	// key: findServiceNodeAndName matches on container_name too, so keploy would
+	// treat the USER's service as its agent and move the app's dns onto it, and
+	// compose rejects the file with `container name "keploy-agent" is already in
+	// use`.
+	//
+	// Checked before GenerateKeployAgentService so a doomed run does not first
+	// fire the enterprise compose hook.
+	for i := 0; i+1 < len(compose.Services.Content); i += 2 {
+		if compose.Services.Content[i].Value == "keploy-agent" {
+			return fmt.Errorf("the compose file already defines a service named " +
+				"\"keploy-agent\"; rename it so keploy can add its own")
+		}
+		svc := compose.Services.Content[i+1]
+		for j := 0; j+1 < len(svc.Content); j += 2 {
+			if svc.Content[j].Value == "container_name" &&
+				svc.Content[j+1].Value == "keploy-agent" {
+				return fmt.Errorf("service %q already uses container_name "+
+					"\"keploy-agent\"; rename it so keploy can add its own",
+					compose.Services.Content[i].Value)
+			}
+		}
+	}
+
 	// Generate the keploy-agent service configuration
 	keployServiceNode, err := idc.GenerateKeployAgentService(opts)
 	if err != nil {
 		return fmt.Errorf("failed to generate keploy-agent service: %w", err)
 	}
-
-	// Ensure services section exists
-	ensureMapping(&compose.Services)
 
 	// Add the keploy-agent service to the compose file
 	compose.Services.Content = append(compose.Services.Content,
@@ -1167,13 +1213,21 @@ func (idc *Impl) AddKeployAgentToCompose(compose *Compose, opts models.SetupOpti
 
 // Helper: findServiceNodeAndName finds the YAML node and the Service Key (name)
 func (idc *Impl) findServiceNodeAndName(compose *Compose, appIdentifier string) (*yaml.Node, string, error) {
+	// `services: *svcs` is legal compose, and an alias holds no entries of its
+	// own, so the scan below saw nothing and reported "no services found".
+	resolveServiceAlias(&compose.Services)
 	if compose.Services.Content == nil {
 		return nil, "", fmt.Errorf("no services found")
 	}
 
 	for i := 0; i < len(compose.Services.Content); i += 2 {
+		if i+1 >= len(compose.Services.Content) {
+			break // odd Content: guarded like the sibling loops rather than panicking
+		}
 		serviceNameNode := compose.Services.Content[i]
-		serviceContentNode := compose.Services.Content[i+1]
+		// Resolved at the loop top, not at either return, so the container_name
+		// match below scans real content instead of an alias's empty Content.
+		serviceContentNode := resolveServiceAlias(compose.Services.Content[i+1])
 		serviceName := serviceNameNode.Value
 
 		// Check 1: Does the Service Key match?
@@ -1246,7 +1300,7 @@ func (idc *Impl) modifyAppServiceForKeploy(compose *Compose, appContainerName st
 		}
 
 		serviceNameNode := compose.Services.Content[i]
-		serviceContentNode := compose.Services.Content[i+1]
+		serviceContentNode := resolveServiceAlias(compose.Services.Content[i+1])
 		serviceName := serviceNameNode.Value
 
 		// Check if this is the target app service
@@ -1528,6 +1582,61 @@ func resolvedKind(n *yaml.Node) yaml.Kind {
 		return n.Alias.Kind
 	}
 	return n.Kind
+}
+
+// resolveServiceAlias replaces an alias node with a DEEP copy of what it names,
+// so the resolved node can be edited without reaching back into the shared
+// fragment.
+//
+// sectionForAppend's shallow copy is right for `volumes:`/`networks:`, whose
+// entries are inert and only ever appended to. It is wrong for a SERVICE,
+// because keploy does not only append to one: modifyAppServiceForKeploy DELETES
+// keys (networks, ports, dns/dns_search/dns_opt) and OVERWRITES values in place
+// (addServiceEnvVar), and enterprise's ComposeServiceHook rewrites
+// JAVA_TOOL_OPTIONS unconditionally on every replay.
+//
+// With children shared, a sibling service aliasing the same fragment inherits
+// all of it -- including a TLS environment pointing SSL_CERT_FILE,
+// REQUESTS_CA_BUNDLE and NODE_EXTRA_CA_CERTS at keploy's CA, inside a container
+// that is NOT in the agent's network namespace, so its outbound TLS fails
+// verification. Silently. A mapping-style `environment:` is worse: the user's
+// own value is overwritten inside their own fragment.
+//
+// Anchors are stripped from the copy. Keeping them would emit a SECOND
+// definition of the same anchor, and because this copy is about to be mutated
+// the two would diverge -- a later `*name` or `<<: *name` binds to the nearest
+// preceding definition, so an unrelated service would silently pick up keploy's
+// edits. Stripping leaves the user's fragment as the only definition, which is
+// what every other reference should still resolve to.
+//
+// Deliberately unlike sectionForAppend, which KEEPS the anchor: a copied volumes
+// fragment is only ever appended to, so a duplicate definition cannot diverge
+// from the original. A copied service is edited, so it can.
+func resolveServiceAlias(n *yaml.Node) *yaml.Node {
+	if n == nil || n.Kind != yaml.AliasNode || n.Alias == nil {
+		return n
+	}
+	if n.Alias.Kind != yaml.MappingNode {
+		// Cannot hold entries. Left exactly as the user wrote it rather than
+		// reshaping a fragment they authored; the caller reports it.
+		return n
+	}
+	clone := cloneYAMLNode(n.Alias)
+	stripAnchors(clone)
+	*n = *clone
+	return n
+}
+
+// stripAnchors clears anchor names throughout a subtree. See resolveServiceAlias
+// for why a copy must not carry them.
+func stripAnchors(n *yaml.Node) {
+	if n == nil {
+		return
+	}
+	n.Anchor = ""
+	for _, c := range n.Content {
+		stripAnchors(c)
+	}
 }
 
 // sectionForAppend returns the mapping a section's entries must actually be

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -1463,36 +1463,142 @@ func (idc *Impl) appendServiceEnvVar(serviceNode *yaml.Node, envKey, appendValue
 
 // Helper to ensure top-level volumes exists
 func (idc *Impl) addTopLevelVolume(compose *Compose, volumeName string) {
-	ensureMapping(&compose.Volumes)
-	if compose.Volumes.Kind != yaml.MappingNode {
-		// Left deliberately un-reshaped by ensureMapping because it holds
-		// something. The append below cannot land, so the generated compose
-		// will declare no volume while the agent service mounts one, and
-		// docker compose will reject it with "refers to undefined volume".
-		// That error names the agent, not the user's `volumes:` line, so say
-		// here what actually has to change.
+	vols := sectionForAppend(&compose.Volumes)
+	if vols.Kind != yaml.MappingNode {
+		// Reached in three shapes: a populated scalar, a populated sequence, or
+		// an ALIAS whose target is one of those (kind 16 in the log below, not
+		// the scalar/sequence a reader might expect). None can hold entries, and
+		// none is reshaped -- rewriting a fragment the user authored to suit us
+		// is worse than declining.
 		//
-		// `volumes: *alias` is the shape worth calling out: it is legal
-		// compose, and it is the same x-* + anchor idiom this file works hard
-		// to preserve elsewhere.
-		idc.logger.Warn("top-level `volumes:` is not a mapping, so keploy cannot declare "+
-			"its volume there; docker compose will reject the generated file",
+		// The append cannot land, so the generated file declares no volume while
+		// the agent service mounts one, and docker compose rejects it with
+		// "refers to undefined volume". That error names the agent, not the
+		// user's `volumes:` line, so say here what actually has to change.
+		idc.logger.Warn("top-level `volumes:` cannot hold a volume entry, so keploy "+
+			"cannot declare its own there and docker compose will reject the "+
+			"generated file; `volumes:` must be a mapping (or an anchor naming one)",
 			zap.String("volume", volumeName),
-			zap.Int("yamlKind", int(compose.Volumes.Kind)))
+			zap.String("volumesShape", yamlKindName(compose.Volumes.Kind)),
+			zap.String("resolvesTo", yamlKindName(resolvedKind(&compose.Volumes))))
 	}
 
 	// Check if volume exists
-	for i := 0; i < len(compose.Volumes.Content); i += 2 {
-		if compose.Volumes.Content[i].Value == volumeName {
+	for i := 0; i < len(vols.Content); i += 2 {
+		if vols.Content[i].Value == volumeName {
 			return // Already exists
 		}
 	}
 
 	// Add it (empty content is fine for local driver)
-	compose.Volumes.Content = append(compose.Volumes.Content,
+	vols.Content = append(vols.Content,
 		&yaml.Node{Kind: yaml.ScalarNode, Value: volumeName},
 		&yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{}}, // {}
 	)
+}
+
+// yamlKindName renders a yaml.Kind for a log line. The raw enum means nothing to
+// an operator reading it.
+func yamlKindName(k yaml.Kind) string {
+	switch k {
+	case 0:
+		return "absent"
+	case yaml.DocumentNode:
+		return "document"
+	case yaml.SequenceNode:
+		return "sequence"
+	case yaml.MappingNode:
+		return "mapping"
+	case yaml.ScalarNode:
+		return "scalar"
+	case yaml.AliasNode:
+		return "alias"
+	}
+	return "unknown"
+}
+
+// resolvedKind reports what a node ultimately names, following one alias hop, so
+// a diagnostic can point at the anchor the user has to fix rather than at the
+// `volumes:` line that merely references it.
+func resolvedKind(n *yaml.Node) yaml.Kind {
+	if n == nil {
+		return 0
+	}
+	if n.Kind == yaml.AliasNode && n.Alias != nil {
+		return n.Alias.Kind
+	}
+	return n.Kind
+}
+
+// sectionForAppend returns the mapping a section's entries must actually be
+// appended to, normalising an empty section and resolving an alias.
+//
+// `volumes: *vols` is legal compose and is the same `x-*` + anchor idiom this
+// file works to preserve elsewhere, but an alias node is a REFERENCE -- it holds
+// no entries of its own, so appending to it writes into a node the encoder never
+// emits. The generated file then declared no volume while the agent service
+// mounted one, and docker compose rejected it.
+//
+// The fragment is RESOLVED BY COPY, not by reference. Appending into the
+// anchored node directly is the obvious move and it is wrong: an `x-*` fragment
+// is shared, so every other alias to it silently inherits keploy's volume.
+// Reproduced, on a file docker compose accepts:
+//
+//	x-common: &common
+//	  shared: {}
+//	volumes: *common
+//	networks: *common
+//
+// Appending in place gives the user a `keploy-tls-certs` NETWORK. Corrupting an
+// unrelated part of their file to fix our own is a bad trade, and it leaves no
+// trace. It can also produce a file that no longer loads at all: when the shared
+// fragment is a sequence aliased by a service's `volumes:` list, reshaping it to
+// a mapping makes compose reject that service.
+//
+// Copying costs the alias on this one key in the GENERATED file: `volumes:` is
+// emitted expanded rather than as `*vols`. The anchor and every other reference
+// to it are untouched, the resolved volume set is identical, and the file is
+// transient -- keploy writes it to run the app, it is not the user's source.
+//
+// One consequence worth naming, since a MISSING anchor definition is what this
+// file's other half exists to prevent: an anchor nested INSIDE the fragment is
+// now emitted twice, once in the fragment and once in the copy. That is safe
+// rather than merely tolerated -- the copy shares the same child nodes, so the
+// two definitions cannot diverge -- and the file still loads.
+func sectionForAppend(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	ensureMapping(n)
+	if n.Kind != yaml.AliasNode || n.Alias == nil {
+		return n
+	}
+	target := n.Alias
+	if target.Kind != yaml.MappingNode && !isEmptySection(target) {
+		// Resolves to something that cannot hold entries (a populated scalar or
+		// sequence). Leave the alias exactly as written -- the caller warns --
+		// rather than reshaping a fragment the user wrote.
+		return n
+	}
+	// Replace the alias with a copy of what it named.
+	//
+	// The slice is CLONED rather than shared, and that is load-bearing, not
+	// defensive: a mapping node's Content grows two entries per key, so a
+	// three-key fragment sits at len 6 / cap 8 -- exactly the two spare slots
+	// one append consumes. Sharing the slice would write keploy's entry into
+	// the user's fragment backing array without reallocating, and a second
+	// section resolved through the same fragment would then overwrite the
+	// first's entry instead of appending after it.
+	//
+	// Child NODES are still shared, which is safe: every writer here appends,
+	// and nothing mutates an existing volume entry in place (checked in OSS and
+	// in the enterprise BeforeDockerComposeSetup hook).
+	replaced := yaml.Node{Kind: yaml.MappingNode}
+	if target.Kind == yaml.MappingNode {
+		replaced.Content = append([]*yaml.Node(nil), target.Content...)
+	}
+	*n = replaced
+	return n
 }
 
 // ensureMapping turns an EMPTY section node into an empty mapping so callers can

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -162,6 +162,140 @@ type Compose struct {
 	Volumes  yaml.Node `yaml:"volumes,omitempty"`
 	Configs  yaml.Node `yaml:"configs,omitempty"`
 	Secrets  yaml.Node `yaml:"secrets,omitempty"`
+
+	// raw is the original top-level mapping, kept so that a read/modify/write
+	// round trip does not silently discard the keys this struct does not name.
+	//
+	// It matters most for `x-*` extension fields. The Compose spec designates
+	// them as the place to put reusable fragments, and the conventional way to
+	// reuse one is a YAML anchor:
+	//
+	//	x-mysql-common: &mysql-common
+	//	  healthcheck: {...}
+	//	services:
+	//	  db:
+	//	    <<: *mysql-common
+	//
+	// Services is a yaml.Node, so it preserves `<<: *mysql-common` verbatim.
+	// Without raw, the anchor DEFINITION was dropped while that reference
+	// survived, and the compose file keploy generates to run the user's app
+	// failed to load with "unknown anchor 'mysql-common' referenced" -- the
+	// user's app never started, on a compose file docker itself accepts.
+	//
+	// Appending the missing keys instead of keeping the original node is not
+	// enough: an alias must follow its anchor in the document, and go-yaml
+	// emits inline/extra keys after the named struct fields, which puts the
+	// definition after the reference. Preserving the original mapping keeps
+	// the original order, and with it the comments and any other tooling's
+	// top-level keys.
+	raw *yaml.Node
+}
+
+// UnmarshalYAML captures the original mapping alongside the decoded fields, so
+// every path that parses a Compose (file or in-memory) keeps raw without having
+// to remember to do it.
+func (c *Compose) UnmarshalYAML(value *yaml.Node) error {
+	// plain drops the methods, so decoding below does not recurse into this one.
+	type plain Compose
+	var p plain
+	if err := value.Decode(&p); err != nil {
+		// Rewrite the shim's name out of the message; a user seeing this is
+		// looking at their own malformed compose file, not at keploy internals.
+		return fmt.Errorf("%s", strings.ReplaceAll(err.Error(), "docker.plain", "docker.Compose"))
+	}
+	*c = Compose(p)
+	if value.Kind == yaml.MappingNode {
+		node := *value
+		c.raw = &node
+	}
+	return nil
+}
+
+// MarshalYAML puts the round-trip fix on the TYPE rather than on individual
+// call sites, so `yaml.Marshal(compose)` is correct wherever it appears --
+// including callers outside this package, such as enterprise's --dump-compose
+// hook. Fixing only WriteComposeFile/MarshalCompose would leave the file keploy
+// RUNS and the file it hands an operator for debugging disagreeing, in exactly
+// the situation this bug shows up in.
+// The receiver is a VALUE, not a pointer, on purpose: a pointer-receiver method
+// is absent from the method set of a `Compose`, so `yaml.Marshal(*compose)`
+// would silently fall back to encoding the struct and emit the same unloadable
+// document this fixes. A value receiver is in both method sets, and copying is
+// harmless because the result is only ever marshalled.
+func (c Compose) MarshalYAML() (interface{}, error) {
+	if c.raw == nil {
+		// plain sheds the method set; returning c here would re-enter this
+		// method and recurse until the stack blows.
+		type plain Compose
+		return plain(c), nil
+	}
+	return composeDocument(&c), nil
+}
+
+// composeDocument rebuilds the document to serialise: the original mapping with
+// the (possibly modified) sections spliced back in. Only ever called with a
+// non-nil raw (see MarshalYAML).
+//
+// The result is for marshalling only. Its top-level node is a copy, but the
+// children it did not replace are the SAME pointers as raw's, so mutating the
+// returned document would reach back into the Compose.
+func composeDocument(compose *Compose) interface{} {
+	doc := *compose.raw
+	doc.Content = append([]*yaml.Node(nil), compose.raw.Content...)
+	// Version is a string rather than a node, so it needs its own splice to be
+	// write-through like the other five named fields.
+	//
+	// Only when it actually CHANGED, though. Splicing unconditionally replaces
+	// the original node with a fresh scalar, which drops any line comment on
+	// `version:` and re-quotes the value -- making it the one key in the file
+	// that loses the fidelity the rest of this function exists to preserve, on
+	// every compose that declares a version, to serve a write path no caller
+	// currently uses.
+	if compose.Version != "" && !hasSectionValue(&doc, "version", compose.Version) {
+		setComposeSection(&doc, "version",
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: compose.Version})
+	}
+	for _, section := range []struct {
+		key  string
+		node *yaml.Node
+	}{
+		{"services", &compose.Services},
+		{"networks", &compose.Networks},
+		{"volumes", &compose.Volumes},
+		{"configs", &compose.Configs},
+		{"secrets", &compose.Secrets},
+	} {
+		setComposeSection(&doc, section.key, section.node)
+	}
+	return &doc
+}
+
+// hasSectionValue reports whether key already maps to exactly this scalar, so a
+// splice that would change nothing can be skipped and the original node kept.
+func hasSectionValue(mapping *yaml.Node, key, value string) bool {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return mapping.Content[i+1].Value == value
+		}
+	}
+	return false
+}
+
+// setComposeSection replaces key's value in the mapping, appending the pair when
+// the key is absent. A zero node means the section was neither present nor added,
+// so it is skipped rather than written out as an explicit null.
+func setComposeSection(mapping *yaml.Node, key string, val *yaml.Node) {
+	if val == nil || val.Kind == 0 {
+		return
+	}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			mapping.Content[i+1] = val
+			return
+		}
+	}
+	mapping.Content = append(mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, val)
 }
 
 func (idc *Impl) ReadComposeFile(filePath string) (*Compose, error) {


### PR DESCRIPTION
Five defects in the compose file keploy generates to run the user's app. Every one is silent, and every one makes a compose file that `docker compose` itself accepts fail under keploy — or, worse, succeed while doing nothing.

They share a root: keploy parses the user's compose, edits it, and writes it back out, but several of its accessors assumed a shape YAML need not have.

---

## 1. Top-level keys were dropped, taking YAML anchors with them

The `Compose` struct names **six** top-level keys — `version, services, networks, volumes, configs, secrets` — and every other one was silently discarded on read, including `name:` and every `x-*` extension field.

`x-*` is where the Compose spec says reusable fragments belong, and the way to reuse one is an anchor:

```yaml
x-mysql-common: &mysql-common
  healthcheck: {...}
services:
  db:
    <<: *mysql-common
```

`Compose.Services` is **not** a second parse: decoding into a `yaml.Node` copies the node from the *same* document tree, so the alias under `services` and the anchor under `x-*` are siblings. The anchor was lost purely because no struct field named the `x-*` key, and go-yaml emits aliases by name — so the reference outlived its definition:

```
go-yaml load error in composer at L15.C21: unknown anchor 'mysql-common' referenced
```

**The user's app never starts.** Hit in real CI (keploy/enterprise `kafka-ecommerce`).

**Fix:** keep the original top-level mapping and splice the modified sections back into it. Appending the missing keys does *not* work — an alias must follow its anchor, and go-yaml emits extra keys *after* the named struct fields, putting the definition below the reference.

The hook is `MarshalYAML` **on the type**, with a **value** receiver, so every marshal path is correct — including `yaml.Marshal(*compose)` and callers outside this package such as enterprise's `--dump-compose`. Fixing only the two wrappers would leave the file keploy *runs* and the file it hands an operator for *debugging* disagreeing, precisely when this bug bites.

## 2. An empty section was only normalised in one of its shapes

`addTopLevelVolume` guarded only on a **zero** node — what an *absent* key decodes to. Every other empty shape decodes to something else:

| source | decodes as | before |
|---|---|---|
| `volumes:` (explicit null) | `ScalarNode` `!!null` | append silently dropped |
| `volumes: []` | empty `SequenceNode` | emitted as a **sequence** |
| `volumes: ""` | empty scalar | append silently dropped |

The generated compose then declared no volume while the agent service mounted one, and compose refused it: `volumes must be a mapping` / `refers to undefined volume keploy-tls-certs`.

The **same defect** sat on `services:` under a *different* predicate (`Content == nil`), which caught the null scalar but set `Kind` without clearing the tag — emitting `services: !!null`. Two guards, two shapes each, is what produced this; both call sites now share one `ensureMapping`.

`isEmptySection` decides emptiness **explicitly** rather than by proxy. `len(Content) == 0` is the tempting test and it is wrong: a scalar keeps its payload in `Value` and an alias resolves elsewhere, so both report zero children — normalising on that would have discarded `volumes: appdata`, and `volumes: *populated_alias` with it.

## 3. `volumes: *alias` could not hold the entry

An alias node is a **reference** — it holds no entries — so the append went into a node the encoder never emits, producing the same `refers to undefined volume` rejection.

The alias is now resolved **by copy**: `volumes:` receives a mapping cloned from the fragment, and keploy's volume is appended there.

Appending into the anchored node instead is the obvious move and it is **wrong** — an `x-*` fragment is shared, so every other reference inherits the entry:

```yaml
x-common: &common
  shared: {}
volumes: *common
networks: *common          # ← gains a `keploy-tls-certs` NETWORK
```

It can be worse than a stray entry: when the fragment is a **sequence** also aliased by a service's `volumes:` list, reshaping it makes compose reject that service outright.

The clone is **load-bearing, not defensive**. A mapping's `Content` holds two entries per key, so a three-key fragment sits at `len 6 / cap 8` — exactly the two spare slots one append consumes. Sharing the slice writes into the user's backing array without reallocating, and a second section resolved through the same fragment then *overwrites* the first's entry.

## 4. An aliased service could not hold keploy's edits

`services: {app: *appdef}` is legal compose, and the node the lookup returns is exactly what `modifyAppServiceForKeploy` writes into. An alias holds no entries, so the agent wiring, TLS mounts and entrypoint rewrite all went into a node the encoder never emits — **no error, no warning: keploy ran the user's service unmodified and recorded nothing.** `services: *svcs` failed differently, surfacing as `container 'X' not found in any of the compose files` on a file that plainly declares it.

Resolved to a **deep** copy here, unlike §3. Shallow is right for volumes, whose entries are inert and only appended to. It is wrong for a service, because keploy **deletes** keys (`networks`, `ports`, `dns*`) and **overwrites values in place**, and enterprise's compose hook appends to `JAVA_TOOL_OPTIONS` on every run. With children shared, a sibling aliasing the same fragment inherits all of it — `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE`/`NODE_EXTRA_CA_CERTS` pointed at keploy's CA in a container that gets none of keploy's wiring, so its outbound TLS fails against a CA path that does not exist there.

Anchors are stripped from that copy — a second definition would diverge once the copy is mutated, and a later `*name`/`<<: *name` binds to the nearest preceding one. Deliberately unlike §3, which keeps the anchor: a copied volumes fragment is only appended to, so its duplicate cannot diverge.

Resolution runs at the section level and at the top of **all three** loops that walk services. `findContainerInServices` matters as much as the rest: it runs *before* `ModifyComposeForAgent` and its ports become `opts.AppPorts`, so reading them off an alias yields an empty list, keploy-agent publishes nothing on the app's behalf under `network_mode: service:keploy-agent`, and the app is unreachable from the host even when everything else works. Resolving at the loop top also fixes the `container_name` lookup, which scans the node's contents and so could never match an alias.

`AddKeployAgentToCompose` now resolves rather than depending on call order, refuses a `services:` that still cannot hold entries, and refuses a `keploy-agent` collision **by service key or by container_name** — the latter worse than a duplicate key, since the lookup matches on it and keploy would adopt the user's service as its own agent, then move the app's DNS onto it.

## 5. An aliased `environment:` or `volumes:` list inside a service

One level further down, and at least as common an `x-*` idiom. Unresolved, the two writers failed in **opposite** directions and neither said anything:

- `addServiceEnvVar`'s type switch tests `SequenceNode` then `MappingNode` and falls straight through for an `AliasNode` — so keploy's CA paths and `JAVA_TOOL_OPTIONS` were never added and the app ran uninstrumented.
- `addServiceListProperty` appended into the alias, so the TLS-cert mount simply did not appear.

Both left a file docker compose accepts, which is what made them invisible.

Resolved at the two accessors every writer goes through — `getOrCreateEnvNode` and `addServiceListProperty`'s key lookup — so the fix covers `appendServiceEnvVar` and any future caller rather than one call site. Sequence targets are accepted here, unlike at the service level: `environment: - K=V` and `volumes: - a:b` are the ordinary shapes, while a service must be a mapping.

---

## Verification

Every behaviour is pinned by a test that fails when it is reverted. Mutations killed, across all five fixes:

| Mutation | Caught by |
|---|---|
| `MarshalYAML` reverted to the lossy struct | 6 tests |
| `UnmarshalYAML` doesn't capture the original mapping | 3 tests |
| services splice removed / `Version` splice removed or unconditional | `ModifiedServicesAreWritten`, `VersionIsWriteThrough`, `UntouchedVersionKeepsItsNode` |
| zero-node skip removed (emits `configs: null`) | `AbsentSectionsStayAbsent` |
| pointer receiver instead of value | `ValueReceiverAlsoCorrect` |
| `ensureMapping` narrowed to null-only / reshapes populated nodes | `AbsentAndPopulated/empty_sequence`, `/empty_string`, `LeavesPopulatedNonMappingAlone` |
| volumes alias not resolved / resolved by mutating the fragment | `ResolvesAnAliasByCopy`, `DoesNotCorruptAFragmentSharedElsewhere` |
| volumes fragment's slice shared instead of cloned | `ResolvedCopiesAreIndependent` (three-key fixture) |
| service alias: shallow copy, anchors kept, section resolve dropped | `EditsLandAndSiblingsAreUntouched`, `PortsReadThroughAnAliasedSection` |
| loop-top resolve in `modifyAppServiceForKeploy` dropped | `ModifyResolvesWhenAgentComesFirst` |
| duplicate-agent guard dropped / key-only | `RefusesADuplicate`, `RefusesAContainerNameCollision` |
| sub-key alias not resolved in env or list accessor | `SubKeyAlias_EnvAndVolumesResolve`, `SequenceStyleEnvResolves` |

Two of those needed a specific fixture to discriminate at all, and are worth knowing before editing the tests: the volumes slice-sharing mutation is invisible below a **three-key** fragment (one and two keys have no spare capacity, so `append` reallocates), and the service shallow-copy mutation is invisible without `environment`/`volumes` in the fixture — the keys keploy actually writes into.

For a compose file with no anchors and no extra top-level keys — the common case — the generated output is **byte-identical** to before. `gofmt`, `go vet`, `go build ./...` clean; `pkg/platform/docker` and `pkg/client/app` green.

## Deliberate decisions, not omissions

**The alias on a resolved key is expanded** in the generated file rather than emitted as `*vols`. Resolving only when a fragment has a single reference was considered and rejected: behaviour would then depend on an invisible property of the user's file, and missing a merge-key reference (`<<: *vols` inside a service) would put the corruption straight back. The file is the temporary one keploy writes to run the app, not the user's source.

**§3 keeps anchors on the copy, §4 strips them.** Not an oversight: a copied volumes fragment is only appended to, so a duplicate definition cannot diverge from the original; a copied service is edited, so it can. One consequence worth naming — the §3 duplicate anchor is accepted by docker compose but **rejected by PyYAML**, so a generated file fed to other tooling may complain.

**Clearing the `!!null` tag and flow `Style` is cosmetic**, not correctness — verified with the real `docker compose` binary, which accepts `volumes: !!null` with entries under it either way. Done so a generated file an operator reads carries no stray tag, and pinned so it isn't unjustified dead code.

## Side effect: this also repairs an enterprise failure

Enterprise's `BeforeDockerComposeSetup` appends its own volumes through `ensureTopLevelVolumesNode`, which handles only a zero node and a null scalar — **not an alias**. With `volumes: *vols` and dedup/time-freeze enabled it appended `keploy-sockets-vol` into an `AliasNode` (invisible), then mounted it, producing the same `refers to undefined volume` rejection. OSS now hands that hook a real mapping, so the enterprise path is fixed with no change on its side.

## Companion PR

Enterprise's compose hook had a **destructive** variant of §5: its `setEnv`/`appendEnv` `default:` branch *replaced* an aliased `environment:` node, discarding every variable the user kept in that fragment. Fixed in **keploy/enterprise#2562**, which is load-bearing until this PR merges and enterprise bumps its OSS pin — after that the app-path resolve there becomes a no-op and stays as defence-in-depth.
