### PR TITLE
fix(docker): apply keploy's compose edits to keys inherited through `<<:`

### DIFF
--- a/pkg/platform/docker/compose_merge_key_test.go
+++ b/pkg/platform/docker/compose_merge_key_test.go
@@ -1,0 +1,637 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+
+	"go.keploy.io/server/v3/config"
+)
+
+// runWithGate drives the real path in the order the caller uses it: the gate
+// first, whose ports become opts.AppPorts, then the rewrite.
+func runWithGate(t *testing.T, in string) (map[string]interface{}, []string) {
+	t.Helper()
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	_, ports, _, found := idc.findContainerInServices(&compose, "app")
+	if !found {
+		t.Fatalf("gate did not find the app service")
+	}
+	opts := buildAgentOpts()
+	opts.AppPorts = ports
+	if err := idc.ModifyComposeForAgent(&compose, opts, "app"); err != nil {
+		t.Fatalf("ModifyComposeForAgent: %v", err)
+	}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	t.Logf("generated:\n%s", data)
+	return out, ports
+}
+
+func mergeApp(t *testing.T, out map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	svcs, _ := out["services"].(map[string]interface{})
+	app, _ := svcs["app"].(map[string]interface{})
+	if app == nil {
+		t.Fatalf("app service missing: %v", svcs)
+	}
+	return app
+}
+
+// TestMergeKey_InheritedKeysAreEditedLikeAnyOther is the regression test for all
+// three ways a `<<:` key went wrong. The fixture is the shape the compose spec
+// recommends — reusable config in an `x-*` fragment, pulled in with a merge key.
+func TestMergeKey_InheritedKeysAreEditedLikeAnyOther(t *testing.T) {
+	out, ports := runWithGate(t, `x-common: &common
+  environment:
+    - MINE=1
+  networks:
+    - mynet
+  ports:
+    - "8080:8080"
+networks:
+  mynet:
+services:
+  app:
+    <<: *common
+    image: alpine:3.21
+`)
+	app := mergeApp(t, out)
+
+	// 1. The gate.
+	if len(ports) != 1 || ports[0] != "8080:8080" {
+		t.Errorf("the gate read %#v through the merge key; keploy-agent publishes "+
+			"on the app's behalf, so the app would be unreachable from the host", ports)
+	}
+
+	// 2. The user's own variables.
+	env, _ := app["environment"].([]interface{})
+	var keptMine, gotCA bool
+	for _, e := range env {
+		s, _ := e.(string)
+		if s == "MINE=1" {
+			keptMine = true
+		}
+		if strings.HasPrefix(s, "SSL_CERT_FILE=") {
+			gotCA = true
+		}
+	}
+	if !keptMine {
+		t.Errorf("the inherited variable was lost: keploy added an explicit "+
+			"environment: that overrides the merged one: %v", env)
+	}
+	if !gotCA {
+		t.Errorf("keploy's CA was not added: %v", env)
+	}
+
+	// 3. The keys keploy has to DELETE. An inherited key cannot be unset in
+	//    YAML, so leaving the merge in place left both of these standing next to
+	//    the network_mode keploy adds.
+	if app["networks"] != nil {
+		t.Errorf("networks survived alongside network_mode=%v; docker compose "+
+			"rejects that pair as mutually exclusive: %v",
+			app["network_mode"], app["networks"])
+	}
+	if app["ports"] != nil {
+		t.Errorf("ports survived on a service using network_mode=%v: %v",
+			app["network_mode"], app["ports"])
+	}
+	if app["network_mode"] != "service:keploy-agent" {
+		t.Errorf("the app was not put in the agent's netns: %v", app["network_mode"])
+	}
+}
+
+// TestMergeKey_PrecedenceFollowsTheSpec pins the two rules that are easy to get
+// backwards. An explicit key beats a merged one, and within `<<: [*a, *b]` the
+// EARLIER entry wins — which reads like the opposite of "later overrides".
+func TestMergeKey_PrecedenceFollowsTheSpec(t *testing.T) {
+	t.Run("explicit beats merged", func(t *testing.T) {
+		app := mergeApp(t, mustRun(t, `x-common: &common
+  image: alpine:3.20
+  working_dir: /from-fragment
+services:
+  app:
+    <<: *common
+    image: alpine:3.21
+`))
+		if app["image"] != "alpine:3.21" {
+			t.Errorf("the merged value overrode the explicit one: %v", app["image"])
+		}
+		if app["working_dir"] != "/from-fragment" {
+			t.Errorf("the inherited key was lost: %v", app["working_dir"])
+		}
+	})
+
+	t.Run("earlier entry wins in a sequence", func(t *testing.T) {
+		app := mergeApp(t, mustRun(t, `x-first: &first
+  working_dir: /first
+x-second: &second
+  working_dir: /second
+  user: someone
+services:
+  app:
+    <<: [*first, *second]
+    image: alpine:3.21
+`))
+		if app["working_dir"] != "/first" {
+			t.Errorf("precedence is backwards: got %v, the spec gives the earlier "+
+				"entry priority", app["working_dir"])
+		}
+		if app["user"] != "someone" {
+			t.Errorf("a key only the later entry defines was dropped: %v", app["user"])
+		}
+	})
+
+	t.Run("a merge nested inside a fragment is followed", func(t *testing.T) {
+		app := mergeApp(t, mustRun(t, `x-base: &base
+  working_dir: /base
+  user: someone
+x-mid: &mid
+  <<: *base
+  working_dir: /mid
+services:
+  app:
+    <<: *mid
+    image: alpine:3.21
+`))
+		if app["working_dir"] != "/mid" {
+			t.Errorf("the nested merge overrode its own parent: %v", app["working_dir"])
+		}
+		if app["user"] != "someone" {
+			t.Errorf("a key reached only through the nested merge was lost: %v", app["user"])
+		}
+	})
+}
+
+// TestMergeKey_TheFragmentIsNotEdited is the guard that matters most. The
+// fragment is the user's, and it is shared: keploy deletes keys from the app
+// service and appends to its environment, so taking the fragment's nodes by
+// reference would carry every one of those edits into each sibling that merges
+// the same fragment.
+func TestMergeKey_TheFragmentIsNotEdited(t *testing.T) {
+	out := mustRun(t, `x-common: &common
+  environment:
+    - MINE=1
+  networks:
+    - mynet
+networks:
+  mynet:
+services:
+  app:
+    <<: *common
+    image: alpine:3.21
+  sidecar:
+    <<: *common
+    image: alpine:3.21
+`)
+	// The sibling must be exactly what the user wrote.
+	svcs, _ := out["services"].(map[string]interface{})
+	sidecar, _ := svcs["sidecar"].(map[string]interface{})
+	if sidecar == nil {
+		t.Fatalf("sidecar disappeared: %v", svcs)
+	}
+	env, _ := sidecar["environment"].([]interface{})
+	if len(env) != 1 || env[0] != "MINE=1" {
+		t.Errorf("the sidecar's environment is %v; it is not in the agent's netns, "+
+			"so keploy's CA paths would point at a file it does not have", env)
+	}
+	if nets, _ := sidecar["networks"].([]interface{}); len(nets) != 1 {
+		t.Errorf("keploy's deletion reached the sidecar: %v", sidecar["networks"])
+	}
+	// And the fragment itself.
+	frag, _ := out["x-common"].(map[string]interface{})
+	if frag == nil {
+		t.Fatalf("the fragment disappeared: %v", out["x-common"])
+	}
+	if fenv, _ := frag["environment"].([]interface{}); len(fenv) != 1 {
+		t.Errorf("the user's fragment gained keploy's variables: %v", frag["environment"])
+	}
+	if _, present := frag["networks"]; !present {
+		t.Errorf("keploy deleted a key from the user's fragment: %v", frag)
+	}
+}
+
+// TestMergeKey_NoMergeKeyIsUntouched pins that a file without `<<:` is not
+// reshaped. flattenMergeKeys runs on every app service, so a no-op has to be a
+// real no-op.
+func TestMergeKey_NoMergeKeyIsUntouched(t *testing.T) {
+	app := mergeApp(t, mustRun(t, `services:
+  app:
+    image: alpine:3.21
+    environment:
+      - MINE=1
+`))
+	env, _ := app["environment"].([]interface{})
+	if len(env) == 0 || env[0] != "MINE=1" {
+		t.Errorf("the user's own entry moved or was lost: %v", env)
+	}
+}
+
+func mustRun(t *testing.T, in string) map[string]interface{} {
+	t.Helper()
+	out, _ := runWithGate(t, in)
+	return out
+}
+
+// TestMergeKey_RewriteAloneFlattensToo pins the call on the write path. The gate
+// normally runs first and flattens the same node, so this is the only thing that
+// distinguishes the two call sites — and ModifyComposeForAgent is exported and
+// called directly, including from enterprise, without the gate in front of it.
+func TestMergeKey_RewriteAloneFlattensToo(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(`x-common: &common
+  networks:
+    - mynet
+networks:
+  mynet:
+services:
+  app:
+    <<: *common
+    image: alpine:3.21
+`), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Deliberately no findContainerInServices call.
+	if err := idc.ModifyComposeForAgent(&compose, buildAgentOpts(), "app"); err != nil {
+		t.Fatalf("ModifyComposeForAgent: %v", err)
+	}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	app := mergeApp(t, out)
+	if app["networks"] != nil {
+		t.Errorf("the inherited networks survived next to network_mode=%v; compose "+
+			"rejects that pair:\n%s", app["network_mode"], data)
+	}
+}
+
+// TestMergeKey_MaterialisedValuesCarryNoAnchor pins the order of the two passes.
+//
+// A fragment may anchor a value inside itself, and the materialised copy carries
+// that anchor — a SECOND definition of the same name, where a later `*ref` binds
+// to whichever the parser saw last. flattenMergeKeys does not strip it itself;
+// detachSubtree clears every anchor in the subtree and runs immediately after,
+// which is precisely why flattening comes first. Swap the two and this fails.
+func TestMergeKey_MaterialisedValuesCarryNoAnchor(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(`x-common: &common
+  environment: &shared
+    - MINE=1
+services:
+  app:
+    <<: *common
+    image: alpine:3.21
+`), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := idc.ModifyComposeForAgent(&compose, buildAgentOpts(), "app"); err != nil {
+		t.Fatalf("ModifyComposeForAgent: %v", err)
+	}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if n := strings.Count(string(data), "&shared"); n != 1 {
+		t.Errorf("the anchor is defined %d times; the materialised copy kept the "+
+			"one the fragment owns:\n%s", n, data)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+}
+
+// TestMergeKey_EveryMergeKeyIsConsumed pins that a second `<<` is not skipped.
+//
+// Two `<<` keys in one mapping is not legal YAML and docker compose rejects the
+// file — but decoding into a yaml.Node accepts it, which is the only reason
+// keploy sees it at all. Consuming only the first leaves whatever the second
+// brings in invisible to keploy's writers, which is this function's entire bug
+// class reappearing in a rarer file: here the inherited `networks:` would
+// survive next to the `network_mode:` keploy adds, and compose rejects that pair.
+func TestMergeKey_EveryMergeKeyIsConsumed(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(`x-first: &first
+  working_dir: /first
+x-second: &second
+  working_dir: /second
+  networks:
+    - mynet
+  user: someone
+networks:
+  mynet:
+services:
+  app:
+    <<: *first
+    <<: *second
+    image: alpine:3.21
+`), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := idc.ModifyComposeForAgent(&compose, buildAgentOpts(), "app"); err != nil {
+		t.Fatalf("ModifyComposeForAgent: %v", err)
+	}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	app := mergeApp(t, out)
+	// Both define working_dir, so this also pins the precedence BETWEEN merge
+	// keys: the earlier one wins, matching the rule inside a single
+	// `<<: [*a, *b]`. With a disjoint fixture the order is unobservable.
+	if app["working_dir"] != "/first" {
+		t.Errorf("working_dir is %v; the earlier merge key must win", app["working_dir"])
+	}
+	if app["user"] != "someone" {
+		t.Errorf("the second merge key was skipped: %v", app["user"])
+	}
+	if app["networks"] != nil {
+		t.Errorf("networks inherited through the second merge key survived next to "+
+			"network_mode=%v; compose rejects that pair: %v",
+			app["network_mode"], app["networks"])
+	}
+	if strings.Contains(string(data), "<<:") {
+		t.Errorf("a merge key was left in the generated file:\n%s", data)
+	}
+}
+
+// TestMergeKey_NestedMergeIsNotLeftOnTheService pins the skip that keeps a `<<`
+// from a nested fragment out of the materialised keys.
+//
+// Without it the app gains a `<<` of its own, and compose re-merges that
+// fragment when it loads the generated file — AFTER keploy's deletes — bringing
+// `networks:` back next to the `network_mode:` keploy added. That is this
+// function's entire bug class, reintroduced by the fix for it.
+//
+// It has to run without the gate: the gate flattens too, and a second pass
+// silently cleans up the stray key, which is why every other fixture misses this.
+func TestMergeKey_NestedMergeIsNotLeftOnTheService(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(`x-base: &base
+  networks:
+    - mynet
+x-mid: &mid
+  <<: *base
+  working_dir: /mid
+networks:
+  mynet:
+services:
+  app:
+    <<: *mid
+    image: alpine:3.21
+`), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Deliberately no findContainerInServices call — one flatten only.
+	if err := idc.ModifyComposeForAgent(&compose, buildAgentOpts(), "app"); err != nil {
+		t.Fatalf("ModifyComposeForAgent: %v", err)
+	}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("generated compose does not load: %v\n%s", err, data)
+	}
+	app := mergeApp(t, out)
+	if app["networks"] != nil {
+		t.Errorf("networks came back through a merge key left on the app, next to "+
+			"network_mode=%v: %v", app["network_mode"], app["networks"])
+	}
+	if app["working_dir"] != "/mid" {
+		t.Errorf("the nested fragment's own key was lost: %v", app["working_dir"])
+	}
+}
+
+// TestMergeKey_UnmergeableValueIsLeftForComposeToReject covers a `<<` naming
+// something that is not a mapping. go-yaml rejects it with "map merge requires
+// map or sequence of maps as the value", so docker compose does too.
+//
+// Consuming it would delete the key and hand back a file that loads, hiding an
+// error the user needs to see — the same principle ensureMapping states for a
+// populated section it declines to reshape.
+func TestMergeKey_UnmergeableValueIsLeftForComposeToReject(t *testing.T) {
+	for _, tc := range []struct{ name, frag string }{
+		{"null fragment", "x-bad: &bad"},
+		{"scalar fragment", "x-bad: &bad just-a-string"},
+		{"sequence of scalars", "x-bad: &bad [1, 2]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+			var compose Compose
+			if err := yaml.Unmarshal([]byte(tc.frag+`
+services:
+  app:
+    <<: *bad
+    image: alpine:3.21
+`), &compose); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if err := idc.ModifyComposeForAgent(&compose, buildAgentOpts(), "app"); err != nil {
+				t.Fatalf("ModifyComposeForAgent: %v", err)
+			}
+			data, err := idc.MarshalCompose(&compose)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var out map[string]interface{}
+			err = yaml.Unmarshal(data, &out)
+			if err == nil {
+				t.Errorf("keploy consumed a merge key docker compose rejects, so the "+
+					"generated file loads and the user never sees the error:\n%s", data)
+			} else if !strings.Contains(err.Error(), "map merge requires") {
+				t.Errorf("unexpected failure: %v", err)
+			}
+		})
+	}
+}
+
+// TestMergeKey_AQuotedKeyIsNotAMergeKey pins the tag check. `"<<": value` is a
+// plain string key that go-yaml keeps verbatim; matching on Value alone would
+// silently delete it.
+func TestMergeKey_AQuotedKeyIsNotAMergeKey(t *testing.T) {
+	// The value must be a MAPPING to discriminate. With a scalar, dropping the
+	// tag check still leaves the key in place — it takes the unmergeable path
+	// and is kept for compose to reject — so the fixture proves nothing.
+	app := mergeApp(t, mustRun(t, `services:
+  app:
+    "<<":
+      kept: verbatim
+    image: alpine:3.21
+`))
+	held, _ := app["<<"].(map[string]interface{})
+	if held == nil || held["kept"] != "verbatim" {
+		t.Errorf("a quoted key that merely reads like a merge key was consumed as "+
+			"one, and its contents were spliced onto the service: %v", app)
+	}
+	if app["kept"] != nil {
+		t.Errorf("the quoted key's contents leaked onto the service: %v", app["kept"])
+	}
+}
+
+// TestMergeKey_InheritedContainerNameIsFound covers the one member of this bug
+// class that fails loudly: selection runs before anything can be flattened, so
+// an inherited container_name was invisible and keploy aborted with "failed to
+// find target service" on a file docker compose accepts.
+func TestMergeKey_InheritedContainerNameIsFound(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	const in = `x-naming: &naming
+  container_name: myapp
+services:
+  svc:
+    <<: *naming
+    image: alpine:3.21
+`
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, _, _, found := idc.findContainerInServices(&compose, "myapp"); !found {
+		t.Errorf("the gate did not find the service by its inherited container_name")
+	}
+	var second Compose
+	if err := yaml.Unmarshal([]byte(in), &second); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, _, err := idc.findServiceNodeAndName(&second, "myapp"); err != nil {
+		t.Errorf("findServiceNodeAndName: %v", err)
+	}
+}
+
+// TestMergeKey_InheritedDNSAndDependsOnAreHandled covers the two keys keploy
+// MOVES and REWRITES rather than appends to, reached through a merge.
+func TestMergeKey_InheritedDNSAndDependsOnAreHandled(t *testing.T) {
+	out := mustRun(t, `x-common: &common
+  dns:
+    - 1.1.1.1
+  depends_on:
+    - db
+services:
+  app:
+    <<: *common
+    image: alpine:3.21
+  db:
+    image: alpine:3.21
+`)
+	app := mergeApp(t, out)
+	if app["dns"] != nil {
+		t.Errorf("the inherited dns stayed on the app; it shares keploy-agent's "+
+			"netns, so compose rejects dns next to network_mode: %v", app["dns"])
+	}
+	svcs, _ := out["services"].(map[string]interface{})
+	agent, _ := svcs["keploy-agent"].(map[string]interface{})
+	if agent["dns"] == nil {
+		t.Errorf("dns was not moved onto keploy-agent, which owns the namespace: %v", agent)
+	}
+	deps, _ := app["depends_on"].(map[string]interface{})
+	if deps["db"] == nil {
+		t.Errorf("the inherited dependency was lost: %v", deps)
+	}
+	if deps["keploy-agent"] == nil {
+		t.Errorf("the keploy-agent gate is missing: %v", deps)
+	}
+}
+
+// TestMergeKey_EveryMergeInsideAFragmentIsFollowed is the nested counterpart of
+// TestMergeKey_EveryMergeKeyIsConsumed. A fragment carrying two `<<` keys is the
+// same invalid-but-parseable shape, and stopping at the first silently drops
+// everything the second brings in.
+func TestMergeKey_EveryMergeInsideAFragmentIsFollowed(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(`x-one: &one
+  working_dir: /one
+x-two: &two
+  user: someone
+x-mid: &mid
+  <<: *one
+  <<: *two
+services:
+  app:
+    <<: *mid
+    image: alpine:3.21
+`), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := idc.ModifyComposeForAgent(&compose, buildAgentOpts(), "app"); err != nil {
+		t.Fatalf("ModifyComposeForAgent: %v", err)
+	}
+	data, err := idc.MarshalCompose(&compose)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// The document cannot be decoded into a map: `x-mid` still carries the
+	// duplicate `<<` the user wrote, and keploy does not repair the user's
+	// fragment. Read the app service off the node tree instead.
+	keys := generatedServiceKeys(t, data, "app")
+	if keys["working_dir"] != "/one" {
+		t.Errorf("the first nested merge was lost: %q", keys["working_dir"])
+	}
+	// The discriminating assertion: `user` is reachable ONLY through the second
+	// nested merge. Stopping at the first drops it silently — the app then runs
+	// as a different user than the compose file says.
+	if keys["user"] != "someone" {
+		t.Errorf("a key reached only through the SECOND nested merge was lost: %q",
+			keys["user"])
+	}
+	if keys["network_mode"] != "service:keploy-agent" {
+		t.Errorf("the app was not wired to the agent: %q", keys["network_mode"])
+	}
+}
+
+// generatedServiceKeys reads one service's explicit keys straight off the node
+// tree of a generated file, for fixtures whose document cannot be decoded into a
+// map because the USER's own fragment is invalid.
+func generatedServiceKeys(t *testing.T, data []byte, service string) map[string]string {
+	t.Helper()
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("generated compose does not parse: %v\n%s", err, data)
+	}
+	root := doc.Content[0]
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value != "services" {
+			continue
+		}
+		svcs := root.Content[i+1]
+		for j := 0; j+1 < len(svcs.Content); j += 2 {
+			if svcs.Content[j].Value != service {
+				continue
+			}
+			out := map[string]string{}
+			svc := svcs.Content[j+1]
+			for k := 0; k+1 < len(svc.Content); k += 2 {
+				out[svc.Content[k].Value] = svc.Content[k+1].Value
+			}
+			return out
+		}
+	}
+	t.Fatalf("service %q not found in the generated file:\n%s", service, data)
+	return nil
+}

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -514,17 +514,15 @@ func (idc *Impl) findContainerInServices(compose *Compose, containerName string)
 		serviceName := serviceNameNode.Value
 
 		// Check for explicit container_name using the same pattern as existing functions
