### PR TITLE
fix(docker): wire the app service when its container_name is an alias

### DIFF
--- a/.github/workflows/golang_wsl.yml
+++ b/.github/workflows/golang_wsl.yml
@@ -89,10 +89,25 @@ jobs:
             echo "debugfs is already mounted"
           fi
           # Verify the mount
-          mount | grep debugfs || echo "debugfs not found in mount output"  
+          mount | grep debugfs || echo "debugfs not found in mount output"
+
+      - name: Install WSL packages
+        shell: wsl-bash {0}
+        run: |
+          set -euo pipefail
+          # GitHub-hosted runners live in Azure, and archive.ubuntu.com is served
+          # from outside it -- measured at 196 kB/s from this lane, which is slow
+          # enough that `timeout 600` kills apt mid-download (exit 124) with no
+          # hint as to why. azure.archive.ubuntu.com is the in-region mirror.
+          sudo sed -i \
+            -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+            -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list
+          # Once, not four times. golang-go alone pulls ~154 MB of gcc, and every
+          # repeat also re-fetched the ~47 MB of package lists.
           sudo timeout 600 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y
           sudo timeout 600 apt-get install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y golang-go curl git ca-certificates jq
- 
+
       - name: Prepare binaries for WSL
         shell: bash
         run: |
@@ -115,20 +130,10 @@ jobs:
             | xargs -0 -I{} sed -i 's/\r$//' "{}"
           chmod -R a+x "$WS/.github/workflows/test_workflow_scripts"
 
-      - name: Install dependencies in WSL
-        shell: wsl-bash {0}
-        run: |
-          set -euo pipefail
-          sudo timeout 600 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y
-          sudo timeout 600 apt-get install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y golang-go curl git ca-certificates
-
-          
       - name: Prepare CA tools in WSL
         shell: wsl-bash {0}
         run: |
           set -euo pipefail
-          sudo timeout 600 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y
-          sudo timeout 600 apt-get install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y ca-certificates jq
           # Run Debian CA refresh (ok if no custom certs yet)
           sudo update-ca-certificates || true
           # Provide a no-op for RHEL's tool to avoid exit 127 if Keploy probes it
@@ -148,7 +153,6 @@ jobs:
           export RECORD_BIN="$WS/.wsl-bin/keploy_record"
           export REPLAY_BIN="$WS/.wsl-bin/keploy_replay"
           chmod +x "$RECORD_BIN" "$REPLAY_BIN" || true
-          sudo timeout 600 apt-get install -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o DPkg::Lock::Timeout=120 -y golang-go curl git ca-certificates
           cd "$WS/samples-go/${{ matrix.app.path }}"
           # Source the existing Linux bash script under WSL
           source "$WS/.github/workflows/test_workflow_scripts/golang/${{ matrix.app.script_dir }}/golang-linux.sh"

--- a/pkg/platform/docker/compose_services_alias_test.go
+++ b/pkg/platform/docker/compose_services_alias_test.go
@@ -737,3 +737,194 @@ services:
 		})
 	}
 }
