### PR TITLE
fix(docker): read --name=/--network= and stop wiping the container name

### DIFF
--- a/cli/provider/cmd_test.go
+++ b/cli/provider/cmd_test.go
@@ -327,8 +327,8 @@ func TestResolveCommandType_NativeAcceptsAnyCommand(t *testing.T) {
 
 // Substring matching let "./run-docker.sh" past the docker-run guard — a
 // wrapper by any reading, and the naming convention a docker wrapper script
-// actually uses. Past the guard it fails much worse: ParseDockerCmd wipes the
-// user's --container-name and modifyDockerRun dies on the token count.
+// actually uses. Past the guard it fails much worse: ParseDockerCmd finds no
+// container name to work with and modifyDockerRun dies on the token count.
 func TestMentionsDockerBinary(t *testing.T) {
 	yes := []string{
 		"docker compose up",

--- a/cli/provider/core_service.go
+++ b/cli/provider/core_service.go
@@ -81,6 +81,64 @@ func Get(ctx context.Context, cmd string, cfg *config.Config, logger *zap.Logger
 
 }
 
+// resolveDockerNames settles which container and network keploy will act on,
+// and reports the outcome at a severity that matches it.
+//
+// A parse that produced nothing must never overwrite a value the user gave
+// through --container-name/--network-name or keploy.yml. It used to: the
+// assignment was unconditional, so a command keploy could not parse left the
+// container name empty, and everything downstream - the name-conflict
+// pre-clean, teardown, and app-log capture - then operated on "" and silently
+// did nothing.
+//
+// A parse that DID produce a value wins over the flag, because for docker-run
+// and docker-start the command is ground truth: docker names the container
+// from the command, so instrumenting anything else would target a container
+// that was never created. The parse is usually right rather than provably
+// right - it reads the leftmost --name, which a container's own arguments can
+// still shadow - so a disagreement is warned about rather than silently
+// applied.
+//
+// Severity is decided AFTER applying, against what was actually resolved.
+// ParseDockerCmd reports a missing --network as an error even when the
+// container parsed perfectly, which is the ordinary default-bridge shape; if
+// the level were chosen before applying, every such run would print an ERROR
+// naming the container it had in fact just resolved. Several e2e lanes fail
+// the build on any ERROR line.
+func resolveDockerNames(logger *zap.Logger, c *config.Config, cont, net string, err error) {
+	if cont != "" {
+		if c.ContainerName != "" && c.ContainerName != cont {
+			logger.Warn("given app container differs from the one named in the docker command; using the command's",
+				zap.String("given", c.ContainerName), zap.String("parsed", cont))
+		}
+		c.ContainerName = cont
+	}
+
+	if net != "" {
+		if c.NetworkName != "" && c.NetworkName != net {
+			logger.Warn("given docker network differs from the one named in the docker command; using the command's",
+				zap.String("given", c.NetworkName), zap.String("parsed", net))
+		}
+		c.NetworkName = net
+	}
+
+	if err == nil {
+		return
+	}
+
+	switch {
+	case c.ContainerName == "":
+		utils.LogError(logger, err, "failed to resolve the app container from the docker command", zap.String("cmd", c.Command))
+	case cont == "":
+		logger.Warn("could not read a container name out of the docker command; using the one that was provided",
+			zap.String("containerName", c.ContainerName), zap.Error(err))
+	default:
+		// The container resolved and only the network did not. Nothing reads
+		// the network name today, so this is not worth the user's attention.
+		logger.Debug("docker command parsed without a network name", zap.String("containerName", c.ContainerName), zap.Error(err))
+	}
+}
+
 func GetCommonServices(ctx context.Context, c *config.Config, logger *zap.Logger) (*CommonInternalService, error) {
 
 	app.HookImpl = app.NewHooks(logger)
@@ -100,18 +158,7 @@ func GetCommonServices(ctx context.Context, c *config.Config, logger *zap.Logger
 		if utils.CmdType(c.CommandType) != utils.DockerCompose {
 			cont, net, err := docker.ParseDockerCmd(c.Command, utils.CmdType(c.CommandType), client)
 			logger.Debug("container and network parsed from command", zap.String("container", cont), zap.String("network", net), zap.String("command", c.Command))
-			if err != nil {
-				utils.LogError(logger, err, "failed to parse container name from given docker command", zap.String("cmd", c.Command))
-			}
-			if c.ContainerName != "" && c.ContainerName != cont {
-				logger.Debug(fmt.Sprintf("given app container:(%v) is different from parsed app container:(%v), taking parsed value", c.ContainerName, cont))
-			}
-			c.ContainerName = cont
-
-			if c.NetworkName != "" && c.NetworkName != net {
-				logger.Debug(fmt.Sprintf("given docker network:(%v) is different from parsed docker network:(%v), taking parsed value", c.NetworkName, net))
-			}
-			c.NetworkName = net
+			resolveDockerNames(logger, c, cont, net, err)
 
 			logger.Debug("Using container and network", zap.String("container", c.ContainerName), zap.String("network", c.NetworkName))
 		}

--- a/cli/provider/core_service_docker_names_test.go
+++ b/cli/provider/core_service_docker_names_test.go
@@ -1,0 +1,125 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"go.keploy.io/server/v3/config"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// A command keploy cannot parse used to erase the container name the user
+// supplied, because the assignment was unconditional. Everything downstream -
+// the name-conflict pre-clean, teardown, app-log capture - then operated on ""
+// and silently did nothing.
+func TestResolveDockerNames(t *testing.T) {
+	cases := []struct {
+		name          string
+		given         config.Config
+		cont          string
+		net           string
+		wantContainer string
+		wantNetwork   string
+	}{
+		{
+			name:          "a parse that found nothing leaves the user's flags alone",
+			given:         config.Config{ContainerName: "my-app", NetworkName: "my-net"},
+			wantContainer: "my-app",
+			wantNetwork:   "my-net",
+		},
+		{
+			name:          "a successful parse wins, because docker names the container from the command",
+			given:         config.Config{ContainerName: "my-app", NetworkName: "my-net"},
+			cont:          "parsed-app",
+			net:           "parsed-net",
+			wantContainer: "parsed-app",
+			wantNetwork:   "parsed-net",
+		},
+		{
+			name:          "a parse fills in what the user did not supply",
+			cont:          "parsed-app",
+			net:           "parsed-net",
+			wantContainer: "parsed-app",
+			wantNetwork:   "parsed-net",
+		},
+		{
+			name:          "each field is decided on its own",
+			given:         config.Config{ContainerName: "my-app", NetworkName: "my-net"},
+			net:           "parsed-net",
+			wantContainer: "my-app",
+			wantNetwork:   "parsed-net",
+		},
+		{
+			name: "nothing given and nothing parsed stays empty",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.given
+			resolveDockerNames(zap.NewNop(), &cfg, tc.cont, tc.net, nil)
+
+			if cfg.ContainerName != tc.wantContainer {
+				t.Errorf("ContainerName = %q, want %q", cfg.ContainerName, tc.wantContainer)
+			}
+			if cfg.NetworkName != tc.wantNetwork {
+				t.Errorf("NetworkName = %q, want %q", cfg.NetworkName, tc.wantNetwork)
+			}
+		})
+	}
+}
+
+// Several e2e lanes fail the build on any ERROR line, so the severity of a
+// recoverable parse failure is a contract, not a detail. ParseDockerCmd
+// reports a missing --network as an error even when the container parsed -
+// the ordinary default-bridge shape - and that must not reach ERROR.
+func TestResolveDockerNamesLogSeverity(t *testing.T) {
+	parseErr := fmt.Errorf("failed to parse network name")
+
+	cases := []struct {
+		name      string
+		given     config.Config
+		cont      string
+		net       string
+		err       error
+		wantError bool
+	}{
+		{
+			name:      "container parsed, only the network missing",
+			cont:      "my-app",
+			err:       parseErr,
+			wantError: false,
+		},
+		{
+			name:      "command unparseable but the user supplied a container",
+			given:     config.Config{ContainerName: "my-app"},
+			err:       fmt.Errorf("failed to parse container name"),
+			wantError: false,
+		},
+		{
+			name:      "nothing parsed and nothing supplied",
+			err:       fmt.Errorf("failed to parse container name"),
+			wantError: true,
+		},
+		{
+			name: "a clean parse says nothing at all",
+			cont: "my-app",
+			net:  "my-net",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.DebugLevel)
+			cfg := tc.given
+			resolveDockerNames(zap.New(core), &cfg, tc.cont, tc.net, tc.err)
+
+			errors := logs.FilterLevelExact(zapcore.ErrorLevel).Len()
+			if (errors > 0) != tc.wantError {
+				t.Fatalf("error-level entries = %d, wantError %v (all: %v)", errors, tc.wantError, logs.All())
+			}
+		})
+	}
+}

--- a/pkg/platform/docker/parse_docker_cmd_test.go
+++ b/pkg/platform/docker/parse_docker_cmd_test.go
@@ -1,0 +1,96 @@
+package docker
+
+import (
+	"testing"
+
+	"go.keploy.io/server/v3/utils"
+)
+
+// Docker accepts "--name foo" and "--name=foo" interchangeably. ParseDockerCmd
+// used to match only the spaced form, so the equals form produced an empty
+// container name and an error - and the caller assigned the empty name anyway,
+// leaving teardown and log capture pointed at "".
+func TestParseDockerCmdFlagSpellings(t *testing.T) {
+	cases := []struct {
+		name          string
+		cmd           string
+		wantContainer string
+		wantNetwork   string
+		wantErr       bool
+	}{
+		{
+			name:          "space form",
+			cmd:           "docker run --name my-app --network keploy-network img",
+			wantContainer: "my-app",
+			wantNetwork:   "keploy-network",
+		},
+		{
+			name:          "equals form",
+			cmd:           "docker run --name=my-app --network=keploy-network img",
+			wantContainer: "my-app",
+			wantNetwork:   "keploy-network",
+		},
+		{
+			name:          "mixed spellings",
+			cmd:           "docker run --name=my-app --network keploy-network img",
+			wantContainer: "my-app",
+			wantNetwork:   "keploy-network",
+		},
+		{
+			name:          "net alias in equals form",
+			cmd:           "docker run --name my-app --net=keploy-network img",
+			wantContainer: "my-app",
+			wantNetwork:   "keploy-network",
+		},
+		{
+			name:          "ports and other flags in between",
+			cmd:           "docker run -d -p 8080:8080 --name=my-app -e A=B --network=keploy-network img",
+			wantContainer: "my-app",
+			wantNetwork:   "keploy-network",
+		},
+		{
+			name:          "network missing is an error, container still reported",
+			cmd:           "docker run --name=my-app img",
+			wantContainer: "my-app",
+			wantErr:       true,
+		},
+		{
+			name:    "no name at all",
+			cmd:     "docker run --network=keploy-network img",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			container, network, err := ParseDockerCmd(tc.cmd, utils.DockerRun, nil)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParseDockerCmd(%q) err = %v, wantErr %v", tc.cmd, err, tc.wantErr)
+			}
+			if container != tc.wantContainer {
+				t.Errorf("container = %q, want %q", container, tc.wantContainer)
+			}
+			if network != tc.wantNetwork {
+				t.Errorf("network = %q, want %q", network, tc.wantNetwork)
+			}
+		})
+	}
+}
+
+// A flag value that merely contains the text of another flag must not be read
+// as that flag. The previous regex scanned the raw string and did exactly that.
+func TestParseDockerCmdDoesNotReadFlagsOutOfValues(t *testing.T) {
+	container, network, err := ParseDockerCmd(
+		"docker run --name=real --network=realnet -e MSG=--name -e OTHER=--network img",
+		utils.DockerRun, nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if container != "real" {
+		t.Errorf("container = %q, want %q", container, "real")
+	}
+	if network != "realnet" {
+		t.Errorf("network = %q, want %q", network, "realnet")
+	}
+}

--- a/pkg/platform/docker/util.go
+++ b/pkg/platform/docker/util.go
@@ -566,28 +566,20 @@ func getAlias(ctx context.Context, logger *zap.Logger, opts models.SetupOptions,
 	return "", errors.New("failed to get alias")
 }
 
+// ParseDockerCmd returns the container and network names a docker command
+// refers to. Both flags are accepted in either spelling docker allows -
+// "--name foo" and "--name=foo", "--network"/"--net" likewise - because a
+// parser that understands only the spaced form reads nothing at all from a
+// valid command, and the caller then has no container to instrument.
 func ParseDockerCmd(cmd string, kind utils.CmdType, idc Client) (string, string, error) {
-
-	// Regular expression patterns
-	var containerNamePattern string
-	switch kind {
-	case utils.DockerStart:
-		containerNamePattern = `start\s+(?:-[^\s]+\s+)*([^\s]*)`
-	default:
-		containerNamePattern = `--name\s+([^\s]+)`
-	}
-
-	networkNamePattern := `(--network|--net)\s+([^\s]+)`
-
-	// Extract container name
-	containerNameRegex := regexp.MustCompile(containerNamePattern)
-	containerNameMatches := containerNameRegex.FindStringSubmatch(cmd)
-	if len(containerNameMatches) < 2 {
-		return "", "", fmt.Errorf("failed to parse container name")
-	}
-	containerName := containerNameMatches[1]
-
 	if kind == utils.DockerStart {
+		containerNameRegex := regexp.MustCompile(`start\s+(?:-[^\s]+\s+)*([^\s]*)`)
+		containerNameMatches := containerNameRegex.FindStringSubmatch(cmd)
+		if len(containerNameMatches) < 2 {
+			return "", "", fmt.Errorf("failed to parse container name")
+		}
+		containerName := containerNameMatches[1]
+
 		networks, err := idc.ExtractNetworksForContainer(containerName)
 		if err != nil {
 			return containerName, "", err
@@ -598,13 +590,15 @@ func ParseDockerCmd(cmd string, kind utils.CmdType, idc Client) (string, string,
 		return containerName, "", fmt.Errorf("failed to parse network name")
 	}
 
-	// Extract network name
-	networkNameRegex := regexp.MustCompile(networkNamePattern)
-	networkNameMatches := networkNameRegex.FindStringSubmatch(cmd)
-	if len(networkNameMatches) < 3 {
+	containerName := utils.ContainerNameFromDockerRun(cmd)
+	if containerName == "" {
+		return "", "", fmt.Errorf("failed to parse container name")
+	}
+
+	networkName := utils.NetworkNameFromDockerRun(cmd)
+	if networkName == "" {
 		return containerName, "", fmt.Errorf("failed to parse network name")
 	}
-	networkName := networkNameMatches[2]
 
 	return containerName, networkName, nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1361,21 +1361,41 @@ func EnsureRmBeforeName(cmd string) string {
 	return strings.Join(parts, " ")
 }
 
-// ContainerNameFromDockerRun extracts the value of the --name flag from a
-// `docker run` command, supporting both "--name foo" and "--name=foo". It
-// returns "" when no --name is present. Used to free a leftover container name
-// before a re-run when the --container-name flag wasn't supplied.
-func ContainerNameFromDockerRun(cmd string) string {
+// dockerLongFlagValue returns the value of the first occurrence of any of
+// names in cmd, accepting both "--flag value" and "--flag=value". Docker
+// accepts either spelling for every long flag, so a parser that understands
+// only one of them silently reads nothing from perfectly valid commands.
+func dockerLongFlagValue(cmd string, names ...string) string {
 	parts := strings.Fields(cmd)
 	for i, part := range parts {
-		if part == "--name" && i+1 < len(parts) {
-			return parts[i+1]
-		}
-		if name, ok := strings.CutPrefix(part, "--name="); ok {
-			return name
+		for _, name := range names {
+			if part == name && i+1 < len(parts) {
+				return parts[i+1]
+			}
+			// An empty "--flag=" is not a value: keep scanning, so it cannot
+			// swallow a real occurrence later in the command.
+			if value, ok := strings.CutPrefix(part, name+"="); ok && value != "" {
+				return value
+			}
 		}
 	}
 	return ""
+}
+
+// ContainerNameFromDockerRun extracts the value of the --name flag from a
+// `docker run` command, supporting both "--name foo" and "--name=foo". It
+// returns "" when no --name is present. Used to free a leftover container name
+// before a re-run when the --container-name flag wasn't supplied, and to
+// resolve the container keploy must instrument.
+func ContainerNameFromDockerRun(cmd string) string {
+	return dockerLongFlagValue(cmd, "--name")
+}
+
+// NetworkNameFromDockerRun extracts the value of --network or --net from a
+// `docker run` command, in either spelling. It returns "" when neither is
+// present.
+func NetworkNameFromDockerRun(cmd string) string {
+	return dockerLongFlagValue(cmd, "--network", "--net")
 }
 
 func isGoBinary(logger *zap.Logger, filePath string) bool {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -271,3 +271,28 @@ func TestEphemeralPortRangeReportsUnknownWhenUnreadable(t *testing.T) {
 			lo, hi, known, defaultEphemeralLo, defaultEphemeralHi)
 	}
 }
+
+func TestNetworkNameFromDockerRun(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"space form", "docker run --name app --network keploy-network img", "keploy-network"},
+		{"equals form", "docker run --name=app --network=keploy-network img", "keploy-network"},
+		{"net alias, space form", "docker run --net keploy-network img", "keploy-network"},
+		{"net alias, equals form", "docker run --net=keploy-network img", "keploy-network"},
+		{"no network", "docker run --name app img", ""},
+		// An empty "--flag=" must not be taken as the value and stop the scan.
+		{"empty equals then a real flag", "docker run --net= --network mynet img", "mynet"},
+		{"flag with no value", "docker run --network", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NetworkNameFromDockerRun(tc.cmd); got != tc.want {
+				t.Fatalf("NetworkNameFromDockerRun(%q) = %q, want %q", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

`docker run --name=app --network=mynet img` parses to nothing:

```
"docker run --name=myapp --network=mynet img"  ->  container=""      network=""       err="failed to parse container name"
"docker run --name myapp --network mynet img"  ->  container="myapp" network="mynet"  err=nil
```

`ParseDockerCmd` matched `--name\s+([^\s]+)`, so the equals form — which Docker accepts for every long flag — was invisible.

The second half is worse. `cli/provider/core_service.go` logged that error and then assigned the empty strings **over the `--container-name` the user passed explicitly**. From there `models.SetupOptions.Container` is `""`, so the name-conflict pre-clean (`app.go:1237`), teardown, and app-log capture all operate on `""` and silently do nothing.

## The fix

**Delete a dialect rather than add one.** `utils.ContainerNameFromDockerRun` already tokenised correctly and accepted both spellings, with tests — it was just used elsewhere. `ParseDockerCmd` now shares it via one `dockerLongFlagValue` helper, alongside a new `NetworkNameFromDockerRun` for `--network`/`--net`.

Two false positives the regex had disappear for free, because it scanned the raw string unanchored:

| command | before | after |
|---|---|---|
| `docker run --rm -e FOO=--name img` | container = `img` | correctly no name |
| `docker run --label desc=--name x img` | container = `--name` | correctly no name |

**Assignment is now conditional.** A parse that produced nothing leaves the user's flags alone. A parse that produced a value still wins, because for `docker-run`/`docker-start` Docker names the container from the command — instrumenting anything else targets a container that was never created. The parse is *usually* right rather than provably right (it reads the leftmost `--name`, which a container's own arguments can shadow), so a disagreement is now warned about rather than applied silently.

**Severity is decided after applying.** `ParseDockerCmd` reports a missing `--network` as an error even when the container parsed perfectly — the ordinary default-bridge shape. Deciding the log level before applying made every such run print `ERROR failed to parse container name` naming the container it had in fact just resolved. Several e2e lanes fail the build on any ERROR line (`.github/workflows/test_workflow_scripts/python-docker.sh:64`, `golang/echo_sql/golang-docker.sh:75,107,150`, `golang/gin_mongo/golang-docker.sh:125`, `golang/gin_mongo/golang-docker-macos.sh:176,211,255`).

## Behaviour change worth flagging

Making `--container-name` survive means `a.container` is non-empty on the docker-run path where it used to be `""`. That value reaches `ensureContainerNameFreeWithin` → `docker rm -f` (`pkg/client/app/app.go:1237-1241`, `:1400`), which were silent no-ops on `""`. For the documented shape `-c "... --network <net> <img>" --containerName "<name>"` (no `--name` in the command), Keploy will now force-remove a container of that name before starting. That is the intended behaviour of the pre-clean, but it did not previously happen for this shape.

Also worth knowing: **nothing reads `config.NetworkName`** today — not in this repo, not in enterprise. It is written, logged and exposed as a flag, but never consumed. That is why a missing network is logged at debug rather than treated as a failure.

## Not in scope, deliberately

- **`ExtractDockerFlags`** (`pkg/platform/http/utils/utils.go:12`) has the identical blindness for `--network/--net` and `-p/--publish`. It also runs on compose commands, where `-p` is the *project name* — so making `-p=` match uniformly would break the one compose form that works today, and enterprise already routes around this. It needs subcommand scoping first.
- **Image-boundary detection.** "The first non-flag token is the image" breaks `docker run -p 8080:8080 --net keploy-network --name x img`, since `8080:8080` is a non-flag token. Doing it properly needs the flag table.

## Tests

Table-driven, in each package's existing style.

- `TestNetworkNameFromDockerRun` — both spellings, `--net` alias, an empty `--flag=` not swallowing a later real flag.
- `TestParseDockerCmdFlagSpellings` — space, equals, mixed, `--net=`, flags in between, network-missing-but-container-reported, no name at all.
- `TestParseDockerCmdDoesNotReadFlagsOutOfValues` — a flag name appearing inside a value.
- `TestResolveDockerNames` — the precedence matrix.
- `TestResolveDockerNamesLogSeverity` — `zaptest/observer`, asserting no ERROR entry when a fallback exists. This is the CI-facing contract above, so it is pinned rather than assumed.

Each fix was verified by reverting it and confirming its own test fails, then passes when restored.

`go build ./...`, `go vet ./...` and `gofmt -l` are clean; `go test ./utils/... ./cli/... ./pkg/platform/docker/...` passes.