-		var containerNameMatch bool
-		for j := 0; j < len(serviceContentNode.Content)-1; j++ {
-			if serviceContentNode.Content[j].Kind == yaml.ScalarNode && serviceContentNode.Content[j].Value == "container_name" &&
-				aliasTarget(serviceContentNode.Content[j+1]).Value == containerName {
-				containerNameMatch = true
-				break
-			}
-		}
+		cn := serviceKeyThroughMerge(serviceContentNode, "container_name")
+		containerNameMatch := cn != nil && cn.Value == containerName
 
 		// If explicit container_name matches or service name matches, extract networks and ports
 		if containerNameMatch || serviceName == containerName {
+			// `ports:` and `networks:` are routinely put in a shared `x-*`
+			// fragment. Read off the unmerged node they come back empty, and the
+			// app is published on nothing and joins the wrong network.
+			idc.flattenMergeKeys(serviceContentNode)
 			networks := idc.extractServiceNetworks(serviceContentNode, serviceName)
 			ports := idc.extractServicePorts(serviceContentNode)
 			return networks, ports, serviceName, true
@@ -1205,8 +1203,8 @@ func (idc *Impl) AddKeployAgentToCompose(compose *Compose, opts models.SetupOpti
 		}
 		svc := compose.Services.Content[i+1]
 		for j := 0; j+1 < len(svc.Content); j += 2 {
-			if svc.Content[j].Value == "container_name" &&
-				aliasTarget(svc.Content[j+1]).Value == "keploy-agent" {
+			if cn := serviceKeyThroughMerge(svc, "container_name"); cn != nil &&
+				cn.Value == "keploy-agent" {
 				return fmt.Errorf("service %q already uses container_name "+
 					"\"keploy-agent\"; rename it so keploy can add its own",
 					compose.Services.Content[i].Value)
@@ -1253,16 +1251,14 @@ func (idc *Impl) findServiceNodeAndName(compose *Compose, appIdentifier string) 
 			return serviceContentNode, serviceName, nil
 		}
 
-		// Check 2: Does the container_name match?
-		for j := 0; j < len(serviceContentNode.Content)-1; j += 2 {
-			if serviceContentNode.Content[j].Value == "container_name" {
-				// `container_name: *n` is legal; matching on the alias node's own
-				// Value compares against the anchor NAME, so the lookup misses and
-				// keploy aborts with "failed to find target service".
-				if aliasTarget(serviceContentNode.Content[j+1]).Value == appIdentifier {
-					return serviceContentNode, serviceName, nil
-				}
-			}
+		// Check 2: Does the container_name match? Read through an alias and
+		// through `<<`: on the alias node's own Value the comparison is against
+		// the anchor NAME, and an inherited container_name is not in Content at
+		// all -- either way the lookup misses and keploy aborts with "failed to
+		// find target service" on a file docker compose accepts.
+		if cn := serviceKeyThroughMerge(serviceContentNode, "container_name"); cn != nil &&
+			cn.Value == appIdentifier {
+			return serviceContentNode, serviceName, nil
 		}
 	}
 	return nil, "", fmt.Errorf("service not found")
@@ -1283,6 +1279,14 @@ func (idc *Impl) ModifyComposeForAgent(compose *Compose, opts models.SetupOption
 	// sections keploy appends to need the same treatment, one node deep: it adds
 	// a key to `services:` and a volume to `volumes:`, and an anchored section
 	// shared with, say, `networks: *v` would carry those into it.
+	// Before detaching: materialise anything the service inherits through `<<`,
+	// so the writers below see real keys and detach sees the final subtree.
+	if n := idc.flattenMergeKeys(targetServiceNode); n > 0 {
+		idc.logger.Debug("materialised keys the app service inherits through a "+
+			"YAML merge key, so keploy's edits apply to them",
+			zap.Int("keys", n), zap.String("service", serviceName))
+	}
+
 	roots := compose.documentRoots()
 	owned := map[*yaml.Node]bool{}
 	collectNodes(targetServiceNode, owned)
@@ -1670,6 +1674,208 @@ func (idc *Impl) addTopLevelVolume(compose *Compose, volumeName string) {
 		&yaml.Node{Kind: yaml.ScalarNode, Value: volumeName},
 		&yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{}}, // {}
 	)
+}
+
+// flattenMergeKeys materialises `<<:` into explicit keys on a service node, so
+// the rest of this file can treat it as an ordinary mapping.
+//
+// keploy's writers all scan Content for a literal key name, and a key inherited
+// through a merge is not there -- it lives in the fragment `<<` names. Three
+// separate things went wrong as a result, on a file docker compose accepts:
+//
+//   - `removeServiceProperty(app, "networks")` removed nothing, so the generated
+//     file carried the inherited `networks:` alongside the `network_mode:` keploy
+//     adds, and compose rejects that pair as mutually exclusive
+//   - `getOrCreateEnvNode` did not find the inherited `environment:`, so keploy
+//     appended a NEW one -- an explicit key overrides a merged key, so every
+//     variable the user had inherited was silently gone
+//   - the gate read no `ports:`, so keploy-agent published nothing on the app's
+//     behalf and the app was unreachable from the host
+//
+// Reading through the merge instead of materialising it would fix only the third:
+// a key that is inherited cannot be DELETED, which is what keploy needs to do to
+// `networks` and `ports`. YAML has no way to unset a merged key.
+//
+// Key and value are deep-cloned rather than referenced, for the same reason
+// detachSubtree copies: keploy edits what it takes, and the fragment belongs to
+// the user.
+//
+// A clone can carry an anchor the fragment defined, which would be a second
+// definition of that name. This does NOT strip it, because ModifyComposeForAgent
+// runs detachSubtree over the same subtree immediately afterwards and that
+// clears every anchor in it -- which is the reason flattening comes first there,
+// and a test pins that order.
+//
+// The other caller, the read gate, does NOT detach, so a service it flattens can
+// carry a duplicate anchor until the rewrite runs. That is fine only because
+// nothing writes a compose file off the gate alone; a caller that did would have
+// to detach itself.
+//
+// Precedence follows the YAML merge spec: a key the node states explicitly wins
+// over any merged one, and within `<<: [*a, *b]` the earlier entry wins. Merges
+// nested inside a merged fragment are followed too.
+//
+// Idempotent: it removes the `<<` key it consumed, so a second call does nothing.
+func (idc *Impl) flattenMergeKeys(n *yaml.Node) int {
+	// The Kind check states the contract rather than defending a known failure:
+	// no test distinguishes it, because the scan below finds no `<<` key on a
+	// scalar or a sequence and returns early anyway. It stays so that a future
+	// change to the scan cannot start rewriting Content on a node that does not
+	// hold key/value pairs.
+	if n == nil || n.Kind != yaml.MappingNode {
+		return 0
+	}
+
+	// Rebuilt without the `<<` entries: each is being replaced by what it stood
+	// for, and leaving one would re-merge the fragment over keploy's edits when
+	// compose loads the generated file.
+	present := map[string]bool{}
+	var mergeValues []*yaml.Node
+	kept := n.Content[:0]
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if isMergeKey(n.Content[i]) {
+			// EVERY merge key is consumed, not just the first.
+			//
+			// A mapping cannot legally define `<<` twice, and docker compose
+			// rejects such a file -- but decoding into a yaml.Node does not,
+			// which is how one reaches keploy at all. Consuming only the first
+			// would leave the keys the second brings in invisible to keploy's
+			// writers, which is exactly the bug this function exists to fix, just
+			// in a rarer file.
+			//
+			// Earlier wins between them, by analogy with `<<: [*a, *b]`. The spec
+			// states no rule here because the shape is invalid, and go-yaml's own
+			// decoder would do the opposite if it accepted it -- so this is a
+			// choice, not a standard being followed.
+			sources, usable := mergeSources(n.Content[i+1])
+			if !usable {
+				// go-yaml rejects this with "map merge requires map or sequence
+				// of maps as the value", so docker compose does too. Consuming it
+				// would delete the key and hand back a file that loads, hiding an
+				// error the user needs to see -- keep it, and say why.
+				idc.logger.Warn("a `<<:` merge key does not name a mapping, so keploy "+
+					"cannot apply what it inherits; docker compose will reject this "+
+					"file for the same reason",
+					zap.String("mergeShape", yamlKindName(n.Content[i+1].Kind)),
+					zap.String("resolvesTo", yamlKindName(resolvedKind(n.Content[i+1]))))
+				kept = append(kept, n.Content[i], n.Content[i+1])
+				continue
+			}
+			mergeValues = append(mergeValues, sources...)
+			continue
+		}
+		present[n.Content[i].Value] = true
+		kept = append(kept, n.Content[i], n.Content[i+1])
+	}
+	if len(mergeValues) == 0 {
+		return 0
+	}
+	n.Content = kept
+
+	added := 0
+	for _, src := range mergeValues {
+		for i := 0; i+1 < len(src.Content); i += 2 {
+			key := src.Content[i].Value
+			if key == "<<" || present[key] {
+				continue
+			}
+			present[key] = true
+			n.Content = append(n.Content,
+				cloneYAMLNode(src.Content[i]), cloneYAMLNode(src.Content[i+1]))
+			added++
+		}
+	}
+	return added
+}
+
+// mergeSources returns the mappings a `<<` value names, in precedence order.
+//
+// `<<: *a` is one mapping; `<<: [*a, *b]` is several, and the YAML spec gives
+// the EARLIER entry precedence -- the opposite of what "later overrides" reads
+// like, and the reason the caller records keys as it goes.
+//
+// A fragment may merge in turn, so its own `<<` is followed here rather than by
+// recursing into flattenMergeKeys, which would edit a node the user owns.
+func mergeSources(v *yaml.Node) ([]*yaml.Node, bool) {
+	var out []*yaml.Node
+	usable := true
+	var add func(*yaml.Node, int)
+	add = func(n *yaml.Node, depth int) {
+		if n == nil || depth > 16 {
+			usable = false
+			return
+		}
+		switch n.Kind {
+		case yaml.AliasNode:
+			add(n.Alias, depth+1)
+		case yaml.SequenceNode:
+			for _, e := range n.Content {
+				add(e, depth+1)
+			}
+		case yaml.MappingNode:
+			out = append(out, n)
+			// A fragment may merge in turn. Every `<<` inside one is followed,
+			// for the same reason the top level consumes every one: a key reached
+			// only through the second would otherwise stay invisible.
+			for i := 0; i+1 < len(n.Content); i += 2 {
+				if isMergeKey(n.Content[i]) {
+					add(n.Content[i+1], depth+1)
+				}
+			}
+		default:
+			// A null, a scalar, or anything else that cannot be merged.
+			usable = false
+		}
+	}
+	add(v, 0)
+	return out, usable
+}
+
+// serviceKeyThroughMerge finds a key on a service, following `<<` but modifying
+// nothing.
+//
+// The scans that SELECT the app service run before keploy has decided to touch
+// the file, and they cannot flatten first: flattening is keyed on having already
+// found the service. An inherited `container_name` was therefore invisible to
+// selection, and keploy aborted outright with "failed to find target service" on
+// a compose file docker accepts -- the one member of this bug class that fails
+// loudly rather than silently.
+func serviceKeyThroughMerge(service *yaml.Node, key string) *yaml.Node {
+	if service == nil || service.Kind != yaml.MappingNode {
+		return nil
+	}
+	var merges []*yaml.Node
+	for i := 0; i+1 < len(service.Content); i += 2 {
+		if isMergeKey(service.Content[i]) {
+			merges = append(merges, service.Content[i+1])
+			continue
+		}
+		// An explicit key wins over anything inherited.
+		if service.Content[i].Value == key {
+			return aliasTarget(service.Content[i+1])
+		}
+	}
+	for _, m := range merges {
+		sources, _ := mergeSources(m)
+		for _, src := range sources {
+			for i := 0; i+1 < len(src.Content); i += 2 {
+				if src.Content[i].Value == key {
+					return aliasTarget(src.Content[i+1])
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// isMergeKey reports whether a key node is the YAML merge key rather than a
+// string that happens to read like one.
+//
+// `<<: *a` carries the `!!merge` tag; `"<<": *a` is a plain `!!str` that go-yaml
+// keeps as an ordinary key. Matching on Value alone would silently delete that
+// key -- bizarre input, but deleting a user's data over it is not defensible.
+func isMergeKey(key *yaml.Node) bool {
+	return key.Value == "<<" && key.Tag == "!!merge"
 }
 
 // detachSubtree makes every node in a subtree safe for keploy to edit in place,


### PR DESCRIPTION
`<<: *common` is how the compose spec says to reuse configuration, and keploy could not see through it.

Every writer in `docker.go` scans a service mapping's `Content` for a literal key name. A key inherited through a merge key **is not there** — it lives in the fragment. So on a file `docker compose` accepts, three separate things went wrong at once, and none of them said anything:

```yaml
x-common: &common
  environment: [MINE=1]
  networks: [mynet]
  ports: ["8080:8080"]
services:
  app:
    <<: *common
    image: alpine:3.21
```

| | before | after |
|---|---|---|
| `ports` seen by the gate | `[]` — keploy-agent publishes on the app's behalf under `network_mode: service:keploy-agent`, so the app was **unreachable from the host** | `["8080:8080"]` |
| `environment` | keploy appended a *new* `environment:`, and an explicit key overrides a merged one — **`MINE=1` silently gone** | `MINE=1` kept, keploy's CA added |
| `networks` | `removeServiceProperty` removed nothing, so the file carried `networks:` **next to** the `network_mode:` keploy adds, which compose rejects as mutually exclusive | removed |

---

## Why read-through does not work

The obvious fix is to look up a key through the merge instead of materialising it. That fixes only the third row. keploy has to **delete** `networks` and `ports`, and YAML has no way to unset an inherited key — the only way to override one is to state it explicitly, which is materialisation of that key anyway.

`flattenMergeKeys` copies what `<<` names onto the service and drops the merge key, before anything else runs. Precedence follows the spec: an explicit key beats a merged one, the **earlier** entry of `<<: [*a, *b]` wins, and a merge nested inside a fragment is followed. Verified differentially against go-yaml's own decoder on nine shapes, including the depth-first ordering of a nested merge inside a sequence entry.

Values are deep-cloned, so keploy's deletes and appends cannot reach the fragment or any sibling that merges it. That is not defensive: the whole point of a fragment is that it is shared.

## Selection is the exception, and it failed loudest

The scans that *select* the app service run before there is a service to flatten — flattening is keyed on having already found it. So an inherited `container_name` was invisible to selection and keploy aborted outright:

```
failed to find target service 'myapp': service not found
```

on a compose file docker accepts. That path reads through the merge without mutating anything, since it runs before keploy has decided to touch the file at all.

## Two deliberate refusals

**A `<<` naming something that cannot be merged is left where it is.** go-yaml rejects `<<: *scalar` with `map merge requires map or sequence of maps as the value`, so compose does too. Consuming it would delete the key and hand back a file that loads, hiding an error the user needs to see — the same principle `ensureMapping` already states for a populated section it declines to reshape. It is kept, and logged.

**A quoted `"<<"` is not a merge key.** It carries `!!str`, and go-yaml keeps it as an ordinary key; only `!!merge` is the real thing. Matching on spelling alone would silently delete a user's data over a bizarre but legal key.

One consequence worth naming: two `<<` keys in one mapping is invalid YAML, and decoding into a map rejects it — but decoding into a `yaml.Node` does not, which is the only reason keploy sees it. All of them are consumed, because consuming only the first leaves the second's keys invisible, which is this PR's entire bug class reappearing in a rarer file. Earlier-wins between them is a **choice by analogy**, not a spec rule: the spec has none here, and go-yaml would do the opposite if it accepted the shape at all. The code says so.

## Verification

Every behaviour is pinned by a test that fails when it is reverted. **16 mutations, 16 killed.**

Two fixtures needed a second attempt to discriminate at all, and both say so in the test file — worth knowing before editing them:

- the quoted-`<<` test needs a **mapping** value. With a scalar, dropping the tag check still leaves the key in place, because it then takes the unmergeable path and is kept for compose to reject — so the fixture proves nothing.
- the nested duplicate-`<<` test needs a key keploy does **not** delete. With `networks:` the `break` mutation survives: the key is neither materialised nor deleted, so no conflict appears and the test passes while the user's data is gone.

One test cannot decode the generated file into a map at all — the user's own fragment carries the duplicate `<<` and keploy does not repair it — so it reads the app service off the node tree instead.

`gofmt`, `go vet`, `go build ./...` clean; `pkg/platform/docker` and `pkg/client/app` green, including `-race`. A compose file with no merge key is unchanged.