+
+// TestAddKeployAgent_RefusesACollisionReachedThroughAnAlias covers the shape
+// that walked straight past the guard.
+//
+// `services: {x: *frag}` is an AliasNode, whose Content is nil — and the scan
+// used to sit inside a loop over that Content, so it never executed and the
+// check was skipped.
+//
+// What that costs is NOT a rejected file. "keploy-agent" is keploy's internal
+// service KEY; the agent's actual container_name is a randomised
+// `keploy-v3-<rand>`, so docker sees no clash and accepts the output. The damage
+// is silent: findServiceNodeAndName("keploy-agent") matches on container_name
+// and reaches the user's service first, so the app's `dns` is MOVED onto that
+// unrelated service — overwriting its own — while the agent that owns the
+// network namespace gets none. See TestAgentCollision_TheDamageItPrevents.
+//
+// These subtests call AddKeployAgentToCompose directly, so nothing has resolved
+// anything and either ordering reproduces the bug. Ordering is load-bearing only
+// through the full pipeline, which the pipeline subtest below covers.
+func TestAddKeployAgent_RefusesACollisionReachedThroughAnAlias(t *testing.T) {
+	for _, tc := range []struct{ name, in string }{
+		{"fragment claims the name", `x-frag: &frag
+  image: alpine:3.21
+  container_name: keploy-agent
+services:
+  app:
+    image: alpine:3.21
+  x: *frag
+`},
+		{"fragment inherits the name through a merge key", `x-naming: &naming
+  container_name: keploy-agent
+x-frag: &frag
+  image: alpine:3.21
+  <<: *naming
+services:
+  app:
+    image: alpine:3.21
+  x: *frag
+`},
+		// Not a regression test for THIS fix — the service is a real mapping, so
+		// the old loop ran and the value-side resolve from the previous commit
+		// already handled it. Kept for guard-path coverage of that mechanism.
+		{"container_name is itself an alias", `x-name: &agentname keploy-agent
+services:
+  app:
+    image: alpine:3.21
+  x:
+    image: alpine:3.21
+    container_name: *agentname
+`},
+		// The services MAPPING itself inherits the colliding service through a
+		// merge key, so a scan over its own Content sees only the key `<<`.
+		{"service inherited through a services-level merge key", `x-extra: &extra
+  legacy:
+    image: alpine:3.21
+    container_name: keploy-agent
+services:
+  <<: *extra
+  app:
+    image: alpine:3.21
+`},
+		// Same, colliding on the service KEY rather than container_name. Missing
+		// it is worse: keploy appends its own explicit `keploy-agent:` key, which
+		// wins over the merge, so the user's service silently disappears.
+		{"service KEY inherited through a services-level merge key", `x-extra: &extra
+  keploy-agent:
+    image: alpine:3.21
+services:
+  <<: *extra
+  app:
+    image: alpine:3.21
+`},
+		// The service key is itself an alias, so its own Value is the anchor name.
+		{"service key is an alias", `x-k: &k keploy-agent
+services:
+  app:
+    image: alpine:3.21
+  *k :
+    image: alpine:3.21
+`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+			var compose Compose
+			if err := yaml.Unmarshal([]byte(tc.in), &compose); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			err := idc.AddKeployAgentToCompose(&compose, buildAgentOpts())
+			if err == nil {
+				data, _ := idc.MarshalCompose(&compose)
+				t.Fatalf("the collision was not refused; keploy added a second "+
+					"service claiming container_name \"keploy-agent\" and docker "+
+					"will reject the file:\n%s", data)
+			}
+			// Either guard is a correct refusal here; they report different
+			// collisions (service key vs container_name) and word it differently.
+			// What matters is that the message names the clashing name and says
+			// what to do, rather than leaving the user with keploy's silent
+			// dns mis-wiring.
+			if !strings.Contains(err.Error(), "keploy-agent") ||
+				!strings.Contains(err.Error(), "rename") {
+				t.Errorf("the error does not name the problem: %v", err)
+			}
+		})
+	}
+}
+
+// TestAgentCollision_TheDamageItPrevents pins what the guard is actually for,
+// because the obvious answer is wrong.
+//
+// "keploy-agent" is keploy's internal service KEY. The agent's container_name is
+// opts.KeployContainer, a randomised `keploy-v3-<rand>` on every docker run — so
+// a user service named keploy-agent produces NO container-name clash and docker
+// accepts the generated file without complaint.
+//
+// The damage is in keploy's own lookup. findServiceNodeAndName("keploy-agent")
+// matches on container_name too and reaches the user's service first, so the
+// app's `dns` is MOVED onto an unrelated service — overwriting the dns that
+// service declared for itself — while the agent that owns the network namespace
+// gets none. A recording made this way is quietly wrong rather than absent.
+//
+// Driven through the full pipeline, which is also the only place the ordering
+// matters: the lookups that resolve service aliases in place stop as soon as
+// they find the app, so a colliding service declared AFTER it is still an
+// unexpanded alias when the guard runs.
+func TestAgentCollision_TheDamageItPrevents(t *testing.T) {
+	const in = `x-frag: &frag
+  image: alpine:3.21
+  container_name: keploy-agent
+  dns:
+    - 1.1.1.1
+services:
+  app:
+    image: alpine:3.21
+    dns:
+      - 8.8.8.8
+  x: *frag
+`
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(in), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Production-shaped: the agent's container_name is randomised, so there is
+	// no docker-level clash to save us.
+	opts := buildAgentOpts()
+	opts.KeployContainer = "keploy-v3-abc123"
+
+	// The gate runs first in production and resolves aliases as it goes — but it
+	// stops at the app, so `x` is untouched when the guard runs.
+	_, ports, _, _ := idc.findContainerInServices(&compose, "app")
+	opts.AppPorts = ports
+
+	err := idc.ModifyComposeForAgent(&compose, opts, "app")
+	if err == nil {
+		data, _ := idc.MarshalCompose(&compose)
+		t.Fatalf("the collision was accepted; the app's dns is now on an unrelated "+
+			"service and the agent has none:\n%s", data)
+	}
+	if !strings.Contains(err.Error(), "keploy-agent") {
+		t.Errorf("the error does not name the collision: %v", err)
+	}
+}
+
+// TestAddKeployAgent_ExplicitServiceOverridesAMergedCollision is the guard
+// against the guard over-firing. YAML merge precedence gives an explicitly
+// declared key priority over an inherited one, so a `legacy:` service written
+// out in full replaces the `legacy:` the fragment supplies — collision and all.
+// Refusing here would block a file that is perfectly fine.
+func TestAddKeployAgent_ExplicitServiceOverridesAMergedCollision(t *testing.T) {
+	idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+	var compose Compose
+	if err := yaml.Unmarshal([]byte(`x-extra: &extra
+  legacy:
+    image: alpine:3.21
+    container_name: keploy-agent
+services:
+  <<: *extra
+  legacy:
+    image: alpine:3.21
+    container_name: something-else
+  app:
+    image: alpine:3.21
+`), &compose); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := idc.AddKeployAgentToCompose(&compose, buildAgentOpts()); err != nil {
+		t.Errorf("refused a file whose explicit service overrides the merged "+
+			"collision: %v", err)
+	}
+}

