### PR TITLE
fix(docker): make the compose rewrite safe on empty and aliased nodes

### DIFF
--- a/pkg/platform/docker/compose_empty_service_section_test.go
+++ b/pkg/platform/docker/compose_empty_service_section_test.go
@@ -1,0 +1,1296 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+
+	"go.keploy.io/server/v3/config"
+)
+
+// keployEnvVars are the variables modifyAppServiceForKeploy writes into the app
+// service. Losing them is not a cosmetic problem: NODE_EXTRA_CA_CERTS,
+// REQUESTS_CA_BUNDLE, SSL_CERT_FILE and CARGO_HTTP_CAINFO are how Node, Python,
+// Requests and Cargo are told to trust keploy's CA, and without them every
+// outbound TLS call fails verification against a proxy the app now talks to.
+var keployEnvVars = []string{
+	"NODE_EXTRA_CA_CERTS",
+	"REQUESTS_CA_BUNDLE",
+	"SSL_CERT_FILE",
+	"CARGO_HTTP_CAINFO",
+	"JAVA_TOOL_OPTIONS",
+}
+
+// runModifyForAgent drives the real generation path end to end and returns the
+// reloaded output. Asserting on a hand-rolled simulation of what keploy does to
+// a service cannot notice the simulation drifting from the code.
+func runModifyForAgent(t *testing.T, in string) map[string]interface{} {
+	t.Helper()
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	_, ports, _, _ := idc.findContainerInServices(&compose, "app")
+	opts := buildAgentOpts()
+	opts.AppPorts = ports
+	if err := idc.ModifyComposeForAgent(&compose, opts, "app"); err != nil {
+		t.Fatalf("ModifyComposeForAgent: %v", err)
+	}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	t.Logf("generated:\n%s", data)
+	return out
+}
+
+func appService(t *testing.T, out map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	svcs, _ := out["services"].(map[string]interface{})
+	app, _ := svcs["app"].(map[string]interface{})
+	if app == nil {
+		t.Fatalf("app service missing from generated compose: %v", out)
+	}
+	return app
+}
+
+// envKeys returns the variable names present on a service, accepting either the
+// list form (`- K=V`) or the mapping form (`K: V`). The writers emit whichever
+// shape the user's file already used, so a test that understands only one shape
+// silently passes on the other.
+func envKeys(t *testing.T, app map[string]interface{}) map[string]bool {
+	t.Helper()
+	got := map[string]bool{}
+	switch env := app["environment"].(type) {
+	case []interface{}:
+		for _, e := range env {
+			s, _ := e.(string)
+			for i := 0; i < len(s); i++ {
+				if s[i] == '=' {
+					got[s[:i]] = true
+					break
+				}
+			}
+		}
+	case map[string]interface{}:
+		for k := range env {
+			got[k] = true
+		}
+	case nil:
+		// Left as the caller found it: no variables at all.
+	default:
+		t.Fatalf("environment came out as %T, which docker compose rejects: %v", env, env)
+	}
+	return got
+}
+
+// TestEmptyServiceSection_NullEnvironmentStillTakesKeploysVars is the regression
+// test for the silent half of the empty-section bug.
+//
+// `environment:` with nothing under it — what commenting a block out leaves
+// behind — decodes to a `!!null` SCALAR, not to a zero node. getOrCreateEnvNode
+// handed that scalar straight back, and addServiceEnvVar/appendServiceEnvVar
+// test for SequenceNode then MappingNode and fall through with no log, so every
+// variable keploy writes was dropped. docker compose accepts the result, the app
+// starts, and TLS capture fails later for reasons that point nowhere near
+// compose generation.
+func TestEmptyServiceSection_NullEnvironmentStillTakesKeploysVars(t *testing.T) {
+	out := runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    environment:
+    ports:
+      - "8080:8080"
+`)
+	got := envKeys(t, appService(t, out))
+	for _, k := range keployEnvVars {
+		if !got[k] {
+			t.Errorf("%s was dropped; the app runs without keploy's CA and its "+
+				"outbound TLS fails verification at replay. got=%v", k, got)
+		}
+	}
+}
+
+// TestEmptyServiceSection_NullVolumesStillTakesTheTLSMount covers the same hole
+// in addServiceListProperty: the append landed in a null scalar the encoder
+// never emits, so the cert directory the four variables above point at was never
+// mounted.
+func TestEmptyServiceSection_NullVolumesStillTakesTheTLSMount(t *testing.T) {
+	app := appService(t, runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    volumes:
+    ports:
+      - "8080:8080"
+`))
+	vols, ok := app["volumes"].([]interface{})
+	if !ok {
+		t.Fatalf("volumes came out as %T, not a list: %v", app["volumes"], app["volumes"])
+	}
+	var found bool
+	for _, v := range vols {
+		if s, _ := v.(string); s == KeployTLSVolumeName+":"+KeployTLSMountPath+":ro" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the TLS cert mount was dropped, so the CA paths keploy exports "+
+			"point at a directory that does not exist in the container: %v", vols)
+	}
+}
+
+// TestEmptyServiceSection_EveryEmptyShape walks the shapes YAML gives an empty
+// key. Each one reached the writers as something their type switch did not
+// match, and each was silently dropped. A single-shape fixture is how the
+// top-level version of this bug survived its first fix.
+func TestEmptyServiceSection_EveryEmptyShape(t *testing.T) {
+	for _, tc := range []struct{ name, env, vols string }{
+		{"null", "environment:", "volumes:"},
+		{"empty string", `environment: ""`, `volumes: ""`},
+		{"explicit null tag", "environment: !!null", "volumes: !!null"},
+		{"tilde", "environment: ~", "volumes: ~"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app := appService(t, runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    `+tc.env+`
+    `+tc.vols+`
+    ports:
+      - "8080:8080"
+`))
+			got := envKeys(t, app)
+			for _, k := range keployEnvVars {
+				if !got[k] {
+					t.Errorf("%s dropped for %s environment: %v", k, tc.name, got)
+				}
+			}
+			if _, ok := app["volumes"].([]interface{}); !ok {
+				t.Errorf("volumes came out as %T for %s: %v",
+					app["volumes"], tc.name, app["volumes"])
+			}
+		})
+	}
+}
+
+// TestEmptyServiceSection_AliasToAnEmptyFragment covers the same shapes reached
+// through an alias. `x-env: &appenv` with nothing under it is a null scalar, so
+// resolveAliasByCopy declines it — correctly, since it must not reshape a
+// fragment the user wrote — and the alias arrived at the writers holding
+// nothing.
+//
+// The reference is reshaped; the anchored fragment must NOT be. Rewriting a
+// user's `&appenv` in place is how the earlier, abandoned approach to the
+// top-level bug corrupted every other service sharing it.
+func TestEmptyServiceSection_AliasToAnEmptyFragment(t *testing.T) {
+	out := runModifyForAgent(t, `x-env: &appenv
+x-vols: &appvols
+services:
+  app:
+    image: alpine:3.21
+    environment: *appenv
+    volumes: *appvols
+    ports:
+      - "8080:8080"
+  sidecar:
+    image: alpine:3.21
+    environment: *appenv
+`)
+	app := appService(t, out)
+	got := envKeys(t, app)
+	for _, k := range keployEnvVars {
+		if !got[k] {
+			t.Errorf("%s dropped through an aliased empty fragment: %v", k, got)
+		}
+	}
+	if _, ok := app["volumes"].([]interface{}); !ok {
+		t.Errorf("volumes came out as %T through an alias: %v", app["volumes"], app["volumes"])
+	}
+
+	// The user's fragments stay exactly as written.
+	for _, frag := range []string{"x-env", "x-vols"} {
+		if v, present := out[frag]; !present || v != nil {
+			t.Errorf("%s was reshaped to %#v; the anchored fragment must be left "+
+				"as the user wrote it", frag, v)
+		}
+	}
+	// And the sibling, which is not in the agent's network namespace, must not
+	// have inherited keploy's CA paths.
+	svcs, _ := out["services"].(map[string]interface{})
+	sidecar, _ := svcs["sidecar"].(map[string]interface{})
+	if sidecar == nil {
+		t.Fatalf("sidecar disappeared: %v", svcs)
+	}
+	if leaked := envKeys(t, sidecar); len(leaked) != 0 {
+		t.Errorf("sidecar inherited keploy's variables (%v) while living outside "+
+			"the agent's netns, so its TLS fails against a CA path it cannot see", leaked)
+	}
+}
+
+// TestEmptyServiceSection_EmptyMappingEnvironmentKeepsItsShape pins the one
+// carve-out. `environment: {}` already holds entries fine, so it is left alone;
+// reshaping it into a list would rewrite the user's chosen style for no gain.
+func TestEmptyServiceSection_EmptyMappingEnvironmentKeepsItsShape(t *testing.T) {
+	app := appService(t, runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    environment: {}
+    ports:
+      - "8080:8080"
+`))
+	if _, ok := app["environment"].(map[string]interface{}); !ok {
+		t.Errorf("environment: {} was reshaped to %T; an empty mapping is a usable "+
+			"shape and must keep it", app["environment"])
+	}
+	got := envKeys(t, app)
+	for _, k := range keployEnvVars {
+		if !got[k] {
+			t.Errorf("%s dropped from an empty mapping environment: %v", k, got)
+		}
+	}
+}
+
+// TestEmptyServiceSection_EmptyMappingVolumesBecomesASequence pins the other
+// side of that carve-out. A service's volumes list has exactly one legal shape,
+// so an empty mapping cannot hold the mount and IS reshaped — appending a lone
+// scalar to a mapping node leaves odd Content, which go-yaml emits as an empty
+// mapping, dropping the mount without an error.
+func TestEmptyServiceSection_EmptyMappingVolumesBecomesASequence(t *testing.T) {
+	app := appService(t, runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    volumes: {}
+    ports:
+      - "8080:8080"
+`))
+	vols, ok := app["volumes"].([]interface{})
+	if !ok {
+		t.Fatalf("volumes: {} came out as %T, not a list: %v",
+			app["volumes"], app["volumes"])
+	}
+	if len(vols) == 0 {
+		t.Errorf("the TLS mount was dropped into an empty mapping")
+	}
+}
+
+// TestEmptyServiceSection_PopulatedNodesAreLeftAlone is the guard against the
+// fix overreaching. Nothing a user actually wrote may be reshaped or discarded:
+// a populated list keeps its entries, a populated mapping keeps its keys, and a
+// populated scalar — which docker compose rejects on its own terms — is left
+// exactly as written rather than silently replaced.
+func TestEmptyServiceSection_PopulatedNodesAreLeftAlone(t *testing.T) {
+	t.Run("list and mapping keep their entries", func(t *testing.T) {
+		app := appService(t, runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    environment:
+      - MINE=1
+    volumes:
+      - ./data:/data
+    ports:
+      - "8080:8080"
+`))
+		if !envKeys(t, app)["MINE"] {
+			t.Errorf("the user's own variable was lost: %v", app["environment"])
+		}
+		vols, _ := app["volumes"].([]interface{})
+		var kept bool
+		for _, v := range vols {
+			if s, _ := v.(string); s == "./data:/data" {
+				kept = true
+			}
+		}
+		if !kept {
+			t.Errorf("the user's own mount was lost: %v", vols)
+		}
+	})
+
+	t.Run("populated scalar is not replaced", func(t *testing.T) {
+		app := appService(t, runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    environment: "MINE=1"
+    ports:
+      - "8080:8080"
+`))
+		if app["environment"] != "MINE=1" {
+			t.Errorf("a populated scalar environment was rewritten to %#v; keploy "+
+				"must not discard what the user wrote, even on a file compose "+
+				"rejects", app["environment"])
+		}
+	})
+}
+
+// TestEmptyServiceSection_ReshapedNodeCarriesNoStaleShape pins the two fields
+// the reshape clears that are actually observable in the output. Both are
+// cosmetic rather than correctness — docker compose accepts either — but a
+// generated file an operator reads while debugging should not carry a `!!null`
+// tag on a populated list, and a block-style file should not sprout one flow
+// entry.
+func TestEmptyServiceSection_ReshapedNodeCarriesNoStaleShape(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	const in = `services:
+  app:
+    image: alpine:3.21
+    environment: !!null
+    volumes: {}
+    ports:
+      - "8080:8080"
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	opts := buildAgentOpts()
+	if err := idc.ModifyComposeForAgent(&compose, opts, "app"); err != nil {
+		t.Fatalf("ModifyComposeForAgent: %v", err)
+	}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(data)
+	if strings.Contains(got, "!!null") {
+		t.Errorf("the reshaped node kept its null tag, which is emitted onto the "+
+			"populated list:\n%s", got)
+	}
+	if strings.Contains(got, "volumes: [") {
+		t.Errorf("the reshaped volumes node kept the flow style of the `{}` it "+
+			"replaced:\n%s", got)
+	}
+}
+
+// svcField reads one key off one service in the generated output.
+func svcField(t *testing.T, out map[string]interface{}, service, key string) interface{} {
+	t.Helper()
+	svcs, _ := out["services"].(map[string]interface{})
+	s, _ := svcs[service].(map[string]interface{})
+	if s == nil {
+		t.Fatalf("service %q missing from generated compose: %v", service, svcs)
+	}
+	return s[key]
+}
+
+// TestEmptyServiceSection_DependsOnStillGatesOnTheAgent covers the writer whose
+// silent no-op costs the most. Without `keploy-agent: {condition:
+// service_healthy}` the app container starts before the agent's proxy is
+// listening and races it, which shows up as a few unrecorded calls at the head
+// of a session rather than as an error — the hardest possible thing to trace
+// back to a compose shape.
+func TestEmptyServiceSection_DependsOnStillGatesOnTheAgent(t *testing.T) {
+	for _, tc := range []struct{ name, in string }{
+		{"null", `services:
+  app:
+    image: alpine:3.21
+    depends_on:
+`},
+		{"empty sequence", `services:
+  app:
+    image: alpine:3.21
+    depends_on: []
+`},
+		{"empty mapping", `services:
+  app:
+    image: alpine:3.21
+    depends_on: {}
+`},
+		{"alias to a shared fragment", `x-deps: &deps
+  db:
+    condition: service_started
+services:
+  app:
+    image: alpine:3.21
+    depends_on: *deps
+  db:
+    image: alpine:3.21
+`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := runModifyForAgent(t, tc.in)
+			deps, ok := svcField(t, out, "app", "depends_on").(map[string]interface{})
+			if !ok {
+				t.Fatalf("depends_on came out as %T: %v",
+					svcField(t, out, "app", "depends_on"),
+					svcField(t, out, "app", "depends_on"))
+			}
+			if deps["keploy-agent"] == nil {
+				t.Errorf("the app does not wait for keploy-agent to become healthy, "+
+					"so it races the proxy at startup: %v", deps)
+			}
+			// The user's own dependency must survive the rewrite.
+			if tc.name == "alias to a shared fragment" && deps["db"] == nil {
+				t.Errorf("the user's own dependency was dropped: %v", deps)
+			}
+		})
+	}
+}
+
+// TestEmptyServiceSection_ScalarPropertiesAreSetNotPoked covers addServiceProperty,
+// which wrote through `.Value` on whatever node it found. That only works if the
+// node is already a scalar:
+//
+//	network_mode:        -> `network_mode: !!null service:keploy-agent`, which
+//	                        does not parse at all
+//	network_mode: {}     -> write ignored; interception silently off, the app
+//	                        never joins the agent's netns
+//	network_mode: *nm    -> overwrites the alias NAME, and marshalling then fails
+//	                        with "alias value must contain alphanumerical
+//	                        characters only"
+func TestEmptyServiceSection_ScalarPropertiesAreSetNotPoked(t *testing.T) {
+	for _, tc := range []struct{ name, in string }{
+		{"null", `services:
+  app:
+    image: alpine:3.21
+    network_mode:
+    pid:
+`},
+		{"empty mapping", `services:
+  app:
+    image: alpine:3.21
+    network_mode: {}
+    pid: {}
+`},
+		{"empty sequence", `services:
+  app:
+    image: alpine:3.21
+    network_mode: []
+    pid: []
+`},
+		{"alias", `x-nm: &nm host
+services:
+  app:
+    image: alpine:3.21
+    network_mode: *nm
+`},
+		{"populated scalar", `services:
+  app:
+    image: alpine:3.21
+    network_mode: host
+`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := runModifyForAgent(t, tc.in)
+			if got := svcField(t, out, "app", "network_mode"); got != "service:keploy-agent" {
+				t.Errorf("network_mode is %#v, so the app never joins the agent's "+
+					"network namespace and nothing is intercepted", got)
+			}
+		})
+	}
+}
+
+// TestEmptyServiceSection_ScalarPropertyKeepsItsComments pins the one thing
+// replacing the node could lose that poking .Value did not.
+func TestEmptyServiceSection_ScalarPropertyKeepsItsComments(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(`services:
+  app:
+    image: alpine:3.21
+    network_mode: host # and this one
+    pid:
+      # and a note above the value
+      host
+`), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := idc.ModifyComposeForAgent(&compose, buildAgentOpts(), "app"); err != nil {
+		t.Fatalf("ModifyComposeForAgent: %v", err)
+	}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Both comments here sit on the VALUE node, so both are genuinely at risk.
+	// A comment on the line above `network_mode:` would attach to the KEY node
+	// instead, which nothing replaces — asserting on that would pass no matter
+	// what this function does.
+	for _, want := range []string{"# and this one", "# and a note above the value"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("replacing the value node dropped %q:\n%s", want, data)
+		}
+	}
+}
+
+// TestTopLevelSection_AnchoredEmptyVolumesStillGetsTheDeclaration pins the
+// decision NOT to give ensureMapping the anchor guard ensureSequence has.
+//
+// `volumes: &v` at the top level with the app's own list aliasing it: the
+// service list is detached first, so by the time the top-level append runs
+// nothing reads through the anchor any more and reshaping it is a local edit.
+// Declining here would leave keploy's volume undeclared while the app mounts it,
+// and docker compose rejects that with "refers to undefined volume".
+func TestTopLevelSection_AnchoredEmptyVolumesStillGetsTheDeclaration(t *testing.T) {
+	out := runModifyForAgent(t, `volumes: &v
+services:
+  app:
+    image: alpine:3.21
+    volumes: *v
+`)
+	vols, ok := out["volumes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("top-level volumes came out as %T: %v", out["volumes"], out["volumes"])
+	}
+	if _, declared := vols[KeployTLSVolumeName]; !declared {
+		t.Errorf("keploy's volume was not declared, so the mount it adds to the app "+
+			"refers to an undefined volume and compose rejects the file: %v", vols)
+	}
+}
+
+// TestSharedAnchor_AppIsEditedAndSiblingsAreNot is the regression test for the
+// whole anchor family, and for the trap the first two attempts at this fix fell
+// into.
+//
+// keploy does not merely append to the app service: it deletes keys, moves keys
+// onto keploy-agent and overwrites values in place. Doing any of that to a node
+// the user's file reads through an alias corrupts a service keploy was never
+// asked to touch. Reshaping in place leaks; declining leaves the app half-wired
+// and records nothing. detachSubtree does neither: it hands every reader an
+// inline copy of what it named, then edits freely.
+func TestSharedAnchor_AppIsEditedAndSiblingsAreNot(t *testing.T) {
+	t.Run("populated environment", func(t *testing.T) {
+		out := runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    environment: &appenv
+      - MINE=1
+  sidecar:
+    image: alpine:3.21
+    environment: *appenv
+`)
+		if got := envKeys(t, appService(t, out)); !got["MINE"] || !got["SSL_CERT_FILE"] {
+			t.Errorf("the app must keep its own variable AND gain keploy's: %v", got)
+		}
+		sib := envKeys(t, mustService(t, out, "sidecar"))
+		if !sib["MINE"] {
+			t.Errorf("the sidecar lost the variable it actually declared: %v", sib)
+		}
+		for _, k := range keployEnvVars {
+			if sib[k] {
+				t.Errorf("the sidecar inherited %s through the shared anchor; it is "+
+					"not in the agent's netns, so its TLS now fails against a CA "+
+					"path it cannot see: %v", k, sib)
+			}
+		}
+	})
+
+	t.Run("empty environment", func(t *testing.T) {
+		out := runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    environment: &appenv
+  sidecar:
+    image: alpine:3.21
+    environment: *appenv
+`)
+		got := envKeys(t, appService(t, out))
+		for _, k := range keployEnvVars {
+			if !got[k] {
+				t.Errorf("%s was dropped; an anchor on the app's own key is not a "+
+					"reason to leave the app uninstrumented: %v", k, got)
+			}
+		}
+		if sib := mustService(t, out, "sidecar")["environment"]; sib != nil {
+			t.Errorf("the sidecar's environment became %v; it named an empty "+
+				"fragment and must stay empty", sib)
+		}
+	})
+
+	t.Run("volumes shared with the top-level section", func(t *testing.T) {
+		out := runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    volumes: &appvols
+volumes: *appvols
+`)
+		vols, ok := out["volumes"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("top-level volumes came out as %T; compose requires a mapping "+
+				"and rejects the file: %v", out["volumes"], out["volumes"])
+		}
+		if _, declared := vols[KeployTLSVolumeName]; !declared {
+			t.Errorf("keploy's volume was not declared: %v", vols)
+		}
+		if _, ok := appService(t, out)["volumes"].([]interface{}); !ok {
+			t.Errorf("the app's volumes must be a list, got %T",
+				appService(t, out)["volumes"])
+		}
+	})
+
+	t.Run("a scalar property the sibling reads", func(t *testing.T) {
+		out := runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    network_mode: &nm host
+  other:
+    image: alpine:3.21
+    network_mode: *nm
+`)
+		if got := appService(t, out)["network_mode"]; got != "service:keploy-agent" {
+			t.Errorf("network_mode is %#v, so the app never joins the agent's "+
+				"netns and a record run captures nothing", got)
+		}
+		if got := mustService(t, out, "other")["network_mode"]; got != "host" {
+			t.Errorf("the sibling's network_mode became %#v", got)
+		}
+	})
+
+	t.Run("a scalar property nobody reads", func(t *testing.T) {
+		// The shape an earlier version of this fix broke: an anchor with no
+		// alias anywhere. Declining left `pid` set and `network_mode` not, which
+		// docker compose accepts and which intercepts nothing.
+		out := runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    network_mode: &nm host
+`)
+		app := appService(t, out)
+		if app["network_mode"] != "service:keploy-agent" || app["pid"] != "service:keploy-agent" {
+			t.Errorf("the app was left half-wired: network_mode=%#v pid=%#v",
+				app["network_mode"], app["pid"])
+		}
+	})
+}
+
+// TestSharedAnchor_DeletedAndMovedKeysKeepTheFileLoadable covers the two writers
+// that did not merely corrupt the file but made it unloadable.
+//
+// keploy DELETES the app's `networks:` and `ports:`, and MOVES its `dns*` onto
+// keploy-agent. When the app owns the anchor definition, deleting it dangles
+// every `*ref` — `yaml: unknown anchor 'n' referenced` — and moving it puts the
+// definition AFTER the reference, which fails the same way. Both produced a file
+// that does not parse at all, from a file docker compose accepted.
+func TestSharedAnchor_DeletedAndMovedKeysKeepTheFileLoadable(t *testing.T) {
+	for _, tc := range []struct{ name, key, in string }{
+		{"deleted networks", "networks", `services:
+  app:
+    image: alpine:3.21
+    networks: &shared
+      - default
+  sidecar:
+    image: alpine:3.21
+    networks: *shared
+`},
+		{"moved dns", "dns", `services:
+  app:
+    image: alpine:3.21
+    dns: &shared
+      - 1.1.1.1
+  sidecar:
+    image: alpine:3.21
+    dns: *shared
+`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// runModifyForAgent fails the test if the output does not reload,
+			// which is the failure this guards against.
+			out := runModifyForAgent(t, tc.in)
+			got, _ := mustService(t, out, "sidecar")[tc.key].([]interface{})
+			if len(got) != 1 {
+				t.Errorf("the sidecar's %s is %v; it must still name exactly what "+
+					"the user wrote", tc.key, mustService(t, out, "sidecar")[tc.key])
+			}
+		})
+	}
+}
+
+// TestSharedAnchor_TopLevelSectionIsNotCarriedIntoAnotherKey covers the section
+// append rather than the service. An anchored top-level `volumes:` shared with a
+// service's `networks:` is valid compose; appending keploy's volume into the
+// shared node made it invalid — "refers to undefined network keploy-tls-certs".
+func TestSharedAnchor_TopLevelSectionIsNotCarriedIntoAnotherKey(t *testing.T) {
+	out := runModifyForAgent(t, `volumes: &shared {}
+networks:
+  mynet:
+services:
+  app:
+    image: alpine:3.21
+  other:
+    image: alpine:3.21
+    networks: *shared
+`)
+	nets, _ := mustService(t, out, "other")["networks"].(map[string]interface{})
+	if _, leaked := nets[KeployTLSVolumeName]; leaked {
+		t.Errorf("keploy's VOLUME was appended into another service's networks: %v", nets)
+	}
+	vols, ok := out["volumes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("top-level volumes came out as %T", out["volumes"])
+	}
+	if _, declared := vols[KeployTLSVolumeName]; !declared {
+		t.Errorf("keploy's volume was not declared: %v", vols)
+	}
+}
+
+func mustService(t *testing.T, out map[string]interface{}, name string) map[string]interface{} {
+	t.Helper()
+	svcs, _ := out["services"].(map[string]interface{})
+	s, _ := svcs[name].(map[string]interface{})
+	if s == nil {
+		t.Fatalf("service %q missing from generated compose: %v", name, svcs)
+	}
+	return s
+}
+
+// TestGate_PortsAndNetworksReadThroughEmptyAndAliasedNodes covers the read path
+// that runs BEFORE anything is modified. Its results become opts.AppPorts and
+// the agent's network aliases, so what it gets wrong is wrong on keploy-agent,
+// not on the app.
+func TestGate_PortsAndNetworksReadThroughEmptyAndAliasedNodes(t *testing.T) {
+	parse := func(t *testing.T, in string) ([]string, []string) {
+		t.Helper()
+		idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+		var compose Compose
+		if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		nets, ports, _, found := idc.findContainerInServices(&compose, "app")
+		if !found {
+			t.Fatalf("gate did not find the app service")
+		}
+		return nets, ports
+	}
+
+	t.Run("aliased ports still reach keploy-agent", func(t *testing.T) {
+		// keploy-agent publishes on the app's behalf under
+		// `network_mode: service:keploy-agent`. Read empty, the app has no
+		// published port at all and is unreachable from the host.
+		_, ports := parse(t, `x-ports: &appports
+  - "8080:8080"
+services:
+  app:
+    image: alpine:3.21
+    ports: *appports
+`)
+		if len(ports) != 1 || ports[0] != "8080:8080" {
+			t.Errorf("ports read through an alias came back %#v", ports)
+		}
+	})
+
+	t.Run("aliased networks still reach keploy-agent", func(t *testing.T) {
+		nets, _ := parse(t, `x-nets: &appnets
+  - mynet
+services:
+  app:
+    image: alpine:3.21
+    networks: *appnets
+`)
+		if len(nets) != 1 || nets[0] != "mynet" {
+			t.Errorf("networks read through an alias came back %#v", nets)
+		}
+	})
+
+	t.Run("empty ports and networks yield nothing, not an empty name", func(t *testing.T) {
+		// `[""]` was copied onto keploy-agent, where compose rejects it with
+		// `invalid proto: ` and `additional properties '' not allowed`.
+		nets, ports := parse(t, `services:
+  app:
+    image: alpine:3.21
+    ports:
+    networks:
+`)
+		for _, p := range ports {
+			if p == "" {
+				t.Errorf("an empty port name reached keploy-agent: %#v", ports)
+			}
+		}
+		for _, n := range nets {
+			if n == "" {
+				t.Errorf("an empty network name reached keploy-agent: %#v", nets)
+			}
+		}
+		if len(nets) != 1 || nets[0] != "default" {
+			t.Errorf("an empty `networks:` must fall back to default, got %#v", nets)
+		}
+	})
+}
+
+// TestDetach_ExpansionIsDeepAndIndependent pins the properties of detachSubtree
+// that a single obvious implementation gets wrong.
+//
+// It does NOT pin the retry loop: measured, every case here passes with a single
+// pass, because references are collected up front and expanded in walk order, so
+// the inner one is always reached first. detachSubtree's own comment says the
+// same. What the nested case below does pin is that aliasRefsInto recurses at
+// all.
+func TestDetach_ExpansionIsDeepAndIndependent(t *testing.T) {
+	t.Run("copies are independent, not slice-sharing", func(t *testing.T) {
+		// keploy APPENDS to JAVA_TOOL_OPTIONS by rewriting the scalar in place.
+		// A copy that shares children shows that rewrite to the sibling, and an
+		// inherited -javaagent aborts the JVM at initialisation — the sibling
+		// does not start at all.
+		out := runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    environment: &appenv
+      - JAVA_TOOL_OPTIONS=-Xmx1g
+  sidecar:
+    image: alpine:3.21
+    environment: *appenv
+`)
+		sib, _ := mustService(t, out, "sidecar")["environment"].([]interface{})
+		if len(sib) != 1 || sib[0] != "JAVA_TOOL_OPTIONS=-Xmx1g" {
+			t.Errorf("the sidecar's own entry was rewritten in place to %v; the copy "+
+				"shared children with the node keploy edits", sib)
+		}
+	})
+
+	t.Run("a reference nested inside a fragment is expanded", func(t *testing.T) {
+		// `sidecar.labels` names a fragment that itself names another anchor
+		// inside the app service. A search that stops at the top level of each
+		// node never reaches the inner reference, which then points at an anchor
+		// about to be cleared — and the generated file fails to load.
+		// runModifyForAgent fails the test if it does not reload.
+		out := runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    environment: &appenv
+      - MINE=1
+    labels: &applabels
+      inherited: *appenv
+  sidecar:
+    image: alpine:3.21
+    labels: *applabels
+`)
+		labels, _ := mustService(t, out, "sidecar")["labels"].(map[string]interface{})
+		got, _ := labels["inherited"].([]interface{})
+		if len(got) != 1 || got[0] != "MINE=1" {
+			t.Errorf("the nested reference did not survive expansion: %v", labels)
+		}
+	})
+
+	t.Run("a reference from an x- fragment is expanded", func(t *testing.T) {
+		// `x-*` is where the compose spec puts reusable fragments, and it is not
+		// one of the sections the Compose struct names — so it is only reachable
+		// through raw. Missing it dangles the reference.
+		out := runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    environment: &appenv
+      - MINE=1
+x-audit: *appenv
+`)
+		got, _ := out["x-audit"].([]interface{})
+		if len(got) != 1 || got[0] != "MINE=1" {
+			t.Errorf("x-audit came out as %v; it must still name what the user "+
+				"wrote, not keploy's edited copy", out["x-audit"])
+		}
+	})
+}
+
+// TestDetach_ExpandedCopiesCarryNoAnchor pins stripAnchors on the copy. Without
+// it the expansion emits a SECOND definition of the same name, and a later `*nm`
+// binds to whichever the parser saw last. The node keploy overwrote here is
+// replaced wholesale rather than edited, so this fixture says nothing about the
+// anchor-clearing pass — TestDetach_EditedNodesDoNotKeepTheirAnchor covers that.
+func TestDetach_ExpandedCopiesCarryNoAnchor(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(`services:
+  app:
+    image: alpine:3.21
+    network_mode: &nm host
+  other:
+    image: alpine:3.21
+    network_mode: *nm
+`), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := idc.ModifyComposeForAgent(&compose, buildAgentOpts(), "app"); err != nil {
+		t.Fatalf("ModifyComposeForAgent: %v", err)
+	}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if n := strings.Count(string(data), "&nm"); n != 0 {
+		t.Errorf("the generated file carries %d definition(s) of a detached anchor:\n%s",
+			n, data)
+	}
+	// And it must still load: an expansion that drops the definition while a
+	// reference survives is the failure this whole area exists to prevent.
+	var reloaded map[string]interface{}
+	if err := yaml.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+}
+
+// TestDetach_EditedNodesDoNotKeepTheirAnchor is the same tidy-up for the nodes
+// keploy edits IN PLACE rather than replaces — the app's `environment:`, and the
+// top-level `volumes:` section. Both keep their node, so an anchor left on
+// either ends up naming a list or mapping that is now half keploy's.
+func TestDetach_EditedNodesDoNotKeepTheirAnchor(t *testing.T) {
+	for _, tc := range []struct{ name, anchor, in string }{
+		{"service environment", "&appenv", `services:
+  app:
+    image: alpine:3.21
+    environment: &appenv
+      - MINE=1
+  sidecar:
+    image: alpine:3.21
+    environment: *appenv
+`},
+		{"top-level volumes", "&shared", `volumes: &shared {}
+services:
+  app:
+    image: alpine:3.21
+  other:
+    image: alpine:3.21
+    networks: *shared
+`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+			var compose Compose
+			if err := yaml.Unmarshal([]byte(tc.in), &compose); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if err := idc.ModifyComposeForAgent(&compose, buildAgentOpts(), "app"); err != nil {
+				t.Fatalf("ModifyComposeForAgent: %v", err)
+			}
+			data, err := idc.MarshalCompose(&compose)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if n := strings.Count(string(data), tc.anchor); n != 0 {
+				t.Errorf("%s survived on a node keploy edited (%d occurrence(s)); it "+
+					"now names content that is partly keploy's:\n%s", tc.anchor, n, data)
+			}
+		})
+	}
+}
+
+// TestDetach_ReferencesFromEverySectionAreExpanded pins the sections in
+// documentRoots that keploy never writes to. They are still load-bearing: a
+// reference to a node keploy edits can sit under any top-level key, and one that
+// is missed dangles when the anchor is cleared — the generated file then does
+// not load at all.
+func TestDetach_ReferencesFromEverySectionAreExpanded(t *testing.T) {
+	for _, section := range []string{"networks", "configs", "secrets"} {
+		t.Run(section, func(t *testing.T) {
+			// runModifyForAgent fails the test if the output does not reload.
+			out := runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    volumes: &appvols
+`+section+`: *appvols
+`)
+			// The reload inside runModifyForAgent is the assertion here: a
+			// missed reference dangles once the anchor is cleared, and the file
+			// does not parse. The expanded section itself is a copy of the empty
+			// fragment, so there is nothing else meaningful to assert on it —
+			// checking its type would pass in every state, fixed or broken.
+			if _, present := out[section]; !present {
+				t.Errorf("%s disappeared from the generated file", section)
+			}
+		})
+	}
+}
+
+// TestEnvMapping_AliasedValuesAreReplacedNotOverwritten covers the mapping-style
+// environment writers. `SSL_CERT_FILE: *ca` is an alias, and assigning to its
+// Value overwrites the anchor NAME — marshalling then fails outright and keploy
+// aborts on a compose file docker accepts. detachSubtree does not cover it: the
+// anchor lives in an `x-*` fragment, outside the app service.
+func TestEnvMapping_AliasedValuesAreReplacedNotOverwritten(t *testing.T) {
+	t.Run("addServiceEnvVar replaces an aliased value", func(t *testing.T) {
+		out := runModifyForAgent(t, `x-ca: &ca /etc/ssl/mine.pem
+services:
+  app:
+    image: alpine:3.21
+    environment:
+      SSL_CERT_FILE: *ca
+`)
+		env, _ := appService(t, out)["environment"].(map[string]interface{})
+		if env["SSL_CERT_FILE"] != "/tmp/keploy-tls/ca.crt" {
+			t.Errorf("SSL_CERT_FILE is %#v, not keploy's CA", env["SSL_CERT_FILE"])
+		}
+		// The user's fragment is theirs; keploy must not have edited it.
+		if out["x-ca"] != "/etc/ssl/mine.pem" {
+			t.Errorf("the anchored fragment was rewritten to %#v", out["x-ca"])
+		}
+	})
+
+	t.Run("appendServiceEnvVar reads through an aliased value", func(t *testing.T) {
+		out := runModifyForAgent(t, `x-jopts: &jopts -Xmx1g
+services:
+  app:
+    image: alpine:3.21
+    environment:
+      JAVA_TOOL_OPTIONS: *jopts
+`)
+		env, _ := appService(t, out)["environment"].(map[string]interface{})
+		got, _ := env["JAVA_TOOL_OPTIONS"].(string)
+		if !strings.Contains(got, "-Xmx1g") {
+			t.Errorf("the user's own JVM options were lost: %#v", got)
+		}
+		if !strings.Contains(got, "trustStore") {
+			t.Errorf("keploy's trust store was not appended: %#v", got)
+		}
+		if strings.Contains(got, "jopts") {
+			t.Errorf("the ANCHOR NAME was treated as the existing value: %#v", got)
+		}
+	})
+}
+
+// TestGate_AliasElementsInsideAListAreRead covers the shape one level below the
+// list itself. An aliased ELEMENT was dropped, and for networks that is worse
+// than reading nothing: the `default` fallback then fires, so keploy-agent joins
+// `default` while the app — which shares the agent's netns — silently loses the
+// network its database is on.
+func TestGate_AliasElementsInsideAListAreRead(t *testing.T) {
+	parse := func(t *testing.T, in string) ([]string, []string) {
+		t.Helper()
+		idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+		var compose Compose
+		if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		nets, ports, _, found := idc.findContainerInServices(&compose, "app")
+		if !found {
+			t.Fatalf("gate did not find the app service")
+		}
+		return nets, ports
+	}
+
+	t.Run("networks", func(t *testing.T) {
+		nets, _ := parse(t, `x-net: &appnet mynet
+services:
+  app:
+    image: alpine:3.21
+    networks:
+      - *appnet
+`)
+		if len(nets) != 1 || nets[0] != "mynet" {
+			t.Errorf("aliased network element came back %#v; keploy-agent would be "+
+				"put on the wrong network and the app could not reach its database", nets)
+		}
+	})
+
+	t.Run("ports", func(t *testing.T) {
+		_, ports := parse(t, `x-port: &appport "8080:8080"
+services:
+  app:
+    image: alpine:3.21
+    ports:
+      - *appport
+`)
+		if len(ports) != 1 || ports[0] != "8080:8080" {
+			t.Errorf("aliased port element came back %#v; the app would publish "+
+				"nothing and be unreachable from the host", ports)
+		}
+	})
+
+	t.Run("an empty element is skipped, not named \"\"", func(t *testing.T) {
+		// A blank entry in the list yields an empty scalar. Copied onto
+		// keploy-agent it becomes `additional properties '' not allowed` for
+		// networks and `invalid proto: ` for ports.
+		nets, ports := parse(t, `services:
+  app:
+    image: alpine:3.21
+    networks:
+      -
+      - mynet
+    ports:
+      -
+      - "8080:8080"
+`)
+		for _, n := range nets {
+			if n == "" {
+				t.Errorf("an empty network name reached keploy-agent: %#v", nets)
+			}
+		}
+		for _, p := range ports {
+			if p == "" {
+				t.Errorf("an empty port reached keploy-agent: %#v", ports)
+			}
+		}
+		if len(nets) != 1 || len(ports) != 1 {
+			t.Errorf("the real entries were lost: nets=%#v ports=%#v", nets, ports)
+		}
+	})
+
+	t.Run("extended port form with an aliased value", func(t *testing.T) {
+		_, ports := parse(t, `x-pub: &pub 8080
+services:
+  app:
+    image: alpine:3.21
+    ports:
+      - target: 80
+        published: *pub
+`)
+		if len(ports) != 1 || ports[0] != "8080:80" {
+			t.Errorf("published read through an alias came back %#v; the host port "+
+				"is dropped and only the container port is published", ports)
+		}
+	})
+}
+
+// TestEnvMapping_ReplacedValueKeepsItsComments pins what replacing a value node
+// could lose that writing through it did not. Both shapes here put the comment
+// on the VALUE node rather than the key, so both are genuinely at risk.
+func TestEnvMapping_ReplacedValueKeepsItsComments(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(`services:
+  app:
+    image: alpine:3.21
+    environment:
+      SSL_CERT_FILE: /etc/mine/ca.pem # trailing note
+      JAVA_TOOL_OPTIONS:
+        # note above the value
+        -Xmx1g
+`), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := idc.ModifyComposeForAgent(&compose, buildAgentOpts(), "app"); err != nil {
+		t.Fatalf("ModifyComposeForAgent: %v", err)
+	}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{"# trailing note", "# note above the value"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("replacing the value node dropped %q:\n%s", want, data)
+		}
+	}
+}
+
+// TestListElements_AliasesAreReadThroughAndReplaced covers the sequence-style
+// writers, the sibling branch of the mapping-style ones. An element can be an
+// alias, and an alias node's own Value is the anchor NAME — so the "does this
+// key already exist" scan matched nothing.
+func TestListElements_AliasesAreReadThroughAndReplaced(t *testing.T) {
+	t.Run("environment does not gain a duplicate key", func(t *testing.T) {
+		// Unmatched, keploy APPENDED a second JAVA_TOOL_OPTIONS entry. docker
+		// compose takes the last one, so the user's -Xmx1g is silently gone and
+		// the container starts with a heap it was never configured for.
+		out := runModifyForAgent(t, `x-jopts: &jopts "JAVA_TOOL_OPTIONS=-Xmx1g"
+services:
+  app:
+    image: alpine:3.21
+    environment:
+      - *jopts
+`)
+		env, _ := appService(t, out)["environment"].([]interface{})
+		var seen int
+		var value string
+		for _, e := range env {
+			s, _ := e.(string)
+			if strings.HasPrefix(s, "JAVA_TOOL_OPTIONS=") {
+				seen++
+				value = s
+			}
+		}
+		if seen != 1 {
+			t.Fatalf("JAVA_TOOL_OPTIONS appears %d times; compose keeps the last, "+
+				"so one of them is silently discarded: %v", seen, env)
+		}
+		if !strings.Contains(value, "-Xmx1g") {
+			t.Errorf("the user's own JVM options were lost: %q", value)
+		}
+		if !strings.Contains(value, "trustStore") {
+			t.Errorf("keploy's trust store was not appended: %q", value)
+		}
+	})
+
+	t.Run("an aliased CA variable is replaced, not duplicated", func(t *testing.T) {
+		// addServiceEnvVar's sequence branch, the sibling of the append case
+		// above. Unmatched, keploy adds a second SSL_CERT_FILE entry; compose
+		// keeps the last, so which CA the app trusts depends on ordering.
+		out := runModifyForAgent(t, `x-ca: &ca "SSL_CERT_FILE=/etc/mine/ca.pem"
+services:
+  app:
+    image: alpine:3.21
+    environment:
+      - *ca
+`)
+		env, _ := appService(t, out)["environment"].([]interface{})
+		var seen int
+		var value string
+		for _, e := range env {
+			str, _ := e.(string)
+			if strings.HasPrefix(str, "SSL_CERT_FILE=") {
+				seen++
+				value = str
+			}
+		}
+		if seen != 1 {
+			t.Fatalf("SSL_CERT_FILE appears %d times; which CA the app trusts then "+
+				"depends on entry order: %v", seen, env)
+		}
+		if value != "SSL_CERT_FILE=/tmp/keploy-tls/ca.crt" {
+			t.Errorf("SSL_CERT_FILE is %q, not keploy's CA", value)
+		}
+	})
+
+	t.Run("an empty depends_on element is skipped", func(t *testing.T) {
+		// A blank entry would become a dependency named "", which compose
+		// rejects — and it is keploy that put it there.
+		out := runModifyForAgent(t, `services:
+  app:
+    image: alpine:3.21
+    depends_on:
+      -
+      - db
+  db:
+    image: alpine:3.21
+`)
+		deps, _ := appService(t, out)["depends_on"].(map[string]interface{})
+		if _, blank := deps[""]; blank {
+			t.Errorf("an empty dependency name reached the generated file: %v", deps)
+		}
+		if deps["db"] == nil || deps["keploy-agent"] == nil {
+			t.Errorf("a real dependency was lost: %v", deps)
+		}
+	})
+
+	t.Run("depends_on keeps an aliased dependency", func(t *testing.T) {
+		out := runModifyForAgent(t, `x-db: &db db
+services:
+  app:
+    image: alpine:3.21
+    depends_on:
+      - *db
+  db:
+    image: alpine:3.21
+`)
+		deps, _ := appService(t, out)["depends_on"].(map[string]interface{})
+		if deps["db"] == nil {
+			t.Errorf("the app's own dependency was dropped during the seq→map "+
+				"rewrite, so it no longer waits for its database: %v", deps)
+		}
+		if deps["keploy-agent"] == nil {
+			t.Errorf("the keploy-agent gate is missing: %v", deps)
+		}
+	})
+
+	t.Run("an aliased container_name is matched", func(t *testing.T) {
+		// The lookup compared against the alias node's own Value — the anchor
+		// name — so keploy aborted with "failed to find target service" on a file
+		// docker compose accepts.
+		idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+		var compose Compose
+		if err := yaml.Unmarshal([]byte(`x-name: &appname myapp
+services:
+  svc:
+    image: alpine:3.21
+    container_name: *appname
+`), &compose); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if _, _, name, found := idc.findContainerInServices(&compose, "myapp"); !found {
+			t.Errorf("the gate did not find the service (name=%q)", name)
+		}
+		if _, _, err := idc.findServiceNodeAndName(&compose, "myapp"); err != nil {
+			t.Errorf("findServiceNodeAndName: %v", err)
+		}
+	})
+}

--- a/pkg/platform/docker/compose_volumes_test.go
+++ b/pkg/platform/docker/compose_volumes_test.go
@@ -511,8 +511,8 @@ networks: *shared
 	}
 }
 
-// TestAddTopLevelVolume_AliasToAnEmptyFragment pins the isEmptySection arm of
-// sectionForAppend, which nothing else reaches.
+// TestAddTopLevelVolume_AliasToAnEmptyFragment pins what happens to an alias
+// naming a fragment that holds nothing.
 //
 // `x-vols: &vols` with nothing under it is a null scalar, so an alias to it is
 // not a mapping — declining there would regress this shape straight back to the

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -517,7 +517,7 @@ func (idc *Impl) findContainerInServices(compose *Compose, containerName string)
 		var containerNameMatch bool
 		for j := 0; j < len(serviceContentNode.Content)-1; j++ {
 			if serviceContentNode.Content[j].Kind == yaml.ScalarNode && serviceContentNode.Content[j].Value == "container_name" &&
-				serviceContentNode.Content[j+1].Kind == yaml.ScalarNode && serviceContentNode.Content[j+1].Value == containerName {
+				aliasTarget(serviceContentNode.Content[j+1]).Value == containerName {
 				containerNameMatch = true
 				break
 			}
@@ -550,7 +550,7 @@ func (idc *Impl) extractServiceNetworks(serviceNode *yaml.Node, serviceName stri
 		valueNode := serviceNode.Content[i+1]
 
 		if keyNode.Value == "networks" {
-			return idc.parseNetworksNode(valueNode)
+			return idc.parseNetworksNode(aliasTarget(valueNode))
 		}
 	}
 
@@ -574,7 +574,11 @@ func (idc *Impl) extractServicePorts(serviceNode *yaml.Node) []string {
 		valueNode := serviceNode.Content[i+1]
 
 		if keyNode.Value == "ports" {
-			return idc.parsePortsNode(valueNode)
+			// `ports: *appports` matches no arm of the switch below, so the app's
+			// published ports came back empty. keploy-agent publishes on the app's
+			// behalf under `network_mode: service:keploy-agent`, so the app then
+			// has no published port at all and is unreachable from the host.
+			return idc.parsePortsNode(aliasTarget(valueNode))
 		}
 	}
 
@@ -590,7 +594,12 @@ func (idc *Impl) parseNetworksNode(networksNode *yaml.Node) []string {
 	case yaml.SequenceNode:
 		// Array format: networks: [network1, network2]
 		for _, networkNode := range networksNode.Content {
-			if networkNode.Kind == yaml.ScalarNode {
+			// An element can be an alias too, and dropping it is worse than
+			// reading nothing: the fallback below then puts keploy-agent on
+			// `default` while the app, sharing the agent's netns, silently loses
+			// the network its database is on.
+			networkNode = aliasTarget(networkNode)
+			if networkNode.Kind == yaml.ScalarNode && !isEmptyNode(networkNode) {
 				networks = append(networks, networkNode.Value)
 			}
 		}
@@ -603,8 +612,13 @@ func (idc *Impl) parseNetworksNode(networksNode *yaml.Node) []string {
 			}
 		}
 	case yaml.ScalarNode:
-		// Single network as string
-		networks = []string{networksNode.Value}
+		// Single network as string. `networks:` with nothing under it is also a
+		// scalar, and taking its empty Value produced a network named "" -- which
+		// keploy then copied onto keploy-agent, where compose rejects it with
+		// "additional properties '' not allowed".
+		if !isEmptyNode(networksNode) {
+			networks = []string{networksNode.Value}
+		}
 	}
 
 	// If no networks are specified, use default
@@ -623,7 +637,8 @@ func (idc *Impl) parsePortsNode(portsNode *yaml.Node) []string {
 	case yaml.SequenceNode:
 		// Array format: ports: ["80:80", "443:443"] or ports: [8080, "9000:9000"]
 		for _, portNode := range portsNode.Content {
-			if portNode.Kind == yaml.ScalarNode {
+			portNode = aliasTarget(portNode)
+			if portNode.Kind == yaml.ScalarNode && !isEmptyNode(portNode) {
 				ports = append(ports, portNode.Value)
 			} else if portNode.Kind == yaml.MappingNode {
 				// Extended format within array: ports: [{ target: 80, published: 8080 }]
@@ -640,8 +655,11 @@ func (idc *Impl) parsePortsNode(portsNode *yaml.Node) []string {
 			ports = []string{portMapping}
 		}
 	case yaml.ScalarNode:
-		// Single port as string: ports: "80:80"
-		ports = []string{portsNode.Value}
+		// Single port as string: ports: "80:80". An empty `ports:` is a scalar
+		// too, and publishing "" on keploy-agent fails with "invalid proto: ".
+		if !isEmptyNode(portsNode) {
+			ports = []string{portsNode.Value}
+		}
 	}
 
 	return ports
@@ -657,7 +675,7 @@ func (idc *Impl) parseExtendedPortMapping(portNode *yaml.Node) string {
 		}
 
 		keyNode := portNode.Content[i]
-		valueNode := portNode.Content[i+1]
+		valueNode := aliasTarget(portNode.Content[i+1])
 
 		if keyNode.Kind == yaml.ScalarNode && valueNode.Kind == yaml.ScalarNode {
 			switch keyNode.Value {
@@ -1188,7 +1206,7 @@ func (idc *Impl) AddKeployAgentToCompose(compose *Compose, opts models.SetupOpti
 		svc := compose.Services.Content[i+1]
 		for j := 0; j+1 < len(svc.Content); j += 2 {
 			if svc.Content[j].Value == "container_name" &&
-				svc.Content[j+1].Value == "keploy-agent" {
+				aliasTarget(svc.Content[j+1]).Value == "keploy-agent" {
 				return fmt.Errorf("service %q already uses container_name "+
 					"\"keploy-agent\"; rename it so keploy can add its own",
 					compose.Services.Content[i].Value)
@@ -1238,7 +1256,10 @@ func (idc *Impl) findServiceNodeAndName(compose *Compose, appIdentifier string) 
 		// Check 2: Does the container_name match?
 		for j := 0; j < len(serviceContentNode.Content)-1; j += 2 {
 			if serviceContentNode.Content[j].Value == "container_name" {
-				if serviceContentNode.Content[j+1].Value == appIdentifier {
+				// `container_name: *n` is legal; matching on the alias node's own
+				// Value compares against the anchor NAME, so the lookup misses and
+				// keploy aborts with "failed to find target service".
+				if aliasTarget(serviceContentNode.Content[j+1]).Value == appIdentifier {
 					return serviceContentNode, serviceName, nil
 				}
 			}
@@ -1254,6 +1275,32 @@ func (idc *Impl) ModifyComposeForAgent(compose *Compose, opts models.SetupOption
 	targetServiceNode, serviceName, err := idc.findServiceNodeAndName(compose, appContainerName)
 	if err != nil {
 		return fmt.Errorf("failed to find target service '%s': %w", appContainerName, err)
+	}
+
+	// Detach before anything is written. keploy deletes, moves and overwrites
+	// keys on this service, and every one of those corrupts a node the rest of
+	// the user's file reads through an alias -- see detachSubtree. The top-level
+	// sections keploy appends to need the same treatment, one node deep: it adds
+	// a key to `services:` and a volume to `volumes:`, and an anchored section
+	// shared with, say, `networks: *v` would carry those into it.
+	roots := compose.documentRoots()
+	owned := map[*yaml.Node]bool{}
+	collectNodes(targetServiceNode, owned)
+	// The sections themselves, one node deep -- keploy adds a key to `services:`
+	// and a volume to `volumes:`. Both the struct's copy and the live node the
+	// aliases actually point at, since they are not the same pointer.
+	for _, key := range []string{"services", "volumes"} {
+		if n := compose.rawSection(key); n != nil {
+			owned[n] = true
+		}
+	}
+	owned[&compose.Services] = true
+	owned[&compose.Volumes] = true
+	if n := detachSubtree(roots, owned); n > 0 {
+		idc.logger.Debug("expanded YAML aliases that read through nodes keploy edits, "+
+			"so the generated compose file carries keploy's changes without them "+
+			"reaching services keploy was not asked to touch",
+			zap.Int("references", n), zap.String("service", serviceName))
 	}
 
 	existingNetworks := idc.extractServiceNetworks(targetServiceNode, serviceName)
@@ -1383,8 +1430,19 @@ func (idc *Impl) addServiceListProperty(serviceNode *yaml.Node, key, value strin
 		if serviceNode.Content[i].Value == key {
 			// An aliased list (`volumes: *appvols`) holds no entries, so the
 			// append below would land in a node the encoder never emits and the
-			// TLS-cert mount would simply not appear.
+			// TLS-cert mount would simply not appear. A present-but-empty
+			// `volumes:` fails the same way; unlike environment, a service list
+			// has exactly one legal shape, so an empty mapping is reshaped too.
 			valueNode = resolveAliasByCopy(serviceNode.Content[i+1])
+			ensureSequence(valueNode)
+			if valueNode.Kind != yaml.SequenceNode {
+				idc.logger.Warn("a service list cannot hold keploy's entry, so it will "+
+					"not appear in the generated compose file",
+					zap.String("key", key), zap.String("entry", value),
+					zap.String("shape", yamlKindName(serviceNode.Content[i+1].Kind)),
+					zap.String("resolvesTo", yamlKindName(resolvedKind(serviceNode.Content[i+1]))),
+					zap.String("anchor", serviceNode.Content[i+1].Anchor))
+			}
 			break
 		}
 	}
@@ -1402,6 +1460,32 @@ func (idc *Impl) addServiceListProperty(serviceNode *yaml.Node, key, value strin
 	valueNode.Content = append(valueNode.Content, &yaml.Node{Kind: yaml.ScalarNode, Value: value})
 }
 
+// setScalarValue replaces a value node with a scalar, rather than writing
+// through the node it finds.
+//
+// `SSL_CERT_FILE: *ca` is an alias, and assigning to its Value overwrites the
+// alias NAME -- marshalling then fails with "alias value must contain
+// alphanumerical characters only" and keploy aborts on a compose file docker
+// accepts. `x-*` plus an anchor is the conventional way to share config, so this
+// is not an exotic shape.
+//
+// detachSubtree cannot help here: the anchor lives outside the app service, so
+// it is not one of the nodes keploy claims ownership of.
+func setScalarValue(slot **yaml.Node, value string) {
+	old := *slot
+	*slot = &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: value,
+		// Head and line comments both attach to a VALUE node in real files --
+		// `KEY:` with the value on the next line under a comment, and a trailing
+		// `# note` -- and both are pinned by a test. FootComment is not carried:
+		// no shape I could construct puts one on a value node, so copying it
+		// would be code no test could justify.
+		HeadComment: old.HeadComment,
+		LineComment: old.LineComment,
+	}
+}
+
 // getOrCreateEnvNode finds the 'environment' node inside a service, creating
 // a SequenceNode if none exists. It centralizes the lookup/create logic for
 // environment mutations performed by helper methods.
@@ -1413,7 +1497,26 @@ func (idc *Impl) getOrCreateEnvNode(serviceNode *yaml.Node) *yaml.Node {
 			// silently dropped. Resolving by copy also keeps a sibling service
 			// sharing that fragment from inheriting keploy's CA paths while
 			// living outside the agent's network namespace.
-			return resolveAliasByCopy(serviceNode.Content[i+1])
+			env := resolveAliasByCopy(serviceNode.Content[i+1])
+			// A present-but-empty `environment:` fails the same way. An empty
+			// MAPPING is exempt: it already holds entries fine, and reshaping it
+			// would rewrite the user's chosen style for no gain.
+			if env.Kind != yaml.MappingNode {
+				ensureSequence(env)
+			}
+			if env.Kind != yaml.SequenceNode && env.Kind != yaml.MappingNode {
+				// Nothing below this can land. Say so here: the symptom is a TLS
+				// verification failure at replay, which points nowhere near
+				// compose generation.
+				idc.logger.Warn("`environment:` cannot hold an entry, so keploy cannot "+
+					"give the app its CA paths (NODE_EXTRA_CA_CERTS, "+
+					"REQUESTS_CA_BUNDLE, SSL_CERT_FILE, CARGO_HTTP_CAINFO) or "+
+					"JAVA_TOOL_OPTIONS; expect TLS verification failures at replay",
+					zap.String("environmentShape", yamlKindName(serviceNode.Content[i+1].Kind)),
+					zap.String("resolvesTo", yamlKindName(resolvedKind(serviceNode.Content[i+1]))),
+					zap.String("anchor", serviceNode.Content[i+1].Anchor))
+			}
+			return env
 		}
 	}
 
@@ -1434,10 +1537,15 @@ func (idc *Impl) addServiceEnvVar(serviceNode *yaml.Node, envKey, envValue strin
 	// Handle Sequence (array) style environment: ["KEY=VAL"]
 	if envNode.Kind == yaml.SequenceNode {
 		prefix := envKey + "="
-		for _, node := range envNode.Content {
-			if strings.HasPrefix(node.Value, prefix) {
-				// Key already exists — update in place.
-				node.Value = fmt.Sprintf("%s=%s", envKey, envValue)
+		for i, node := range envNode.Content {
+			// An element can be an alias, whose own Value is the anchor NAME --
+			// so `- *jopts` naming "JAVA_TOOL_OPTIONS=-Xmx1g" matched nothing and
+			// keploy appended a SECOND JAVA_TOOL_OPTIONS entry. compose takes the
+			// last, so the user's setting is silently gone.
+			if strings.HasPrefix(aliasTarget(node).Value, prefix) {
+				// Key already exists — replace the element rather than writing
+				// through it, for the reason setScalarValue exists.
+				setScalarValue(&envNode.Content[i], fmt.Sprintf("%s=%s", envKey, envValue))
 				return
 			}
 		}
@@ -1451,8 +1559,9 @@ func (idc *Impl) addServiceEnvVar(serviceNode *yaml.Node, envKey, envValue strin
 	if envNode.Kind == yaml.MappingNode {
 		for i := 0; i < len(envNode.Content)-1; i += 2 {
 			if envNode.Content[i].Value == envKey {
-				// Key already exists — update in place.
-				envNode.Content[i+1].Value = envValue
+				// Key already exists — replace its value. See setScalarValue for
+				// why this is not an in-place write.
+				setScalarValue(&envNode.Content[i+1], envValue)
 				return
 			}
 		}
@@ -1472,7 +1581,8 @@ func (idc *Impl) appendServiceEnvVar(serviceNode *yaml.Node, envKey, appendValue
 	// Handle Sequence (array) style: ["KEY=VAL", ...]
 	if envNode.Kind == yaml.SequenceNode {
 		prefix := envKey + "="
-		for _, node := range envNode.Content {
+		for i, node := range envNode.Content {
+			node = aliasTarget(node)
 			if strings.HasPrefix(node.Value, prefix) {
 				existingVal := strings.TrimPrefix(node.Value, prefix)
 				existingTokens := strings.Fields(existingVal)
@@ -1487,7 +1597,7 @@ func (idc *Impl) appendServiceEnvVar(serviceNode *yaml.Node, envKey, appendValue
 					// All tokens already present — skip to avoid double-injection.
 					return
 				}
-				node.Value = node.Value + " " + strings.Join(missing, " ")
+				setScalarValue(&envNode.Content[i], node.Value+" "+strings.Join(missing, " "))
 				return
 			}
 		}
@@ -1500,7 +1610,10 @@ func (idc *Impl) appendServiceEnvVar(serviceNode *yaml.Node, envKey, appendValue
 	if envNode.Kind == yaml.MappingNode {
 		for i := 0; i < len(envNode.Content)-1; i += 2 {
 			if envNode.Content[i].Value == envKey {
-				existingVal := envNode.Content[i+1].Value
+				// Read through an alias: its own Value is the anchor NAME, so
+				// `JAVA_TOOL_OPTIONS: *jopts` would otherwise compare keploy's
+				// tokens against "jopts" and append to that.
+				existingVal := aliasTarget(envNode.Content[i+1]).Value
 				existingTokens := strings.Fields(existingVal)
 				newTokens := strings.Fields(appendValue)
 				var missing []string
@@ -1513,7 +1626,7 @@ func (idc *Impl) appendServiceEnvVar(serviceNode *yaml.Node, envKey, appendValue
 					// All tokens already present — skip to avoid double-injection.
 					return
 				}
-				envNode.Content[i+1].Value = existingVal + " " + strings.Join(missing, " ")
+				setScalarValue(&envNode.Content[i+1], existingVal+" "+strings.Join(missing, " "))
 				return
 			}
 		}
@@ -1559,6 +1672,145 @@ func (idc *Impl) addTopLevelVolume(compose *Compose, volumeName string) {
 	)
 }
 
+// detachSubtree makes every node in a subtree safe for keploy to edit in place,
+// by giving each alias that reads through it an inline copy of what it names
+// TODAY and then dropping the anchor.
+//
+// keploy does not merely append to the app service. It DELETES `networks` and
+// `ports`, MOVES `dns*` onto keploy-agent, OVERWRITES `network_mode` and `pid`,
+// and appends to `environment` and `volumes`. Every one of those is wrong on a
+// node the user's file reads through an alias, and the failures are not subtle:
+//
+//	networks: &n [default]    deleting the app's key deletes the anchor
+//	sidecar: {networks: *n}   DEFINITION, and the generated file then fails to
+//	                          load at all -- "unknown anchor 'n' referenced"
+//
+//	environment: &e [MINE=1]  appending hands the sidecar keploy's CA paths
+//	sidecar: {environment: *e}  while it lives OUTSIDE the agent's network
+//	                          namespace, so its TLS fails verification against a
+//	                          certificate file its container does not have
+//
+// Expanding a reference costs its reader nothing -- it names exactly the content
+// it named before -- and the file this produces is the temporary one keploy
+// runs, not the user's source. Declining to edit instead was tried and is worse:
+// it leaves the app half-wired (pid set, network_mode not), which docker compose
+// accepts and which records nothing at all.
+//
+// Returns the number of references expanded, for the caller to log.
+func detachSubtree(roots []*yaml.Node, owned map[*yaml.Node]bool) int {
+	if len(owned) == 0 {
+		return 0
+	}
+
+	expanded := 0
+	// Expanding one reference can copy an alias naming another node inside the
+	// subtree, so repeat until the document holds none.
+	//
+	// No fixture I could build needs a second pass, and no test here
+	// distinguishes this loop from a single pass. The loop stays regardless.
+	//
+	// The tempting argument for dropping it -- YAML requires an alias to follow
+	// its anchor, so a reference nested inside a fragment is always reached
+	// first -- does not actually hold: the walk below runs over `roots` in list
+	// order, not document order, so an alias in an `x-*` key written ABOVE
+	// `services:` is visited last. Getting that wrong leaves a dangling alias,
+	// which does not degrade the generated file, it makes it unloadable. The
+	// bound is a termination guarantee, not a policy.
+	for range 64 {
+		refs := aliasRefsInto(roots, owned)
+		if len(refs) == 0 {
+			break
+		}
+		for _, ref := range refs {
+			clone := cloneYAMLNode(ref.Alias)
+			stripAnchors(clone)
+			*ref = *clone
+			expanded++
+		}
+	}
+
+	// Nothing reads through them any more, so the anchors are free to go. Left
+	// in place they would be duplicated by any later copy of this subtree.
+	for n := range owned {
+		n.Anchor = ""
+	}
+	return expanded
+}
+
+func collectNodes(n *yaml.Node, into map[*yaml.Node]bool) {
+	if n == nil || into[n] {
+		return
+	}
+	into[n] = true
+	for _, c := range n.Content {
+		collectNodes(c, into)
+	}
+}
+
+// aliasRefsInto finds every alias in the document that resolves to a node the
+// caller is about to mutate.
+func aliasRefsInto(roots []*yaml.Node, owned map[*yaml.Node]bool) []*yaml.Node {
+	var found []*yaml.Node
+	seen := map[*yaml.Node]bool{}
+	var walk func(*yaml.Node)
+	walk = func(n *yaml.Node) {
+		if n == nil || seen[n] {
+			return
+		}
+		seen[n] = true
+		if n.Kind == yaml.AliasNode && n.Alias != nil && owned[n.Alias] {
+			found = append(found, n)
+			return
+		}
+		for _, c := range n.Content {
+			walk(c)
+		}
+	}
+	for _, r := range roots {
+		walk(r)
+	}
+	return found
+}
+
+// rawSection returns the LIVE node for a top-level key.
+//
+// The Compose struct's section fields are value copies made when the file was
+// decoded -- their Content children are the same pointers as the original's, but
+// the section nodes themselves are not. An alias to `volumes: &v` therefore
+// points at raw's node, never at `&compose.Volumes`, so anything matching on
+// node identity has to look here or it silently matches nothing.
+func (c *Compose) rawSection(key string) *yaml.Node {
+	if c.raw == nil {
+		return nil
+	}
+	for i := 0; i+1 < len(c.raw.Content); i += 2 {
+		if c.raw.Content[i].Value == key {
+			return c.raw.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// documentRoots returns the nodes to search for aliases: the struct's section
+// fields AND raw, always. Neither alone is enough.
+//
+// raw is the original mapping and its children are the same pointers as the live
+// tree, but MarshalCompose splices the struct's own section fields back over it,
+// and those are value copies made at decode time. An alias sitting directly
+// under `volumes:` therefore exists as two separate nodes; expanding only raw's
+// leaves the copy -- the one that gets emitted -- pointing at an anchor about to
+// be cleared, and the generated file fails to load with "unknown anchor".
+func (c *Compose) documentRoots() []*yaml.Node {
+	// Networks, Configs and Secrets are here for the same reason even though
+	// keploy never writes to them: a service's `volumes: &v` can be named by
+	// `networks: *v`, and that reference has to be expanded like any other.
+	roots := []*yaml.Node{&c.Services, &c.Networks, &c.Volumes, &c.Configs, &c.Secrets}
+	if c.raw != nil {
+		roots = append(roots, c.raw)
+	}
+	return roots
+}
+
 // yamlKindName renders a yaml.Kind for a log line. The raw enum means nothing to
 // an operator reading it.
 func yamlKindName(k yaml.Kind) string {
@@ -1577,6 +1829,24 @@ func yamlKindName(k yaml.Kind) string {
 		return "alias"
 	}
 	return "unknown"
+}
+
+// aliasTarget follows an alias to what it names, WITHOUT mutating anything.
+//
+// The read paths must not use resolveAliasByCopy: that rewrites the node in
+// place. The gate around them already resolves SERVICE aliases in place -- it
+// has to, or the lookup finds nothing -- but that is a deliberate, narrow
+// exception, and reading a port list is no reason to widen it.
+func aliasTarget(n *yaml.Node) *yaml.Node {
+	// Bounded rather than recursive: an anchor cannot be cyclic, but the node
+	// comes from a user's file and this is a cheap way not to depend on that.
+	for i := 0; i < 16; i++ {
+		if n == nil || n.Kind != yaml.AliasNode || n.Alias == nil {
+			return n
+		}
+		n = n.Alias
+	}
+	return n
 }
 
 // resolvedKind reports what a node ultimately names, following one alias hop, so
@@ -1714,10 +1984,13 @@ func sectionForAppend(n *yaml.Node) *yaml.Node {
 		return n
 	}
 	target := n.Alias
-	if target.Kind != yaml.MappingNode && !isEmptySection(target) {
+	if target.Kind != yaml.MappingNode {
 		// Resolves to something that cannot hold entries (a populated scalar or
 		// sequence). Leave the alias exactly as written -- the caller warns --
 		// rather than reshaping a fragment the user wrote.
+		//
+		// An alias to an EMPTY fragment never reaches here: ensureMapping above
+		// has already reshaped the reference, so n is no longer an alias.
 		return n
 	}
 	// Replace the alias with a copy of what it named.
@@ -1765,7 +2038,7 @@ func sectionForAppend(n *yaml.Node) *yaml.Node {
 // handed to debug. Value is deliberately NOT cleared: the encoder never reads it
 // for a mapping, so clearing it would be an unobservable no-op.
 func ensureMapping(n *yaml.Node) {
-	if n == nil || n.Kind == yaml.MappingNode || !isEmptySection(n) {
+	if n == nil || n.Kind == yaml.MappingNode || !isEmptyNode(n) {
 		return
 	}
 	n.Kind = yaml.MappingNode
@@ -1778,25 +2051,63 @@ func ensureMapping(n *yaml.Node) {
 	n.Content = []*yaml.Node{}
 }
 
-// isEmptySection reports whether a section node holds nothing, in any of the
-// shapes YAML can express that: an absent key (zero node), a null in any
-// spelling, an empty string, or an empty sequence.
+// isEmptyNode reports whether a node holds nothing, in any of the shapes YAML
+// can express that: an absent key (zero node), a null in any spelling, an empty
+// string, an empty sequence or mapping, or an alias naming any of those.
 //
 // A node carrying content is NOT empty, and that includes shapes whose payload
-// does not live in Content: a scalar keeps its text in Value, and an alias
-// resolves elsewhere entirely. Treating those as empty would silently discard
-// what the user wrote.
-func isEmptySection(n *yaml.Node) bool {
+// does not live in Content: a scalar keeps its text in Value, so `len(Content)`
+// is the tempting test and the wrong one -- it would report `volumes: appdata`
+// as empty and discard what the user wrote. An alias is judged by what it names,
+// for the same reason.
+func isEmptyNode(n *yaml.Node) bool {
 	switch n.Kind {
 	case 0:
 		return true
 	case yaml.ScalarNode:
 		return n.Tag == "!!null" || n.Value == ""
-	case yaml.SequenceNode:
+	case yaml.SequenceNode, yaml.MappingNode:
 		return len(n.Content) == 0
+	case yaml.AliasNode:
+		// An alias to an empty fragment holds nothing either. Reshaping the
+		// REFERENCE is safe -- the anchored fragment itself is a separate node
+		// and stays exactly as the user wrote it.
+		return n.Alias == nil || isEmptyNode(n.Alias)
 	default:
 		return false
 	}
+}
+
+// ensureSequence reshapes a present-but-empty node into an empty sequence so an
+// append lands somewhere the encoder emits.
+//
+// `environment:` or `volumes:` with nothing under them -- what a commented-out
+// block leaves behind -- is not a zero node: it decodes to a `!!null` scalar, or
+// to an alias naming an empty fragment. The writers' type switch matches neither
+// shape, so every variable and mount keploy adds was dropped without a word and
+// the app ran without keploy's CA. A node carrying anything is left untouched.
+//
+// Reshaping in place is safe for a node the app OWNS, because detachSubtree has
+// already given away copies of anything shared. It is also safe for an alias
+// naming an `x-*` fragment, which detach deliberately leaves alone: what gets
+// reshaped there is the app's own reference node, not the fragment.
+func ensureSequence(n *yaml.Node) {
+	if n == nil || n.Kind == yaml.SequenceNode || !isEmptyNode(n) {
+		return
+	}
+	n.Kind = yaml.SequenceNode
+	// A leftover `!!null` tag is emitted verbatim onto the sequence, and Style
+	// carries the flow bits of the shape being replaced, so `volumes: {}` would
+	// otherwise normalise into a flow-style list in a block-style file. Both are
+	// pinned by a test.
+	//
+	// Value and Alias are deliberately not cleared: the encoder reads neither
+	// once Kind is a sequence. Content is left as isEmptyNode found it -- empty
+	// for every shape that reaches here today, since yaml.v3 never gives an alias
+	// node children. Re-check that if isEmptyNode ever admits a node with
+	// children of its own.
+	n.Tag = ""
+	n.Style = 0
 }
 
 func cloneYAMLNode(node *yaml.Node) *yaml.Node {
@@ -1879,8 +2190,19 @@ func (idc *Impl) addServiceProperty(serviceNode *yaml.Node, key, value string) {
 		}
 
 		if serviceNode.Content[i].Kind == yaml.ScalarNode && serviceNode.Content[i].Value == key {
-			// Update existing property
-			serviceNode.Content[i+1].Value = value
+			// Replace rather than write through. Setting .Value only works when
+			// the node is already a
+			// scalar. On a `!!null` (`network_mode:` with nothing after it) the
+			// tag survives and the file is emitted as `network_mode: !!null
+			// service:keploy-agent`, which does not parse; on a mapping or
+			// sequence the write is ignored and interception is silently off; on
+			// an alias it overwrites the alias NAME and marshalling fails with
+			// "alias value must contain alphanumerical characters only".
+			//
+			// Replacing the node is what "set this property" means in every one
+			// of those cases. Comments are carried over so a `# keep me` above
+			// the value is not dropped.
+			setScalarValue(&serviceNode.Content[i+1], value)
 			return
 		}
 	}
@@ -1905,15 +2227,35 @@ func (idc *Impl) addOrUpdateDependsOn(serviceNode *yaml.Node) {
 		}
 
 		if serviceNode.Content[i].Kind == yaml.ScalarNode && serviceNode.Content[i].Value == "depends_on" {
-			// Update existing depends_on
-			dependsOnNode := serviceNode.Content[i+1]
+			// Update existing depends_on.
+			//
+			// An aliased or present-but-empty `depends_on:` matches neither
+			// branch below, and falling through drops the `keploy-agent:
+			// {condition: service_healthy}` gate without a word -- so the app
+			// container starts before the agent's proxy is listening and races
+			// it, which surfaces as a handful of unrecorded calls at the head of
+			// the session rather than as an error.
+			dependsOnNode := resolveAliasByCopy(serviceNode.Content[i+1])
+			ensureSequence(dependsOnNode)
+			if dependsOnNode.Kind != yaml.SequenceNode && dependsOnNode.Kind != yaml.MappingNode {
+				idc.logger.Warn("`depends_on:` cannot hold an entry, so keploy cannot "+
+					"make the app wait for keploy-agent to become healthy; the app "+
+					"may start before interception is ready",
+					zap.String("dependsOnShape", yamlKindName(serviceNode.Content[i+1].Kind)),
+					zap.String("resolvesTo", yamlKindName(resolvedKind(serviceNode.Content[i+1]))))
+				return
+			}
 
 			// Check if it's a simple array or extended format
 			if dependsOnNode.Kind == yaml.SequenceNode {
 				// Store existing dependencies first
 				existingDeps := make([]string, 0)
 				for _, dep := range dependsOnNode.Content {
-					if dep.Kind == yaml.ScalarNode && dep.Value != "keploy-agent" {
+					// `- *db` is an alias; dropping it here silently removes a
+					// real dependency, and the app stops waiting for it.
+					dep = aliasTarget(dep)
+					if dep.Kind == yaml.ScalarNode && !isEmptyNode(dep) &&
+						dep.Value != "keploy-agent" {
 						existingDeps = append(existingDeps, dep.Value)
 					}
 				}


### PR DESCRIPTION
keploy rewrites the user's compose file to run their app under the agent. Several writers matched a key, took `Content[i+1]` and assumed a shape YAML need not have.

**None of these produce an error.** The generated file loads, the app starts, and the damage shows up much later — as TLS verification failures, or a handful of unrecorded calls at the head of a session, or a sibling service that mysteriously stops working. That is what makes them worth fixing together rather than one at a time.

---

## 1. A key that is present but empty

`environment:` with nothing under it — what commenting a block out leaves behind — is legal compose and is **not** a zero node. It decodes to a `!!null` **scalar**, and every writer's type switch tests `SequenceNode` then `MappingNode` and falls through with no log.

| shape | what was dropped |
|---|---|
| `environment:` | `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `CARGO_HTTP_CAINFO`, `JAVA_TOOL_OPTIONS` — the app ran without keploy's CA |
| `volumes:` | the cert directory those four paths point at |
| `depends_on:` | the `keploy-agent: {condition: service_healthy}` gate |
| `network_mode:` | emitted `network_mode: !!null service:keploy-agent`, which **does not parse** |
| `network_mode: {}` / `[]` | write ignored — the app never joined the agent's netns, so nothing was intercepted |

`depends_on` is the one that costs the most to diagnose: without the gate the app container starts before the agent's proxy is listening and races it, which shows up as a few missing calls at the start of a session, intermittently, with nothing logged.

Fixed at the accessors every writer funnels through. `isEmptySection` becomes `isEmptyNode` and gains the shapes it was missing; a new `ensureSequence` reshapes a present-but-empty node so an append lands somewhere the encoder emits. `addServiceProperty` now **replaces** the value node instead of writing through `.Value`, which is the only thing that works when the node is not already a scalar.

**Two carve-outs, both deliberate and both pinned.** `environment: {}` is left alone — an empty mapping already holds entries fine, and reshaping it would rewrite the user's chosen style for nothing. A service's `volumes: {}` **is** reshaped, because a service list has exactly one legal shape: appending a lone scalar to a mapping leaves odd `Content`, which go-yaml emits as an empty mapping, dropping the mount without an error.

## 2. A node reached through a YAML anchor

keploy does not merely append to the app service. It **deletes** `networks` and `ports`, **moves** `dns*` onto keploy-agent, **overwrites** `network_mode` and `pid`, and appends to `environment` and `volumes`. Every one of those is wrong on a node the rest of the user's file reads through an alias:

```yaml
services:
  app:
    environment: &appenv     # ← keploy appends its CA paths here
  sidecar:
    environment: *appenv     # ← and the sidecar inherits all of them
```

`sidecar` is not in the agent's network namespace, so it now points at a certificate file its container does not have and its outbound TLS fails verification — caused by keploy, on a service keploy was never asked to touch.

Deleting or moving is worse than leaking. When the app owns the anchor definition, `removeServiceProperty(app, "networks")` deletes it and every `*ref` dangles:

```
yaml: unknown anchor 'shared' referenced
```

The generated file does not load **at all**, from a file `docker compose` accepted. The `dns*` move fails the same way, by relocating the definition below the reference.

### Why declining is not the answer

The first two attempts at this fix declined to edit an anchored node. Both were measured to be **worse than the bug**: declining leaves the app half-wired — `pid: service:keploy-agent` set, `network_mode` not — which `docker compose config` accepts, which starts fine, and which records **nothing**.

`detachSubtree` instead gives every alias an inline copy of what it names *today*, then clears the anchor, after which keploy edits freely and no reader is affected. Expanding a reference costs its reader nothing — it names exactly the content it named before — and the file this produces is the temporary one keploy runs, not the user's source. §3 of #4574 already established that trade for a different node.

One subtlety worth knowing before editing this code: `Compose`'s section fields are **value copies** made at decode time, so an alias directly under `volumes:` exists as two separate nodes and `&compose.Volumes` is not the one aliases point at. `documentRoots` searches both, and dropping either half produces a file that fails to load. `Networks`, `Configs` and `Secrets` are searched too — keploy never writes to them, but a reference to a node keploy *does* edit can sit under any top-level key.

## 3. The read path, one level down

An alias node's own `Value` is the **anchor name**, so anything comparing against it silently misses:

| shape | consequence |
|---|---|
| `ports: [- *p]` | app publishes nothing; keploy-agent publishes on its behalf under `network_mode: service:keploy-agent`, so the app is unreachable from the host |
| `networks: [- *n]` | the `default` fallback fires and masks it — keploy-agent joins `default` while the app silently loses the network its database is on |
| `depends_on: [- *db]` | a real dependency dropped during the seq→map rewrite |
| `environment: [- *jopts]` | a **duplicate** `JAVA_TOOL_OPTIONS=` entry; compose keeps the last, so the user's setting is gone |
| `environment: {KEY: *ca}` | assigning to the alias's Value overwrote the anchor NAME — `MarshalCompose` then failed with `alias value must contain alphanumerical characters only` and keploy **aborted** |
| `container_name: *n` | `failed to find target service` on a file that plainly declares it |
| `ports:` / `networks:` empty | `[""]` copied onto keploy-agent → `invalid proto: ` / `additional properties '' not allowed` |

Resolved with `aliasTarget`, a non-mutating pointer chase — the gate runs before keploy has written anything, and reading a port list is no reason to widen the one narrow in-place resolution it already does.

---

## Verification

Every behaviour is pinned by a test that fails when it is reverted. **~50 mutations across four review rounds; all killed but one.**

The survivor is the retry loop in `detachSubtree`. No fixture I could build needs a second pass, and the comment says exactly that rather than implying coverage. It stays because the tempting argument for dropping it — YAML orders anchors before aliases, so a nested reference is always reached first — **does not hold**: the walk runs over roots in list order, not document order. Getting it wrong does not degrade the generated file, it makes it unloadable.

Three earlier survivors turned out to be genuinely dead assignments, and were **deleted rather than given a test**: clearing `Value`, `Alias` and `Content` in `ensureSequence` (the encoder reads none of them once `Kind` is a sequence), and `FootComment` carry-over (no shape I could construct puts one on a value node). `HeadComment` and `LineComment` *are* reachable on a value node — measured — so those kept their assignment and got a test.

Two fixtures are load-bearing in a way that is easy to undo by accident, and both say so in the test file: the shallow-copy mutation is invisible below a three-key fragment, and the anchor-leak mutation is invisible unless the fixture carries the keys keploy actually writes into.

`gofmt`, `go vet`, `go build ./...` clean; `pkg/platform/docker` and `pkg/client/app` green, including `-race`. For a compose file with none of these shapes the generated output is unchanged.

## Also found, filed rather than folded in

Keys inherited through a merge key are invisible to keploy. For `app: {<<: *common}` where `common` defines `environment` and `networks`, keploy appends a *new* `environment:` that shadows the merged one, and `removeServiceProperty(app, "networks")` removes nothing — so the output carries both `networks:` and `network_mode:`, which compose rejects as mutually exclusive. Pre-existing, a different mechanism (merge-key resolution, not alias resolution), and large enough to deserve its own change rather than being grown onto this one.