--- a/pkg/platform/docker/compose_services_alias_test.go
+++ b/pkg/platform/docker/compose_services_alias_test.go
@@ -617,3 +617,123 @@ services:
 		t.Errorf("the user's own env var was lost: %v", env)
 	}
 }
+
+// TestServiceAlias_AliasedContainerNameIsWired is the regression test for the
+// loudest-silent failure in this family: keploy records nothing at all.
+//
+// `container_name: *appname` is legal compose, and findServiceNodeAndName
+// already matched it — but modifyAppServiceForKeploy's own scan required the
+// value to be a ScalarNode, so an alias missed and the entire wiring block was
+// skipped. No `pid:`, no `network_mode:`, no `depends_on:`, no CA variables: the
+// app runs completely uninstrumented and the recording comes back empty, with
+// nothing in the logs pointing at the compose file.
+//
+// The same scan stepped by ONE rather than by two, so it also matched
+// "container_name" sitting in VALUE position — wiring the wrong service. Both
+// shapes are in the table below.
+func TestServiceAlias_AliasedContainerNameIsWired(t *testing.T) {
+	for _, tc := range []struct{ name, in string }{
+		{"alias", `x-name: &appname myapp
+x-other: &othername notmyapp
+services:
+  decoy:
+    image: alpine:3.21
+    container_name: *othername
+  svc:
+    image: alpine:3.21
+    container_name: *appname
+    ports:
+      - "8080:8080"
+`},
+		// A companion that already passed before the fix, kept so the two shapes
+		// stay together. It does NOT pin the flatten ordering: serviceKeyThroughMerge
+		// reads through `<<` itself, so this passes with the flatten removed.
+		{"merge key", `x-naming: &naming
+  container_name: myapp
+services:
+  svc:
+    image: alpine:3.21
+    <<: *naming
+    ports:
+      - "8080:8080"
+`},
+		// The one combination neither this file nor compose_merge_key_test.go
+		// exercised: inherited through `<<` AND aliased on the far side.
+		{"merge key naming an aliased container_name", `x-name: &appname myapp
+x-naming: &naming
+  container_name: *appname
+services:
+  svc:
+    image: alpine:3.21
+    <<: *naming
+    ports:
+      - "8080:8080"
+`},
+		// The OTHER bug the same two lines fix. The old scan stepped by ONE, so
+		// it matched the literal string "container_name" in VALUE position when
+		// the next node happened to be the app's name — and keploy then wired
+		// this service and left the real app untouched.
+		{"container_name in value position", `services:
+  decoy:
+    image: alpine:3.21
+    command: container_name
+    myapp: whatever
+  svc:
+    image: alpine:3.21
+    container_name: myapp
+    ports:
+      - "8080:8080"
+`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			idc := &Impl{logger: zap.NewNop(), conf: &config.Config{}}
+			var compose Compose
+			if err := yaml.Unmarshal([]byte(tc.in), &compose); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			_, ports, _, found := idc.findContainerInServices(&compose, "myapp")
+			if !found {
+				t.Fatalf("the gate did not find the service")
+			}
+			opts := buildAgentOpts()
+			opts.AppPorts = ports
+			if err := idc.ModifyComposeForAgent(&compose, opts, "myapp"); err != nil {
+				t.Fatalf("ModifyComposeForAgent: %v", err)
+			}
+			data, err := idc.MarshalCompose(&compose)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var out map[string]interface{}
+			if err := yaml.Unmarshal(data, &out); err != nil {
+				t.Fatalf("generated compose does not load: %v\n%s", err, data)
+			}
+			svcs, _ := out["services"].(map[string]interface{})
+			svc, _ := svcs["svc"].(map[string]interface{})
+			if svc == nil {
+				t.Fatalf("service missing: %v", svcs)
+			}
+			if svc["network_mode"] != "service:keploy-agent" {
+				t.Errorf("network_mode=%v: the app never joins the agent's netns, so "+
+					"nothing is intercepted and the recording is empty", svc["network_mode"])
+			}
+			if svc["pid"] != "service:keploy-agent" {
+				t.Errorf("pid=%v", svc["pid"])
+			}
+			if svc["depends_on"] == nil {
+				t.Errorf("the app does not wait for keploy-agent to be healthy")
+			}
+			if svc["environment"] == nil {
+				t.Errorf("keploy's CA variables were not added")
+			}
+			// A service that merely HAS a container_name must not be adopted:
+			// without comparing the value, keploy wires whichever service it
+			// reaches first and the real app is left alone.
+			if decoy, _ := svcs["decoy"].(map[string]interface{}); decoy != nil {
+				if decoy["network_mode"] != nil || decoy["pid"] != nil {
+					t.Errorf("keploy wired the wrong service: %v", decoy)
+				}
+			}
+		})
+	}
+}

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -1188,27 +1188,38 @@ func (idc *Impl) AddKeployAgentToCompose(compose *Compose, opts models.SetupOpti
 	// A user service by that name is unusual but legal, and appending beside it
 	// produced a generated file that does not parse at all -- `mapping key
 	// "keploy-agent" already defined` -- reading as a keploy bug rather than the
-	// name collision it is. The container_name variant is worse than a duplicate
-	// key: findServiceNodeAndName matches on container_name too, so keploy would
-	// treat the USER's service as its agent and move the app's dns onto it, and
-	// compose rejects the file with `container name "keploy-agent" is already in
-	// use`.
+	// name collision it is.
+	//
+	// The container_name variant is worse, and not for the reason it looks like.
+	// "keploy-agent" is keploy's internal SERVICE KEY, not the agent's container
+	// name: opts.KeployContainer is a randomised `keploy-v3-<rand>` on every
+	// docker run, so there is no container-name clash and docker accepts the file
+	// happily. What breaks is the lookup -- findServiceNodeAndName("keploy-agent")
+	// matches on container_name too, and reaches the USER's service first. keploy
+	// then MOVES the app's `dns` onto that unrelated service, overwriting whatever
+	// dns it declared, while the agent that actually owns the network namespace
+	// gets none. Nothing errors; the recording is simply wrong.
 	//
 	// Checked before GenerateKeployAgentService so a doomed run does not first
 	// fire the enterprise compose hook.
-	for i := 0; i+1 < len(compose.Services.Content); i += 2 {
-		if compose.Services.Content[i].Value == "keploy-agent" {
+	for _, e := range effectiveServiceEntries(&compose.Services) {
+		// The key can be an alias too (`*k:` where `&k` is "keploy-agent"), in
+		// which case its own Value is the anchor name.
+		if aliasTarget(e.key).Value == "keploy-agent" {
 			return fmt.Errorf("the compose file already defines a service named " +
 				"\"keploy-agent\"; rename it so keploy can add its own")
 		}
-		svc := compose.Services.Content[i+1]
-		for j := 0; j+1 < len(svc.Content); j += 2 {
-			if cn := serviceKeyThroughMerge(svc, "container_name"); cn != nil &&
-				cn.Value == "keploy-agent" {
-				return fmt.Errorf("service %q already uses container_name "+
-					"\"keploy-agent\"; rename it so keploy can add its own",
-					compose.Services.Content[i].Value)
-			}
+		// `services: {x: *frag}` gives an AliasNode, whose Content is nil -- so
+		// the scan that used to sit here, wrapped in a loop over that empty
+		// Content, never ran and the guard was skipped entirely. It is reachable
+		// whenever the colliding service appears AFTER the app: the lookups that
+		// resolve aliases in place stop at the app, so nothing has expanded this
+		// one yet.
+		if cn := serviceKeyThroughMerge(aliasTarget(e.value), "container_name"); cn != nil &&
+			cn.Value == "keploy-agent" {
+			return fmt.Errorf("service %q already uses container_name "+
+				"\"keploy-agent\"; rename it so keploy can add its own",
+				aliasTarget(e.key).Value)
 		}
 	}
 
@@ -1833,6 +1844,63 @@ func mergeSources(v *yaml.Node) ([]*yaml.Node, bool) {
 	}
 	add(v, 0)
 	return out, usable
+}
+
+// serviceEntry is one key/value pair from the `services:` mapping.
+type serviceEntry struct{ key, value *yaml.Node }
+
+// effectiveServiceEntries lists every service the compose file declares,
+// including any inherited through a merge key ON THE SERVICES MAPPING ITSELF:
+//
+//	x-extra: &extra
+//	  legacy: {container_name: keploy-agent}
+//	services:
+//	  <<: *extra
+//	  app: {...}
+//
+// A scan that walks only the mapping's own Content sees the key `<<` and nothing
+// else, so `legacy` is invisible to it -- and the collision guard that exists to
+// catch exactly that name walks straight past.
+//
+// Explicit entries come first and win, matching YAML merge precedence, so a
+// caller that stops at the first match behaves the way the document reads.
+// Nothing here mutates: this runs before keploy has decided the file is usable.
+func effectiveServiceEntries(services *yaml.Node) []serviceEntry {
+	// No alias resolve here: the only caller checks `services:` is a mapping
+	// first, and resolveServiceAlias has already run on it. The Kind check states
+	// the contract for any future caller -- no test distinguishes it.
+	if services == nil || services.Kind != yaml.MappingNode {
+		return nil
+	}
+	var out []serviceEntry
+	var merges []*yaml.Node
+	seen := map[string]bool{}
+	for i := 0; i+1 < len(services.Content); i += 2 {
+		if isMergeKey(services.Content[i]) {
+			merges = append(merges, services.Content[i+1])
+			// Skipped rather than emitted: `<<` is not a service. Emitting it is
+			// inert for today's only caller, which compares names, but this
+			// function reads as "the services in this file" and a caller that
+			// iterated it would act on a service that does not exist.
+			continue
+		}
+		out = append(out, serviceEntry{services.Content[i], services.Content[i+1]})
+		seen[aliasTarget(services.Content[i]).Value] = true
+	}
+	for _, m := range merges {
+		sources, _ := mergeSources(m)
+		for _, src := range sources {
+			for i := 0; i+1 < len(src.Content); i += 2 {
+				name := aliasTarget(src.Content[i]).Value
+				if seen[name] {
+					continue
+				}
+				seen[name] = true
+				out = append(out, serviceEntry{src.Content[i], src.Content[i+1]})
+			}
+		}
+	}
+	return out
 }
 
 // serviceKeyThroughMerge finds a key on a service, following `<<` but modifying

--- a/pkg/platform/docker/docker.go
+++ b/pkg/platform/docker/docker.go
@@ -1354,17 +1354,21 @@ func (idc *Impl) modifyAppServiceForKeploy(compose *Compose, appContainerName st
 		serviceContentNode := resolveServiceAlias(compose.Services.Content[i+1])
 		serviceName := serviceNameNode.Value
 
-		// Check if this is the target app service
-		var isTargetService bool
-		for j := 0; j < len(serviceContentNode.Content)-1; j++ {
-			if serviceContentNode.Content[j].Kind == yaml.ScalarNode &&
-				serviceContentNode.Content[j].Value == "container_name" &&
-				serviceContentNode.Content[j+1].Kind == yaml.ScalarNode &&
-				serviceContentNode.Content[j+1].Value == appContainerName {
-				isTargetService = true
-				break
-			}
-		}
+		// Check if this is the target app service.
+		//
+		// Read through an alias and through `<<`. Requiring the value to be a
+		// ScalarNode is what made `container_name: *appname` miss: the match
+		// failed, the whole block below was skipped, and the service was left
+		// entirely unwired -- no `pid:`, no `network_mode:`, no `depends_on:`, no
+		// CA variables. keploy then records NOTHING, on a compose file docker
+		// accepts and which findServiceNodeAndName had already matched.
+		//
+		// The old scan also stepped by ONE rather than by two, so a service with
+		// the literal string "container_name" in VALUE position followed by a key
+		// equal to the app's name matched it -- and keploy wired that service
+		// instead of the app. Stepping by key/value pairs closes that too.
+		cn := serviceKeyThroughMerge(serviceContentNode, "container_name")
+		isTargetService := cn != nil && cn.Value == appContainerName
 
 		// If no explicit container_name, check service name
 		if !isTargetService && serviceName == appContainerName {


### PR DESCRIPTION
Three commits: two alias-blind spots in the compose rewriter that each end a recording badly, and the CI change that made this PR's own lanes able to pass.

---

## 1. The app service is never wired when its `container_name` is an alias

`container_name: *appname` is legal compose, and `findServiceNodeAndName` already matched it — but `modifyAppServiceForKeploy` ran its **own** scan and required the value node to be a `ScalarNode`. An alias is not, so the match failed and the entire wiring block was skipped:

```
gate found=true | network_mode=<nil> pid=<nil> depends_on=false env=false
```

No `pid:`, no `network_mode:`, no `depends_on:`, no CA variables. The app runs completely uninstrumented and **the recording comes back empty**, with nothing in the logs pointing near compose generation.

### A second bug in the same two lines

That scan stepped by **one** rather than two, so it also matched the literal string `container_name` in **value** position whenever the next node happened to be the app's name:

```yaml
services:
  decoy:
    command: container_name   # ← matched as a key…
    myapp: whatever           # ← …with this as its "value"
  svc:
    container_name: myapp     # the real app
```

keploy wired `decoy` and left the real app alone. This came out of review, not from me.

Both go away by reusing `serviceKeyThroughMerge`, which walks key/value **pairs** and reads through an alias and through `<<:`. The point is not just the alias: three paths select the app service — the ports/networks gate, `findServiceNodeAndName`, and this one — and until now the third used a different, hand-rolled predicate. Reverted, they disagree on four of ten real compose files.

## 2. The keploy-agent collision guard could not see an aliased service

The guard refuses to add keploy's agent when a user service already claims the name. `services: {x: *frag}` is an `AliasNode` whose `Content` is nil — and the scan sat inside a loop over that `Content`, so it never executed. It also read the services mapping directly, missing anything inherited by a `<<:` on the mapping itself.

Reachable by **document order**: the lookups that resolve service aliases in place return as soon as they find the app, so a colliding service declared *after* it is still an unexpanded alias when the guard runs.

**What that costs is not what the old comment claimed**, and the correction matters for anyone maintaining this. `keploy-agent` is keploy's internal **service key**; the agent's `container_name` is `opts.KeployContainer`, a randomised `keploy-v3-<rand>`. There is no container-name clash and docker accepts the file. The damage is silent — `findServiceNodeAndName("keploy-agent")` matches on `container_name` and reaches the **user's** service first:

```
app           container_name=<nil>             dns=<nil>       ← lost its DNS
x             container_name=keploy-agent      dns=[8.8.8.8]   ← received the app's
keploy-agent  container_name=keploy-v3-abc123  dns=<nil>       ← owns the netns, has none
```

The app's DNS is moved onto an unrelated service, that service's own `dns: [1.1.1.1]` is overwritten, and the namespace owner gets none. Both halves of the guard now read through an alias — key side as well as value side — and both consider services inherited through a services-level merge key. The key-collision variant was the worse one: keploy appends its own explicit `keploy-agent:` key, which wins over the merge, so **the user's service silently disappears**.

Explicit entries still win over merged ones, so a file whose own `legacy:` overrides an inherited colliding one is **not** refused.

## 3. The WSL lanes could not finish

Two of the three `http-pokeapi` WSL jobs failed with **exit code 124** — the `timeout 600` around apt, fired while still downloading. One sat nine minutes on `jammy/universe Packages [14.1 MB]`, the other six and a half on `gcc-11 [20.1 MB]`. keploy never ran in either.

Two causes:

- GitHub-hosted runners live in **Azure**, and `archive.ubuntu.com` is served from outside it. The job that *passed* on the same commit shows the margin: 47.7 MB at **196 kB/s**. The existing `Acquire::http::Timeout=30` does not help — it catches a *stalled* transfer, not a slow one.
- The lane installed the same packages **four times**, in four steps, each with its own `apt-get update`. `golang-go` alone pulls ~154 MB of gcc.

| | before | after |
|---|---|---|
| package-list fetch | 47.7 MB in 4m 3s (196 kB/s) | 50.1 MB in **6s** (9005 kB/s) |
| whole WSL job | 859s | **384s** |

Retries and timeouts are unchanged; with one pass against an in-region mirror, 600s stops being a ceiling anything realistic reaches.

---

## Verification

Every behaviour is pinned by a test that fails when its guard is reverted. **13 mutations across the two product fixes, all killed** — four of them only after a fixture was made able to discriminate:

- the **decoy** service in the container_name table: mutating the predicate to "match *any* `container_name`" passes on a single-service fixture;
- the **explicit-overrides-merged** test: without it, a mutation that lets merged entries shadow explicit ones survives, and the guard would refuse a valid file;
- the **services-level merge** fixtures: the collision is invisible to a scan over the mapping's own `Content`;
- the **pipeline** test: the direct-call tests reproduce the bug in either document order, so ordering is load-bearing only through the full path.

Two tests are deliberately labelled as *not* pinning this PR — one covers the previous commit's mechanism, and the `merge key` row passes either way. Leaving a passenger test dressed as a guard is how the collision hole survived in the first place.

`gofmt`, `go vet`, `go build ./...` clean; `pkg/platform/docker` and `pkg/client/app` green.
